### PR TITLE
Tea-9653: Fjern infotrygd fane fra saksoversikt

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -156,7 +156,7 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
     return (
         <div className={'saksoversikt'}>
             <Innholdstittel children={'Saksoversikt'} />
-            <StyledTabs tabs={[{ label: ksSakTab.label }, { label: ksSakTab.label }]} />
+            <StyledTabs tabs={[{ label: ksSakTab.label }]} />
             <FagsakLenkepanel minimalFagsak={minimalFagsak} />
             {minimalFagsak.status === FagsakStatus.LØPENDE && (
                 <>

--- a/src/frontend/komponenter/Infotrygd/useInfotrygd.ts
+++ b/src/frontend/komponenter/Infotrygd/useInfotrygd.ts
@@ -56,31 +56,6 @@ export const useInfotrygdSkjema = () => {
     };
 };
 
-export const useInfotrygdRequest = () => {
-    const { request } = useHttp();
-    const [infotrygdsakerRessurs, settInfotrygdsakerRessurs] = useState<Ressurs<IInfotrygdsaker>>(
-        byggTomRessurs()
-    );
-
-    const hentInfotrygdsaker = (ident: string) => {
-        settInfotrygdsakerRessurs(byggHenterRessurs<IInfotrygdsaker>());
-        request<IInfotrygdsakerRequest, IInfotrygdsaker>(hentInfotrygdsakerRequestConfig(ident))
-            .then((ressurs: Ressurs<IInfotrygdsaker>) => {
-                settInfotrygdsakerRessurs(konverterTilFeiletRessursDersomIkkeTilgang(ressurs));
-            })
-            .catch((_error: AxiosError) => {
-                settInfotrygdsakerRessurs(
-                    byggFeiletRessurs('Ukjent feil ved innhenting av infotrygdsaker')
-                );
-            });
-    };
-
-    return {
-        hentInfotrygdsaker,
-        infotrygdsakerRessurs,
-    };
-};
-
 export const useInfotrygdMigrering = () => {
     const navigate = useNavigate();
     const { request } = useHttp();


### PR DESCRIPTION
* Fjerner infotrygd fane
* ks-sak -> KS-sak i gjenværende fane
* Fjernet noe ubrukte infotrygd funksjoner etter at vi fjerner fane

Before
![Screenshot 2022-09-19 at 22 57 56](https://user-images.githubusercontent.com/110383605/191128805-1d597eb1-9bd7-4727-aba0-6e77236329ce.png)

After
![Screenshot 2022-09-20 at 00 11 13](https://user-images.githubusercontent.com/110383605/191128788-247c137f-51de-4969-8487-0250fd578ff1.png)
