### PR TITLE
Returnerer null for antallTimer dersom barn ikke har barnehageplass

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import styled from 'styled-components';
+
 import { Radio } from 'nav-frontend-skjema';
 
 import { FamilieInput, FamilieRadioGruppe } from '@navikt/familie-form-elements';
@@ -9,6 +11,10 @@ import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
 import { useBarnehageplass } from './BarnehageplassContext';
+
+const StyledFamilieInput = styled(FamilieInput)`
+    margin-bottom: 1rem;
+`;
 
 type BarnehageplassProps = IVilkårSkjemaBaseProps;
 
@@ -101,7 +107,7 @@ export const Barnehageplass: React.FC<BarnehageplassProps> = ({
                 />
             </FamilieRadioGruppe>
             {harBarnehageplass && (
-                <FamilieInput
+                <StyledFamilieInput
                     label={'Antall timer'}
                     type={'number'}
                     erLesevisning={lesevisning}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/BarnehageplassValidering.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/BarnehageplassValidering.ts
@@ -10,6 +10,9 @@ export const erAntallTimerGyldig = (
 ): FeltState<string> => {
     if (felt.verdi !== '') {
         const antallTimer = Number(felt.verdi);
+        if (antallTimer <= 0) {
+            return feil(felt, 'Antall timer med barnehageplass må være større enn 0');
+        }
         if (antallTimer > 122) {
             return feil(felt, 'Antall timer med barnehageplass kan ikke overstige 122');
         }

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjemaContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjemaContext.ts
@@ -72,7 +72,9 @@ export const useVilkårSkjema = <T extends IVilkårSkjemaContext>(
                     vurderesEtter: skjema.felter.vurderesEtter.verdi,
                     utdypendeVilkårsvurderinger: skjema.felter.utdypendeVilkårsvurdering.verdi,
                     antallTimer: skjema.felter.antallTimer
-                        ? Number(skjema.felter.antallTimer.verdi)
+                        ? skjema.felter.antallTimer.verdi !== ''
+                            ? Number(skjema.felter.antallTimer.verdi)
+                            : undefined
                         : undefined,
                 },
             };


### PR DESCRIPTION
Tidligere ble 0 returnert i feltet `antallTimer` dersom SB hadde valgt at barn ikke har barnehageplass. Dette fordi ```Number('')``` blir 0. Har fikset logikken slik at feltet blir `undefined` dersom feltet er tom string `''`.

Også en liten visuell justering av feltet `antallTimer`