### PR TITLE
Fjernet ytelseType fra utbetalingsperioder

### DIFF
--- a/src/frontend/context/test/SøknadContext.test.ts
+++ b/src/frontend/context/test/SøknadContext.test.ts
@@ -1,6 +1,5 @@
 import { kjønnType } from '@navikt/familie-typer';
 
-import { YtelseType } from '../../typer/beregning';
 import { PersonType } from '../../typer/person';
 import { Målform } from '../../typer/søknad';
 import { Vedtaksperiodetype } from '../../typer/vedtaksperiode';
@@ -37,14 +36,12 @@ describe('SøknadContext', () => {
                                 ...person,
                                 personIdent: '12345678911',
                             },
-                            ytelseType: YtelseType.ORDINÆR_KONTANTSTØTTE,
                             utbetaltPerMnd: 1054,
                             erPåvirketAvEndring: false,
                             antallTimer: 7,
                             prosent: 80,
                         },
                     ],
-                    ytelseTyper: [YtelseType.ORDINÆR_KONTANTSTØTTE],
                     antallBarn: 1,
                     utbetaltPerMnd: 1054,
                 },
@@ -57,14 +54,12 @@ describe('SøknadContext', () => {
                     utbetalingsperiodeDetaljer: [
                         {
                             person,
-                            ytelseType: YtelseType.ORDINÆR_KONTANTSTØTTE,
                             utbetaltPerMnd: 1054,
                             erPåvirketAvEndring: false,
                             antallTimer: 7,
                             prosent: 80,
                         },
                     ],
-                    ytelseTyper: [YtelseType.ORDINÆR_KONTANTSTØTTE],
                     antallBarn: 1,
                     utbetaltPerMnd: 1054,
                 },

--- a/src/frontend/typer/test/utbetalingsperiode.mock.ts
+++ b/src/frontend/typer/test/utbetalingsperiode.mock.ts
@@ -1,5 +1,5 @@
 import { mockSøker } from '../../utils/test/person/person.mock';
-import { YtelseType } from '../beregning';
+import type { YtelseType } from '../beregning';
 import type { IGrunnlagPerson } from '../person';
 import type { IUtbetalingsperiodeDetalj } from '../vedtaksperiode';
 
@@ -14,14 +14,12 @@ interface IMockUtbetalingsperiodeDetalj {
 
 export const lagUtbetalingsperiodeDetalj = ({
     person = mockSøker(),
-    ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
     utbetaltPerMnd = 0,
     erPåvirketAvEndring = false,
     antallTimer = 0,
     prosent = 100,
 }: IMockUtbetalingsperiodeDetalj = {}): IUtbetalingsperiodeDetalj => ({
     person: person,
-    ytelseType: ytelseType,
     utbetaltPerMnd: utbetaltPerMnd,
     erPåvirketAvEndring: erPåvirketAvEndring,
     antallTimer: antallTimer,

--- a/src/frontend/typer/vedtaksperiode.ts
+++ b/src/frontend/typer/vedtaksperiode.ts
@@ -1,5 +1,4 @@
 import type { FamilieIsoDate } from '../utils/kalender';
-import type { YtelseType } from './beregning';
 import { ytelsetype } from './beregning';
 import type { IGrunnlagPerson } from './person';
 import type { VedtakBegrunnelse, VedtakBegrunnelseType } from './vedtak';
@@ -39,7 +38,6 @@ export type Vedtaksperiode =
           periodeTom?: FamilieIsoDate;
           vedtaksperiodetype: Vedtaksperiodetype.UTBETALING;
           utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
-          ytelseTyper: YtelseType[];
           antallBarn: number;
           utbetaltPerMnd: number;
       }
@@ -65,14 +63,12 @@ export type Utbetalingsperiode = {
     periodeTom?: FamilieIsoDate;
     vedtaksperiodetype: Vedtaksperiodetype.UTBETALING;
     utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
-    ytelseTyper: YtelseType[];
     antallBarn: number;
     utbetaltPerMnd: number;
 };
 
 export interface IUtbetalingsperiodeDetalj {
     person: IGrunnlagPerson;
-    ytelseType: YtelseType;
     utbetaltPerMnd: number;
     antallTimer: number;
     prosent: number;


### PR DESCRIPTION
YtelseType vil alltid være `ORDINÆR_KONTANTSTØTTE` så trenger ikke å sende inn dette feltet.