### PR TITLE
Tea 9655: Fjerner fagsaktype i frontend

### DIFF
--- a/src/frontend/context/InstitusjonOgVergeContext.tsx
+++ b/src/frontend/context/InstitusjonOgVergeContext.tsx
@@ -130,9 +130,6 @@ const [InstitusjonOgVergeProvider, useInstitusjonOgVerge] = createUseContext(
         };
 
         const erSkjemaUendret = () => {
-            if (fagsakType === FagsakType.INSTITUSJON) {
-                return skjema.felter.institusjon.verdi === fagsak?.institusjon;
-            }
             return skjema.felter.fødselsnummer.verdi === åpenBehandling.verge?.ident || '';
         };
 
@@ -147,16 +144,8 @@ const [InstitusjonOgVergeProvider, useInstitusjonOgVerge] = createUseContext(
                 onSubmit<IRegistrerInstitusjonOgVerge | undefined>(
                     {
                         data: {
-                            institusjonInfo:
-                                fagsakType === FagsakType.INSTITUSJON
-                                    ? skjema.felter.institusjon.verdi
-                                    : undefined,
-                            vergeInfo:
-                                fagsakType !== FagsakType.INSTITUSJON
-                                    ? {
-                                          ident: skjema.felter.fødselsnummer.verdi,
-                                      }
-                                    : undefined,
+                            institusjonInfo: undefined,
+                            vergeInfo: undefined,
                         },
                         method: 'POST',
                         url: `/familie-ks-sak/api/behandlinger/${åpenBehandling?.behandlingId}/steg/registrer-institusjon-og-verge`,

--- a/src/frontend/context/InstitusjonOgVergeContext.tsx
+++ b/src/frontend/context/InstitusjonOgVergeContext.tsx
@@ -34,7 +34,6 @@ const [InstitusjonOgVergeProvider, useInstitusjonOgVerge] = createUseContext(
             minimalFagsak.status !== RessursStatus.SUKSESS
                 ? hentFrontendFeilmelding(minimalFagsak) || 'Ukjent feil ved henting av fagsak'
                 : '';
-        const fagsakType = fagsak?.fagsakType;
 
         const { skjema, onSubmit } = useSkjema<
             {
@@ -165,7 +164,6 @@ const [InstitusjonOgVergeProvider, useInstitusjonOgVerge] = createUseContext(
 
         return {
             fagsakFeilmelding,
-            fagsakType,
             hentPerson,
             onSubmitMottaker,
             skjema,

--- a/src/frontend/context/InstitusjonOgVergeContext.tsx
+++ b/src/frontend/context/InstitusjonOgVergeContext.tsx
@@ -11,12 +11,10 @@ import { RessursStatus } from '@navikt/familie-typer';
 import useSakOgBehandlingParams from '../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../typer/behandling';
 import { BehandlingSteg } from '../typer/behandling';
-import { FagsakType } from '../typer/fagsak';
 import type { IInstitusjon, IRegistrerInstitusjonOgVerge } from '../typer/institusjon-og-verge';
 import type { IPersonInfo } from '../typer/person';
 import { hentAlder } from '../utils/formatter';
 import { hentFrontendFeilmelding } from '../utils/ressursUtils';
-import { identValidator } from '../utils/validators';
 import { useBehandling } from './behandlingContext/BehandlingContext';
 import { useFagsakRessurser } from './FagsakContext';
 
@@ -57,9 +55,7 @@ const [InstitusjonOgVergeProvider, useInstitusjonOgVerge] = createUseContext(
                         if (avhengigheter?.feilmelding) {
                             return feil(felt, avhengigheter?.feilmelding);
                         } else {
-                            return fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG
-                                ? identValidator(felt)
-                                : ok(felt);
+                            return ok(felt);
                         }
                     },
                 }),

--- a/src/frontend/komponenter/Fagsak/InstitusjonOgVerge/RegistrerMottaker.tsx
+++ b/src/frontend/komponenter/Fagsak/InstitusjonOgVerge/RegistrerMottaker.tsx
@@ -8,9 +8,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useInstitusjonOgVerge } from '../../../context/InstitusjonOgVergeContext';
 import { BehandlingSteg } from '../../../typer/behandling';
-import { FagsakType } from '../../../typer/fagsak';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
-import Institusjon from './Institusjon';
 import Verge from './Verge';
 
 const StyledSkjemasteg = styled(Skjemasteg)`
@@ -22,7 +20,7 @@ const StyledAlert = styled(Alert)`
 `;
 
 const RegistrerMottaker: React.FC = () => {
-    const { fagsakType, fagsakFeilmelding, onSubmitMottaker, submitFeilmelding } =
+    const { fagsakFeilmelding, onSubmitMottaker, submitFeilmelding } =
         useInstitusjonOgVerge();
     const { behandlingsstegSubmitressurs, erLesevisning } = useBehandling();
 
@@ -37,11 +35,7 @@ const RegistrerMottaker: React.FC = () => {
                     senderInn={behandlingsstegSubmitressurs.status === RessursStatus.HENTER}
                     steg={BehandlingSteg.REGISTRERE_INSTITUSJON_OG_VERGE}
                 >
-                    {fagsakType === FagsakType.INSTITUSJON ? (
-                        <Institusjon />
-                    ) : (
-                        <Verge erLesevisning={erLesevisning()} />
-                    )}
+                    <Verge erLesevisning={erLesevisning()} />)
                     {submitFeilmelding && <Alert variant="error" children={submitFeilmelding} />}
                 </StyledSkjemasteg>
             )}

--- a/src/frontend/komponenter/Fagsak/InstitusjonOgVerge/RegistrerMottaker.tsx
+++ b/src/frontend/komponenter/Fagsak/InstitusjonOgVerge/RegistrerMottaker.tsx
@@ -20,8 +20,7 @@ const StyledAlert = styled(Alert)`
 `;
 
 const RegistrerMottaker: React.FC = () => {
-    const { fagsakFeilmelding, onSubmitMottaker, submitFeilmelding } =
-        useInstitusjonOgVerge();
+    const { fagsakFeilmelding, onSubmitMottaker, submitFeilmelding } = useInstitusjonOgVerge();
     const { behandlingsstegSubmitressurs, erLesevisning } = useBehandling();
 
     return (

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -65,12 +65,7 @@ const OpprettBehandling: React.FC<IProps> = ({ onListElementClick, minimalFagsak
                             key={'bekreft'}
                             type={'hoved'}
                             mini={true}
-                            onClick={() =>
-                                onBekreft(
-                                    minimalFagsak.søkerFødselsnummer,
-                                    minimalFagsak.fagsakType
-                                )
-                            }
+                            onClick={() => onBekreft(minimalFagsak.søkerFødselsnummer)}
                             children={'Bekreft'}
                             spinner={
                                 opprettBehandlingSkjema.submitRessurs.status ===

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -19,7 +19,6 @@ import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingPar
 import type { IBehandling, IRestNyBehandling } from '../../../../../typer/behandling';
 import { BehandlingSteg, Behandlingstype, BehandlingÅrsak } from '../../../../../typer/behandling';
 import type { IBehandlingstema } from '../../../../../typer/behandlingstema';
-import type { FagsakType } from '../../../../../typer/fagsak';
 import { Tilbakekrevingsbehandlingstype } from '../../../../../typer/tilbakekrevingsbehandling';
 import type { FamilieIsoDate } from '../../../../../utils/kalender';
 import { erIsoStringGyldig } from '../../../../../utils/kalender';
@@ -124,7 +123,7 @@ const useOpprettBehandling = ({
         }
     }, [skjema.felter.behandlingstype.verdi]);
 
-    const onBekreft = (søkersIdent: string, fagsakType: FagsakType) => {
+    const onBekreft = (søkersIdent: string) => {
         const { behandlingstype, behandlingsårsak } = skjema.felter;
         if (kanSendeSkjema()) {
             if (
@@ -153,7 +152,6 @@ const useOpprettBehandling = ({
                             behandlingÅrsak: behandlingsårsak.verdi as BehandlingÅrsak,
                             navIdent: innloggetSaksbehandler?.navIdent,
                             søknadMottattDato: skjema.felter.søknadMottattDato.verdi ?? undefined,
-                            fagsakType: fagsakType,
                         },
                         method: 'POST',
                         url: '/familie-ks-sak/api/behandlinger',

--- a/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
@@ -8,8 +8,6 @@ import { kjønnType } from '@navikt/familie-typer';
 import Visittkort from '@navikt/familie-visittkort';
 
 import { useApp } from '../../../context/AppContext';
-import KontorIkonGrønn from '../../../ikoner/KontorIkonGrønn';
-import { FagsakType } from '../../../typer/fagsak';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 import type { IPersonInfo } from '../../../typer/person';
 import {

--- a/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
@@ -35,9 +35,6 @@ const Personlinje: React.FC<IProps> = ({ bruker, minimalFagsak }) => {
             ident={formaterIdent(bruker?.personIdent ?? '')}
             alder={hentAlder(bruker?.fødselsdato ?? '')}
             kjønn={bruker?.kjønn ?? kjønnType.UKJENT}
-            ValgfrittIkon={
-                minimalFagsak?.fagsakType === FagsakType.INSTITUSJON ? KontorIkonGrønn : undefined
-            }
         >
             <div className="visittkort__pipe">|</div>
             <Normaltekst>{`Kommunenr: ${bruker?.kommunenummer ?? 'ukjent'}`}</Normaltekst>

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
@@ -6,19 +6,12 @@ import { LenkepanelBase } from 'nav-frontend-lenkepanel';
 import Panel from 'nav-frontend-paneler';
 import { Normaltekst } from 'nav-frontend-typografi';
 
-import { Alert } from '@navikt/ds-react';
-
 import { BehandlingStatus } from '../../../typer/behandling';
 import type { IBehandlingstema } from '../../../typer/behandlingstema';
 import { tilBehandlingstema } from '../../../typer/behandlingstema';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
-import { FagsakType } from '../../../typer/fagsak';
 import { hentAktivBehandlingPåMinimalFagsak, hentFagsakStatusVisning } from '../../../utils/fagsak';
 import type { VisningBehandling } from './visningBehandling';
-
-interface IFagsakTypeLabel {
-    fagsakType: FagsakType;
-}
 
 interface IBehandlingLenkepanel {
     minimalFagsak: IMinimalFagsak;
@@ -58,29 +51,6 @@ const Innholdstabell: React.FC<IInnholdstabell> = ({ minimalFagsak }) => {
     );
 };
 
-const FagsakTypeLabel: React.FC<IFagsakTypeLabel> = ({ fagsakType }) => {
-    switch (fagsakType) {
-        case FagsakType.INSTITUSJON:
-            return (
-                <Alert
-                    className="fagsak-type-label"
-                    children={'Dette er en institusjonssak'}
-                    variant={'info'}
-                ></Alert>
-            );
-        case FagsakType.BARN_ENSLIG_MINDREÅRIG:
-            return (
-                <Alert
-                    className="fagsak-type-label"
-                    children={'Dette er en enslig mindreårig sak'}
-                    variant={'info'}
-                ></Alert>
-            );
-        default:
-            return null;
-    }
-};
-
 const genererHoverTekst = (behandling: VisningBehandling) => {
     return behandling.status === BehandlingStatus.AVSLUTTET
         ? 'Gå til gjeldende vedtak'
@@ -100,14 +70,12 @@ const FagsakLenkepanel: React.FC<IBehandlingLenkepanel> = ({ minimalFagsak }) =>
             >
                 <Innholdstabell minimalFagsak={minimalFagsak} />
             </LenkepanelBase>
-            <FagsakTypeLabel fagsakType={minimalFagsak.fagsakType}></FagsakTypeLabel>
         </>
     ) : (
         <>
             <Panel className={'fagsak-panel'}>
                 <Innholdstabell minimalFagsak={minimalFagsak} />
             </Panel>
-            <FagsakTypeLabel fagsakType={minimalFagsak.fagsakType}></FagsakTypeLabel>
         </>
     );
 };

--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -16,8 +16,6 @@ import {
 import type { Ressurs } from '@navikt/familie-typer';
 
 import IkkeTilgang from '../../../ikoner/IkkeTilgang';
-import KontorIkonGrønn from '../../../ikoner/KontorIkonGrønn';
-import { FagsakType } from '../../../typer/fagsak';
 import type { IFagsakDeltager, ISøkParam } from '../../../typer/fagsakdeltager';
 import { fagsakdeltagerRoller } from '../../../typer/fagsakdeltager';
 import OpprettFagsakModal from './OpprettFagsakModal';
@@ -77,8 +75,8 @@ const FagsakDeltagerSøk: React.FC = () => {
         }
     };
 
-    const mapTilSøkeresultater = (): Ressurs<ISøkeresultat[]> => {
-        return fagsakDeltagere.status === RessursStatus.SUKSESS
+    const mapTilSøkeresultater = (): Ressurs<ISøkeresultat[]> =>
+        fagsakDeltagere.status === RessursStatus.SUKSESS
             ? {
                   ...fagsakDeltagere,
                   data: fagsakDeltagere.data.map((fagsakDeltager: IFagsakDeltager) => {
@@ -89,11 +87,7 @@ const FagsakDeltagerSøk: React.FC = () => {
                           navn: fagsakDeltager.navn,
                           ident: fagsakDeltager.ident,
                           ikon: fagsakDeltager.harTilgang ? (
-                              fagsakDeltager.fagsakType !== FagsakType.INSTITUSJON ? (
-                                  ikoner[`${fagsakDeltager.rolle}_${fagsakDeltager.kjønn}`]
-                              ) : (
-                                  <KontorIkonGrønn height={32} width={32} />
-                              )
+                              ikoner[`${fagsakDeltager.rolle}_${fagsakDeltager.kjønn}`]
                           ) : (
                               <IkkeTilgang height={30} width={30} />
                           ),
@@ -104,7 +98,6 @@ const FagsakDeltagerSøk: React.FC = () => {
                   }),
               }
             : fagsakDeltagere;
-    };
 
     return (
         <>

--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/OpprettFagsakModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/OpprettFagsakModal.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { Knapp } from 'nav-frontend-knapper';
 import { Feilmelding, Normaltekst, Undertittel } from 'nav-frontend-typografi';
 
-import { FamilieCheckbox, FamilieInput, FamilieKnapp } from '@navikt/familie-form-elements';
 import type { ISøkeresultat } from '@navikt/familie-header';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -15,7 +14,6 @@ import type { IPersonInfo } from '../../../typer/person';
 import type { ISamhandlerInfo } from '../../../typer/samhandler';
 import { ToggleNavn } from '../../../typer/toggles';
 import { formaterIdent } from '../../../utils/formatter';
-import { SamhandlerTabell } from '../../Fagsak/InstitusjonOgVerge/SamhandlerTabell';
 import { useSamhandlerSkjema } from '../../Fagsak/InstitusjonOgVerge/useSamhandler';
 import UIModalWrapper from '../Modal/UIModalWrapper';
 import useOpprettFagsak from './useOpprettFagsak';
@@ -26,16 +24,6 @@ export interface IOpprettFagsakModal {
     personInfo?: IPersonInfo;
 }
 
-const StyledDiv = styled.div`
-    display: flex;
-`;
-
-const StyledKnapp = styled(FamilieKnapp)`
-    margin-left: 1rem;
-    margin-top: auto;
-    height: 1rem;
-`;
-
 const StyledUndertittel = styled(Undertittel)`
     font-size: 1rem;
     margin-bottom: 1.5rem;
@@ -44,11 +32,6 @@ const StyledUndertittel = styled(Undertittel)`
 const StyledKnappContainer = styled.div`
     margin-top: 1.2rem;
     margin-bottom: 0.5rem;
-`;
-
-const StyledCheckBoxWrapper = styled.div`
-    margin-top: 1.2rem;
-    margin-bottom: 1rem;
 `;
 
 const OpprettFagsakModal: React.FC<IOpprettFagsakModal> = ({
@@ -62,7 +45,7 @@ const OpprettFagsakModal: React.FC<IOpprettFagsakModal> = ({
     const [fagsakType, settFagsakType] = useState<FagsakType>(FagsakType.NORMAL);
     const [visFeilmelding, settVisFeilmelding] = useState(false);
     const [valgtSamhandler, settValgtSamhandler] = useState<ISamhandlerInfo | undefined>(undefined);
-    const { onSubmitWrapper, samhandlerSkjema } = useSamhandlerSkjema();
+    const { samhandlerSkjema } = useSamhandlerSkjema();
 
     const onClose = () => {
         settFagsakType(FagsakType.NORMAL);
@@ -206,67 +189,6 @@ const OpprettFagsakModal: React.FC<IOpprettFagsakModal> = ({
                             personInfo.personIdent
                         )})`}</Normaltekst>
                     )}
-                    <StyledCheckBoxWrapper>
-                        <FamilieCheckbox
-                            id={'gjelder-enslig-mindreårig'}
-                            erLesevisning={false}
-                            label={'Gjelder enslig mindreårig'}
-                            checked={fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG}
-                            disabled={fagsakType === FagsakType.INSTITUSJON}
-                            onChange={() => {
-                                if (fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG) {
-                                    settFagsakType(FagsakType.NORMAL);
-                                } else {
-                                    settFagsakType(FagsakType.BARN_ENSLIG_MINDREÅRIG);
-                                }
-                                settVisFeilmelding(false);
-                            }}
-                        />
-                        <br />
-                        <FamilieCheckbox
-                            id={'gjelder-institusjon'}
-                            erLesevisning={false}
-                            label={'Gjelder institusjon'}
-                            checked={fagsakType === FagsakType.INSTITUSJON}
-                            disabled={fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG}
-                            onChange={() => {
-                                if (fagsakType === FagsakType.INSTITUSJON) {
-                                    settFagsakType(FagsakType.NORMAL);
-                                } else {
-                                    settFagsakType(FagsakType.INSTITUSJON);
-                                }
-                                settVisFeilmelding(false);
-                            }}
-                        />
-                        <br />
-                        {fagsakType === FagsakType.INSTITUSJON && (
-                            <StyledDiv>
-                                <FamilieInput
-                                    {...samhandlerSkjema.felter.orgnr.hentNavInputProps(
-                                        samhandlerSkjema.visFeilmeldinger
-                                    )}
-                                    erLesevisning={false}
-                                    id={'hent-samhandler'}
-                                    label={'Institusjonens organisasjonsnummer'}
-                                    bredde={'XL'}
-                                    placeholder={'organisasjonsnummer'}
-                                />
-
-                                <StyledKnapp
-                                    onClick={() => {
-                                        onSubmitWrapper();
-                                    }}
-                                    children={'Hent institusjon'}
-                                    erLesevisning={false}
-                                />
-                            </StyledDiv>
-                        )}
-                        <br />
-
-                        {fagsakType === FagsakType.INSTITUSJON && valgtSamhandler !== undefined && (
-                            <SamhandlerTabell samhandler={valgtSamhandler}></SamhandlerTabell>
-                        )}
-                    </StyledCheckBoxWrapper>
                     {!!feilmelding && visFeilmelding && <Feilmelding children={feilmelding} />}
                 </UIModalWrapper>
             )}

