### PR TITLE
Oppdaterer redis til nyere versjon og flytter til team namespace

### DIFF
--- a/build_n_deploy/redis/naiserator_redis_default.yaml
+++ b/build_n_deploy/redis/naiserator_redis_default.yaml
@@ -2,17 +2,20 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: familie-ks-sak-frontend-redis
-  namespace: default
+  namespace: teamfamilie
   labels:
     team: teamfamilie
+  annotations:
+    "nais.io/run-as-group": "0"
+    "nais.io/read-only-file-system": "false"
 spec:
-  image: navikt/secure-redis:5.0.3-alpine-2
+  image: bitnami/redis:6.0.16
   port: 6379
   replicas: # A single Redis-app doesn't scale
     min: 1
     max: 1
-  vault:
-    enabled: true
+  envFrom:
+    - secret: familie-ks-sak-frontend-redis
   resources: # you need to monitor need your self
     limits:
       cpu: 250m 
@@ -22,3 +25,4 @@ spec:
       memory: 256Mi
   service:
     port: 6379
+    protocol: redis

--- a/build_n_deploy/redis/naiserator_redis_exporter.yaml
+++ b/build_n_deploy/redis/naiserator_redis_exporter.yaml
@@ -2,11 +2,11 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: familie-ks-sak-frontend-redis-exporter
-  namespace: default
+  namespace: teamfamilie
   labels:
     team: teamfamilie
 spec:
-  image: navikt/secure-redisexporter:v0.29.0-alpine-3
+  image: oliver006/redis_exporter:v1.16.0
   port: 9121
   prometheus:
     enabled: true
@@ -20,8 +20,12 @@ spec:
     requests:
       cpu: 100m
       memory: 100Mi
-  vault:
-    enabled: true
+  envFrom:
+    - secret: familie-ks-sak-frontend-redis
+  liveness:
+    path: /health
   env:
     - name: REDIS_ADDR
-      value: familie-ks-sak-frontend-redis.default.svc.nais.local:6379
+      value: familie-ks-sak-frontend-redis:6379
+    - name: REDIS_EXPORTER_LOG_FORMAT
+      value: json

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -84,7 +84,7 @@ const Environment = () => {
             buildPath: '../frontend_production',
             namespace: 'preprod',
             proxyUrl: 'http://familie-ks-sak',
-            redisUrl: 'familie-ks-sak-frontend-redis.default.svc.nais.local',
+            redisUrl: 'familie-ks-sak-frontend-redis.teamfamilie',
         };
     }
 
@@ -92,7 +92,7 @@ const Environment = () => {
         buildPath: '../frontend_production',
         namespace: 'production',
         proxyUrl: 'http://familie-ks-sak',
-        redisUrl: 'familie-ks-sak-frontend-redis.default.svc.nais.local',
+        redisUrl: 'familie-ks-sak-frontend-redis.teamfamilie',
     };
 };
 const env = Environment();


### PR DESCRIPTION
Endringer i nais gjør att vi må endre på SecurityContext https://doc.nais.io/nais-application/securitycontext/
https://nav-it.slack.com/archives/GREQVPXHS/p1636362845011700

I stedet for å endre for å kunne starte /root/start.sh så oppdateres redis til nyere versjon.
Secrets er lagt til i dev og prod (må logge inn på nytt etter att denne er inmerget, så fint å ikke merge mens det er mange saksbehandlere som jobber)

Vet ikke hvilken rolle som kreves for att jeg skal få testet saksbehandling i dev