### PR TITLE
Byttet `proxyUrl` for ks-sak backend ved kjøring med ENV=lokalt-mot-preprod

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -16,7 +16,7 @@ const Environment = () => {
         return {
             buildPath: 'frontend_development',
             namespace: 'local',
-            proxyUrl: 'https://familie-ks-sak.dev.intern.nav.no',
+            proxyUrl: 'https://familie-kontantstotte-sak.dev.intern.nav.no',
             familieTilbakeUrl: 'https://familie-tilbake.dev.intern.nav.no',
             endringsloggProxyUrl: 'https://familie-endringslogg.dev.intern.nav.no',
         };


### PR DESCRIPTION
Å kjøre applikasjonen lokalt mot preprod fungerte ikke da vi fikk 404 på kall mot backend. Det viser seg at familie-ks-sak sin ingress: `https://familie-ks-sak.dev.intern.nav.no` ikke fungerer av en eller annen grunn. Har byttet den ut med `https://familie-kontantstotte-sak.dev.intern.nav.no` i `src/bacend/config.ts` og den fungerer. 

Burde undersøke videre hvorfor ingressen ikke fungerer, men nå fungerer det ihvertfall å kjøre frontend mot backend-preprod 😄 