### PR TITLE
Fikset fom-validering for alle vilkår samt antallTimer validering for Barnehageplass

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/BarnehageplassContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/BarnehageplassContext.ts
@@ -56,7 +56,7 @@ export const useBarnehageplass = (vilkår: IVilkårResultat, person: IGrunnlagPe
         antallTimer: useFelt<string>({
             verdi: vilkårSkjema.antallTimer,
             avhengigheter: {
-                resultat,
+                resultat: resultat.verdi,
             },
             valideringsfunksjon: erAntallTimerGyldig,
         }),

--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -103,7 +103,7 @@ describe('utils/validators', () => {
         });
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual(
-            'Du kan ikke legge til periode før barnet har fylt 1 år'
+            'Du kan ikke legge til periode før barnets fødselsdato'
         );
     });
 

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -87,15 +87,12 @@ const datoDifferanseMerEnn1År = (fom: string, tom: string) => {
     return erFør(fomDatoPluss1År, tomDato);
 };
 
-const finnesDatoFørFødselsdatoPluss1År = (person: IGrunnlagPerson, fom: string, tom?: string) => {
-    const fødselsdatoPluss1År = leggTil(kalenderDato(person.fødselsdato), 1, KalenderEnhet.ÅR);
+const finnesDatoFørFødselsdato = (person: IGrunnlagPerson, fom: string, tom?: string) => {
+    const fødselsdato = kalenderDato(person.fødselsdato);
     const fomDato = kalenderDato(fom);
     const tomDato = tom ? kalenderDato(tom) : undefined;
 
-    return (
-        erFør(fomDato, fødselsdatoPluss1År) ||
-        (tomDato ? erFør(tomDato, fødselsdatoPluss1År) : false)
-    );
+    return erFør(fomDato, fødselsdato) || (tomDato ? erFør(tomDato, fødselsdato) : false);
 };
 
 export const erPeriodeGyldig = (
@@ -123,8 +120,8 @@ export const erPeriodeGyldig = (
 
         if (!erEksplisittAvslagPåSøknad) {
             if (person && person.type === PersonType.BARN) {
-                if (finnesDatoFørFødselsdatoPluss1År(person, fom, tom)) {
-                    return feil(felt, 'Du kan ikke legge til periode før barnet har fylt 1 år');
+                if (finnesDatoFørFødselsdato(person, fom, tom)) {
+                    return feil(felt, 'Du kan ikke legge til periode før barnets fødselsdato');
                 }
                 if (erMellom1Og2EllerAdoptertVilkår) {
                     if (utdypendeVilkårsvurdering?.includes(UtdypendeVilkårsvurdering.ADOPSJON)) {


### PR DESCRIPTION
* `fom` kan ikke være før fødselsdato for barn
* Sender inn riktig avhengighet til validering av `antallTimer` på Barnehageplass