--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/OpprettFagsakModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/OpprettFagsakModal.tsx
@@ -9,7 +9,6 @@ import type { ISøkeresultat } from '@navikt/familie-header';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../context/AppContext';
-import { FagsakType } from '../../../typer/fagsak';
 import type { IPersonInfo } from '../../../typer/person';
 import type { ISamhandlerInfo } from '../../../typer/samhandler';
 import { ToggleNavn } from '../../../typer/toggles';
@@ -42,13 +41,11 @@ const OpprettFagsakModal: React.FC<IOpprettFagsakModal> = ({
     const { opprettFagsak, feilmelding, senderInn, settSenderInn } = useOpprettFagsak();
     const { sjekkTilgang, toggles } = useApp();
     const visModal = !!søkeresultat || !!personInfo;
-    const [fagsakType, settFagsakType] = useState<FagsakType>(FagsakType.NORMAL);
     const [visFeilmelding, settVisFeilmelding] = useState(false);
     const [valgtSamhandler, settValgtSamhandler] = useState<ISamhandlerInfo | undefined>(undefined);
     const { samhandlerSkjema } = useSamhandlerSkjema();
 
     const onClose = () => {
-        settFagsakType(FagsakType.NORMAL);
         settVisFeilmelding(false);
         settValgtSamhandler(undefined);
         lukkModal();
@@ -84,7 +81,6 @@ const OpprettFagsakModal: React.FC<IOpprettFagsakModal> = ({
                                             {
                                                 personIdent: søkeresultat.ident,
                                                 aktørId: null,
-                                                fagsakType: FagsakType.NORMAL,
                                                 institusjon: null,
                                             },
                                             lukkModal
@@ -143,7 +139,6 @@ const OpprettFagsakModal: React.FC<IOpprettFagsakModal> = ({
                                                 {
                                                     personIdent: personIdent,
                                                     aktørId: null,
-                                                    fagsakType: fagsakType,
                                                     institusjon: valgtSamhandler
                                                         ? {
                                                               orgNummer: valgtSamhandler.orgNummer,

--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/useOpprettFagsak.ts
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/useOpprettFagsak.ts
@@ -14,7 +14,6 @@ import type { VisningBehandling } from '../../Fagsak/Saksoversikt/visningBehandl
 export interface IOpprettFagsakData {
     personIdent: string | null;
     aktørId: string | null;
-    fagsakType: FagsakType | null;
     institusjon: IInstitusjon | null;
 }
 

--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/useOpprettFagsak.ts
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/useOpprettFagsak.ts
@@ -6,7 +6,7 @@ import { useHttp } from '@navikt/familie-http';
 import { RessursStatus } from '@navikt/familie-typer';
 import type { Ressurs } from '@navikt/familie-typer';
 
-import type { IMinimalFagsak, FagsakType } from '../../../typer/fagsak';
+import type { IMinimalFagsak } from '../../../typer/fagsak';
 import type { IInstitusjon } from '../../../typer/institusjon-og-verge';
 import { hentAktivBehandlingPåMinimalFagsak } from '../../../utils/fagsak';
 import type { VisningBehandling } from '../../Fagsak/Saksoversikt/visningBehandling';

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -13,11 +13,6 @@ export enum FagsakStatus {
     AVSLUTTET = 'AVSLUTTET',
 }
 
-export enum FagsakType {
-    NORMAL = 'NORMAL',
-    BARN_ENSLIG_MINDREÅRIG = 'BARN_ENSLIG_MINDREÅRIG',
-}
-
 // Interface
 export interface IBaseFagsak {
     id: number;
@@ -27,7 +22,6 @@ export interface IBaseFagsak {
     søkerFødselsnummer: string;
     underBehandling: boolean;
     løpendeKategori?: BehandlingKategori;
-    fagsakType: FagsakType;
     institusjon?: IInstitusjon;
 }
 

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -16,7 +16,6 @@ export enum FagsakStatus {
 export enum FagsakType {
     NORMAL = 'NORMAL',
     BARN_ENSLIG_MINDREÅRIG = 'BARN_ENSLIG_MINDREÅRIG',
-    INSTITUSJON = 'INSTITUSJON',
 }
 
 // Interface

--- a/src/frontend/typer/fagsakdeltager.ts
+++ b/src/frontend/typer/fagsakdeltager.ts
@@ -1,7 +1,5 @@
 import type { Adressebeskyttelsegradering, kjønnType } from '@navikt/familie-typer';
 
-import type { FagsakType } from './fagsak';
-
 export enum FagsakDeltagerRolle {
     Barn = 'BARN',
     Forelder = 'FORELDER',
@@ -34,7 +32,6 @@ export interface IFagsakDeltager {
     fagsakId?: number;
     adressebeskyttelseGradering?: Adressebeskyttelsegradering;
     harTilgang: boolean;
-    fagsakType?: FagsakType;
 }
 
 export interface ISøkParam {

--- a/src/frontend/utils/test/minimalFagsak/minimalFagsak.mock.ts
+++ b/src/frontend/utils/test/minimalFagsak/minimalFagsak.mock.ts
@@ -1,7 +1,6 @@
 import type { VisningBehandling } from '../../../komponenter/Fagsak/Saksoversikt/visningBehandling';
 import { BehandlingKategori } from '../../../typer/behandlingstema';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
-import { FagsakType } from '../../../typer/fagsak';
 import { FagsakStatus } from '../../../typer/fagsak';
 import type { Utbetalingsperiode } from '../../../typer/vedtaksperiode';
 import { mockVisningBehandling } from '../behandling/behandling.mock';
@@ -17,7 +16,6 @@ interface IMockMinimalFagsak {
     søkerFødselsnummer?: string;
     underBehandling?: boolean;
     løpendeKategori?: BehandlingKategori;
-    fagsakType?: FagsakType;
 }
 
 export const mockMinimalFagsak = ({
@@ -31,7 +29,6 @@ export const mockMinimalFagsak = ({
     søkerFødselsnummer = '12345678910',
     underBehandling = false,
     løpendeKategori = BehandlingKategori.NASJONAL,
-    fagsakType = FagsakType.NORMAL,
 }: IMockMinimalFagsak = {}): IMinimalFagsak => ({
     migreringsdato,
     behandlinger,
@@ -44,5 +41,4 @@ export const mockMinimalFagsak = ({
     gjeldendeUtbetalingsperioder,
     tilbakekrevingsbehandlinger: [],
     løpendeKategori,
-    fagsakType,
 });


### PR DESCRIPTION
Fagsaktype er en enum som består av

* NORMAL
* BARN_ENSLIG_MINDREÅRIG
* INSTITUSJON

Vi bruker ikke barn enslig mindreårig og institusjon i kontantstøtte, så jeg fjerner derfor denne enum'n.

PS: Kunne sikkert ha fjernet mye mer kode om institusjon, men tenker at det passer en annen PR bedre.