### PR TITLE
Kommentert inn redisUrl i sessionConfig slik at redis benyttes

### DIFF
--- a/build_n_deploy/naiserator/gcp-dev.yaml
+++ b/build_n_deploy/naiserator/gcp-dev.yaml
@@ -9,8 +9,8 @@ spec:
   image: {{ image }}
   team: teamfamilie
   replicas:
-    min: 1
-    max: 1
+    min: 2
+    max: 2
     cpuThresholdPercentage: 50
   port: 8000
   liveness:

--- a/build_n_deploy/naiserator/gcp-prod.yaml
+++ b/build_n_deploy/naiserator/gcp-prod.yaml
@@ -9,8 +9,8 @@ spec:
   image: {{ image }}
   team: teamfamilie
   replicas:
-    min: 1
-    max: 1
+    min: 2
+    max: 2
     cpuThresholdPercentage: 50
   port: 8000
   liveness:

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -26,7 +26,7 @@ const Environment = () => {
             namespace: 'e2e',
             proxyUrl: 'http://familie-ks-sak:8089',
             familieTilbakeUrl: 'http://familie-tilbake-frontend:8000',
-            // redisUrl: 'familie-redis',
+            redisUrl: 'familie-redis',
             endringsloggProxyUrl: 'https://familie-endringslogg.dev.intern.nav.no',
         };
     } else if (process.env.ENV === 'preprod') {
@@ -35,7 +35,7 @@ const Environment = () => {
             namespace: 'preprod',
             proxyUrl: 'http://familie-ks-sak',
             familieTilbakeUrl: 'https://familie-tilbake-frontend.dev.intern.nav.no',
-            // redisUrl: 'familie-ks-sak-frontend-redis',
+            redisUrl: 'familie-ks-sak-frontend-redis',
             endringsloggProxyUrl: 'https://familie-endringslogg.dev.intern.nav.no',
         };
     }
@@ -46,7 +46,7 @@ const Environment = () => {
         proxyUrl: 'http://familie-ks-sak',
         familieTilbakeUrl: 'https://familietilbakekreving.intern.nav.no',
         endringsloggProxyUrl: 'https://familie-endringslogg.intern.nav.no',
-        // redisUrl: 'familie-ks-sak-frontend-redis',
+        redisUrl: 'familie-ks-sak-frontend-redis',
     };
 };
 const env = Environment();
@@ -55,7 +55,7 @@ export const sessionConfig: ISessionKonfigurasjon = {
     cookieSecret: [`${process.env.COOKIE_KEY1}`, `${process.env.COOKIE_KEY2}`],
     navn: 'familie-ks-sak-v1',
     redisPassord: process.env.REDIS_PASSWORD,
-    // redisUrl: env.redisUrl,
+    redisUrl: env.redisUrl,
     secureCookie: !(
         process.env.ENV === 'local' ||
         process.env.ENV === 'lokalt-mot-preprod' ||


### PR DESCRIPTION
Har kjørt opp `naiserator_redis.yaml` og `naiserator_redis_exporter.yaml` i PreProd og Prod slik det er gjort for `ba-sak-frontend` og andre frontend applikasjoner i team familie. I denne PR'en kommenterer jeg inn redisUrl i sessionConfig som jeg tidligere kommenterte ut, men som er nødvendig for å konfigurere redis.

Skalerer også min og max pods tilbake til 2.

Redis er nødvendig for sessjonshåndtering når vi kjører med mer enn 1 pod.

![image](https://user-images.githubusercontent.com/70642183/189593326-e5912ab4-7a0c-4c94-a57c-261891d1c0ca.png)