### PR TITLE
Fikser at datoknapper ikke blir liggende over utdypende vilkårsvurdering select

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
@@ -79,7 +79,7 @@ export const UtdypendeVilkårsvurderingMultiselect: React.FC<Props> = ({
             propSelectStyles={{
                 menu: provided => ({
                     ...provided,
-                    ZIndex: '3',
+                    zIndex: 3,
                 }),
             }}
             creatable={false}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -57,6 +57,12 @@ const FlexDiv = styled.div`
     }
 `;
 
+const StyledFamilieDatovelger = styled(FamilieDatovelger)`
+    .nav-datovelger__kalenderknapp {
+        z-index: 0;
+    }
+`;
+
 const VelgPeriode: React.FC<IProps> = ({
     periode,
     erEksplisittAvslagPåSøknad,
@@ -84,7 +90,7 @@ const VelgPeriode: React.FC<IProps> = ({
             <FlexDiv>
                 {(!lesevisning || periode.verdi.fom) && (
                     <div>
-                        <FamilieDatovelger
+                        <StyledFamilieDatovelger
                             allowInvalidDateSelection={false}
                             limitations={{
                                 maxDate: new Date().toISOString(),
@@ -107,7 +113,7 @@ const VelgPeriode: React.FC<IProps> = ({
                 )}
                 {(!lesevisning || periode.verdi.tom) && (
                     <div>
-                        <FamilieDatovelger
+                        <StyledFamilieDatovelger
                             erLesesvisning={lesevisning}
                             id={`${vilkårPeriodeFeilmeldingId(vilkår)}__fastsett-periode-tom`}
                             label={'T.o.m (valgfri)'}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -57,12 +57,6 @@ const FlexDiv = styled.div`
     }
 `;
 
-const StyledFamilieDatovelger = styled(FamilieDatovelger)`
-    .nav-datovelger__kalenderknapp {
-        z-index: 0;
-    }
-`;
-
 const VelgPeriode: React.FC<IProps> = ({
     periode,
     erEksplisittAvslagPåSøknad,
@@ -90,7 +84,7 @@ const VelgPeriode: React.FC<IProps> = ({
             <FlexDiv>
                 {(!lesevisning || periode.verdi.fom) && (
                     <div>
-                        <StyledFamilieDatovelger
+                        <FamilieDatovelger
                             allowInvalidDateSelection={false}
                             limitations={{
                                 maxDate: new Date().toISOString(),
@@ -113,7 +107,7 @@ const VelgPeriode: React.FC<IProps> = ({
                 )}
                 {(!lesevisning || periode.verdi.tom) && (
                     <div>
-                        <StyledFamilieDatovelger
+                        <FamilieDatovelger
                             erLesesvisning={lesevisning}
                             id={`${vilkårPeriodeFeilmeldingId(vilkår)}__fastsett-periode-tom`}
                             label={'T.o.m (valgfri)'}


### PR DESCRIPTION
Før:
![image](https://user-images.githubusercontent.com/70642183/202659270-368bb7c2-4ef3-4a66-ad3e-e844e80db217.png)

Etter:
![image](https://user-images.githubusercontent.com/70642183/202659369-c931819f-aa9c-4d97-9c87-721c4b312fc6.png)
