### PR TITLE
Endre husky til å kun verifisere, ikke endre filer ved commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:one": "jest -t",
     "lint": "eslint './src/**/*.{js,ts,tsx}'",
     "lint:fix": "eslint './src/**/*.{js,ts,tsx}' --fix",
+    "prettier:fix": "prettier --write",
     "prepare": "husky install",
     "start:cypress": "tsc -p tsconfig.backend.json && NODE_ENV=production node --loader ts-node/esm --es-module-specifier-resolution=node node_dist/backend/cypress-server.js",
     "run:cypress": "cypress run",
@@ -23,9 +24,9 @@
     "typecheck": "tsc --noEmit -p src/frontend/tsconfig.json"
   },
   "lint-staged": {
-    "src/**/*.{js,ts,tsx}": [
-      "prettier --write",
-      "eslint --fix src/ --max-warnings=0"
+    "src/**/*.{js,jsx,ts,tsx,json,css}": [
+      "prettier --check",
+      "eslint --max-warnings=0"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Fra: https://github.com/navikt/familie-ba-sak-frontend/pull/2361

> Vi har satt opp husky og lint-staged til å on-commit kjøre prettier og eslint med skriving i de filene som er lagt inn i commiten (staged):
>
>filen stages
du kjører git commit
prettier kjører på filen og skriver evt endringer
eslint kjører på filen og skriver evt endringer
filen stages på nytt, for å få med disse endringene
commit fullføres
Det er helt supert dersom man commiter en hel fil av gangen. Men om man skal cherry-picke deler av en fil som skal stages stegvis vil prettier/eslint føre til at hele filen blir med i commiten. Dermed kan man ikke faktisk cherry-picke ☹️
>
>Foreslår at vi endrer dette til at husky kun kjører verifisering med prettier og eslint, som feiler dersom noe er galt. Legger til et npm-script som kjører prettier med skriving, altså det samme som husky har pleid å gjøre. Vi har allerede et script for dette med eslint