### PR TITLE
Forhindrer dato fram i tid

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -202,6 +202,9 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                         valgtDato={søknadMottattDato.verdi}
                         label={'Mottatt dato'}
                         placeholder={'DD.MM.ÅÅÅÅ'}
+                        limitations={{
+                            maxDate: new Date().toISOString(),
+                        }}
                     />
                     {søknadMottattDato.feilmelding && visFeilmeldinger && (
                         <FeltFeilmelding>{søknadMottattDato.feilmelding}</FeltFeilmelding>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -78,13 +78,24 @@ const useOpprettBehandling = ({
 
     const søknadMottattDato = useFelt<FamilieIsoDate | undefined>({
         verdi: undefined,
-        valideringsfunksjon: (felt: FeltState<FamilieIsoDate | undefined>) =>
-            felt.verdi && erIsoStringGyldig(felt.verdi)
-                ? ok(felt)
-                : feil(
-                      felt,
-                      'Mottatt dato for søknaden må registreres ved manuell opprettelse av behandling'
-                  ),
+        valideringsfunksjon: (felt: FeltState<FamilieIsoDate | undefined>) => {
+            const erGyldigIsoString = felt.verdi && erIsoStringGyldig(felt.verdi);
+            const erIFremtiden = felt.verdi && erDatoFremITid(felt.verdi);
+
+            if (!erGyldigIsoString) {
+                return feil(
+                    felt,
+                    'Mottatt dato for søknaden må registreres ved manuell opprettelse av behandling'
+                );
+            }
+
+            if (erIFremtiden) {
+                return feil(felt, 'Du kan ikke sette en mottatt dato som er frem i tid.');
+            }
+
+            return ok(felt);
+        },
+
         avhengigheter: { behandlingstype, behandlingsårsak },
         skalFeltetVises: avhengigheter => {
             const { verdi: behandlingstypeVerdi } = avhengigheter.behandlingstype;
@@ -96,6 +107,10 @@ const useOpprettBehandling = ({
             );
         },
     });
+
+    const erDatoFremITid = (dato: FamilieIsoDate): boolean => {
+        return Date.parse(dato.toString()) > new Date().getTime();
+    };
 
     const { skjema, nullstillSkjema, kanSendeSkjema, onSubmit, settSubmitRessurs } = useSkjema<
         {


### PR DESCRIPTION
Hindrer at bruker kan sette dato fram i tid når man oppretter ny behandling.

Før:
<img width="743" alt="Screenshot 2022-11-11 at 16 34 33" src="https://user-images.githubusercontent.com/110383605/201380814-d64c9b7b-885b-4fc3-8e2c-19190ef78cd3.png">

Etter:
<img width="626" alt="Screenshot 2022-11-11 at 16 51 58" src="https://user-images.githubusercontent.com/110383605/201380833-5d127955-3da3-4492-98de-21efbd09b4ad.png">
