### PR TITLE
Setter riktige session variabler.

### DIFF
--- a/src/backend/auth/utils/session.ts
+++ b/src/backend/auth/utils/session.ts
@@ -16,7 +16,6 @@ export type SessionRequest = Request & {
 
 // Set max age of cookie to 12 hours.
 const SESSION_MAX_AGE_MILLISECONDS = 12 * 60 * 60 * 1000;
-const SESSION_MAX_AGE_SECONDS = SESSION_MAX_AGE_MILLISECONDS / 1000;
 
 export default (app: any, passport: PassportStatic) => {
     app.use(cookieParser(process.env.SESSION_SECRET));
@@ -33,7 +32,7 @@ export default (app: any, passport: PassportStatic) => {
 
         app.use(
             session({
-                cookie: { maxAge: SESSION_MAX_AGE_SECONDS, secure: true },
+                cookie: { maxAge: SESSION_MAX_AGE_MILLISECONDS, secure: true },
                 name: 'familie-ks-sak-v1',
                 resave: false,
                 saveUninitialized: true,

--- a/src/backend/auth/utils/session.ts
+++ b/src/backend/auth/utils/session.ts
@@ -16,6 +16,7 @@ export type SessionRequest = Request & {
 
 // Set max age of cookie to 12 hours.
 const SESSION_MAX_AGE_MILLISECONDS = 12 * 60 * 60 * 1000;
+const SESSION_MAX_AGE_SECONDS = SESSION_MAX_AGE_MILLISECONDS / 1000;
 
 export default (app: any, passport: PassportStatic) => {
     app.use(cookieParser(process.env.SESSION_SECRET));
@@ -37,7 +38,7 @@ export default (app: any, passport: PassportStatic) => {
                 resave: false,
                 saveUninitialized: true,
                 secret: [`${process.env.COOKIE_KEY1}`, `${process.env.COOKIE_KEY2}`],
-                store: new RedisStore({ client }),
+                store: new RedisStore({ client, ttl: SESSION_MAX_AGE_SECONDS, disableTouch: true }),
             })
         );
     } else {


### PR DESCRIPTION
Det var redis som tok i mot maxAge/ttl i sekunder og ikke session cookie.