### PR TITLE
Fikset styling av 'Legg til periode' i vilkårsvurdering

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
@@ -93,9 +93,9 @@ const GeneriskVilkår: React.FC<IProps> = ({
                         loading={vilkårsvurderingApi.oppretterVilkår}
                         disabled={vilkårsvurderingApi.oppretterVilkår}
                         variant="tertiary"
-                        size="small"
+                        size="medium"
+                        icon={<AddCircle />}
                     >
-                        <AddCircle />
                         Legg til periode
                     </UtførKnapp>
                 )}


### PR DESCRIPTION
Før:
![image](https://user-images.githubusercontent.com/70642183/198957433-ac075fa7-53a7-481c-a288-396be78e8757.png)

Etter:
![image](https://user-images.githubusercontent.com/70642183/198957519-30dadc98-4b08-4017-943a-00e5af1a5ba3.png)
