### PR TITLE
Endre på barnehage tekst hvis det ikke er utbetaling pga endretutbeta…

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -201,7 +201,10 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                                             </td>
                                             <td>
                                                 <BodyShort>
-                                                    {hentBarnehageplassBeskrivelse(detalj.prosent)}
+                                                    {hentBarnehageplassBeskrivelse(
+                                                        detalj.prosent,
+                                                        detalj.erPåvirketAvEndring
+                                                    )}
                                                 </BodyShort>
                                             </td>
                                             <td>

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/OppsummeringsboksUtils.ts
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/OppsummeringsboksUtils.ts
@@ -1,5 +1,7 @@
-export const hentBarnehageplassBeskrivelse = (prosent: number) => {
+export const hentBarnehageplassBeskrivelse = (prosent: number, erPåvirketAvEndring: boolean) => {
     switch (true) {
+        case erPåvirketAvEndring:
+            return 'Ikke relevant';
         case prosent === 100:
             return 'Ingen plass';
         case prosent === 80:


### PR DESCRIPTION
Vi ønsker å vise 'Ikke relevant' dersom en periode ikke blir utbetalt pga SB har satt inn endrede utbetalingsperioder.
Per i dag vises det alltid 'Over 33 timer' dersom satsen er 0, men det er feil da det også kan være pga endred utbetalingsperiode.

Før:
<img width="1011" alt="førr" src="https://user-images.githubusercontent.com/110383605/205734077-73f58192-dc39-4ef2-9426-d4c590bca3f2.png">

Etter:
<img width="1728" alt="etterrr" src="https://user-images.githubusercontent.com/110383605/205734081-6689ba12-f07b-45de-ae2f-1781bed26b62.png">
