### PR TITLE
Legg til mulighet for å sette eksplitt avslag på endret utbetaling

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -16,7 +16,7 @@ const Environment = () => {
         return {
             buildPath: 'frontend_development',
             namespace: 'local',
-            proxyUrl: 'http://localhost:8083',
+            proxyUrl: 'https://familie-kontantstotte-sak.dev.intern.nav.no',
             familieTilbakeUrl: 'https://familie-tilbake.dev.intern.nav.no',
             endringsloggProxyUrl: 'https://familie-endringslogg.dev.intern.nav.no',
         };

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -16,7 +16,7 @@ const Environment = () => {
         return {
             buildPath: 'frontend_development',
             namespace: 'local',
-            proxyUrl: 'https://familie-kontantstotte-sak.dev.intern.nav.no',
+            proxyUrl: 'http://localhost:8083',
             familieTilbakeUrl: 'https://familie-tilbake.dev.intern.nav.no',
             endringsloggProxyUrl: 'https://familie-endringslogg.dev.intern.nav.no',
         };

--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -38,6 +38,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 avtaletidspunktDeltBosted: FamilieIsoDate | undefined;
                 fullSats: boolean | undefined;
                 begrunnelse: string | undefined;
+                erEksplisittAvslagPåSøknad: boolean | undefined;
             },
             IBehandling
         >({
@@ -106,6 +107,9 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                     valideringsfunksjon: felt =>
                         felt.verdi ? ok(felt) : feil(felt, 'Du må oppgi en begrunnelse.'),
                 }),
+                erEksplisittAvslagPåSøknad: useFelt<boolean | undefined>({
+                    verdi: endretUtbetalingAndel.erEksplisittAvslagPåSøknad,
+                }),
             },
             skjemanavn: 'Endre utbetalingsperiode',
         });
@@ -126,6 +130,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 begrunnelse,
                 søknadstidspunkt,
                 avtaletidspunktDeltBosted,
+                erEksplisittAvslagPåSøknad,
             } = skjema.felter;
             return {
                 id: endretUtbetalingAndel.id,
@@ -138,6 +143,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 søknadstidspunkt: søknadstidspunkt.verdi,
                 avtaletidspunktDeltBosted: avtaletidspunktDeltBosted.verdi,
                 erTilknyttetAndeler: endretUtbetalingAndel.erTilknyttetAndeler,
+                erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
             };
         };
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useEffect } from 'react';
 
+import classNames from 'classnames';
 import styled from 'styled-components';
 
 import variables from 'nav-frontend-core';
@@ -8,7 +9,7 @@ import { SkjemaGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
 
 import { Delete } from '@navikt/ds-icons';
-import { BodyShort, Button, Label, Radio, RadioGroup } from '@navikt/ds-react';
+import { BodyShort, Button, Checkbox, Label, Radio, RadioGroup } from '@navikt/ds-react';
 import type { ISODateString } from '@navikt/familie-form-elements';
 import { FamilieSelect, FamilieTextarea } from '@navikt/familie-form-elements';
 import { useHttp } from '@navikt/familie-http';
@@ -173,6 +174,8 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
         }
     }, [skjema.submitRessurs]);
 
+    const erLesevisning = vurderErLesevisning();
+
     return (
         <>
             <StyledSkjemaGruppe feil={hentFrontendFeilmelding(skjema.submitRessurs)}>
@@ -185,7 +188,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                         onChange={(event): void => {
                             skjema.felter.person.validerOgSettFelt(event.target.value);
                         }}
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                     >
                         <option value={undefined}>Velg person</option>
                         {åpenBehandling.personer
@@ -221,7 +224,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                     skjema.felter.fom.validerOgSettFelt(dato);
                                 }
                             }}
-                            lesevisning={vurderErLesevisning()}
+                            lesevisning={erLesevisning}
                         />
                     </Feltmargin>
                     <MånedÅrVelger
@@ -237,7 +240,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 skjema.felter.tom.validerOgSettFelt(dato);
                             }
                         }}
-                        lesevisning={vurderErLesevisning()}
+                        lesevisning={erLesevisning}
                     />
                 </Feltmargin>
 
@@ -252,7 +255,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 event.target.value as IEndretUtbetalingAndelÅrsak
                             );
                         }}
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                         lesevisningVerdi={
                             skjema.felter.årsak.verdi ? årsakTekst[skjema.felter.årsak.verdi] : ''
                         }
@@ -267,20 +270,27 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                 </Feltmargin>
 
                 <Feltmargin>
-                    {vurderErLesevisning() ? (
+                    {erLesevisning ? (
                         <>
                             <Label>Utbetaling</Label>
                             <BodyShort>
                                 {skjema.felter.periodeSkalUtbetalesTilSøker.verdi ? 'Ja' : 'Nei'}
                             </BodyShort>
+                            skjema.felter.erEksplisittAvslagPåSøknad.verdi && (
+                            <BodyShort
+                                className={classNames('skjemaelement', 'lese-felt')}
+                                children={'Vurderingen er et avslag'}
+                            />
+                            )
                         </>
                     ) : (
                         <RadioGroup
                             legend={<Label>Utbetaling</Label>}
                             value={skjema.felter.periodeSkalUtbetalesTilSøker.verdi}
-                            onChange={(val: boolean | undefined) =>
-                                skjema.felter.periodeSkalUtbetalesTilSøker.validerOgSettFelt(val)
-                            }
+                            onChange={(val: boolean | undefined) => {
+                                skjema.felter.periodeSkalUtbetalesTilSøker.validerOgSettFelt(val);
+                                skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(false);
+                            }}
                         >
                             <Radio
                                 name={'utbetaling'}
@@ -297,6 +307,19 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 {'Perioden skal ikke utbetales'}
                             </Radio>
                         </RadioGroup>
+                    )}
+                    {!skjema.felter.periodeSkalUtbetalesTilSøker.verdi && (
+                        <Checkbox
+                            value={'Vurderingen er et avslag'}
+                            checked={skjema.felter.erEksplisittAvslagPåSøknad.verdi}
+                            onChange={event =>
+                                skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
+                                    event.target.checked
+                                )
+                            }
+                        >
+                            {'Vurderingen er et avslag'}
+                        </Checkbox>
                     )}
                 </Feltmargin>
 
@@ -410,7 +433,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                         }}
                     />
                 </Feltmargin>
-                {!vurderErLesevisning() && (
+                {!erLesevisning && (
                     <Knapperekke>
                         <KnapperekkeVenstre>
                             <StyledFerdigKnapp
@@ -431,7 +454,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                             </Button>
                         </KnapperekkeVenstre>
 
-                        {!vurderErLesevisning() && (
+                        {!erLesevisning && (
                             <Button
                                 variant={'tertiary'}
                                 id={`sletteknapp-endret-utbetaling-andel-${endretUtbetalingAndel.id}`}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -70,7 +70,7 @@ const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
                 vedtaksperioderMedBegrunnelser={avslagOgResterende[0]}
                 overskrift={'Begrunnelser for avslag i vedtaksbrev'}
                 hjelpetekst={
-                    'Her har vi hentet begrunnelsestekster for avslag som du har satt i vilkårsvurderingen.'
+                    'Her har vi hentet begrunnelser for avslag som er satt tidligere i behandlingen.'
                 }
                 åpenBehandling={åpenBehandling}
             />

--- a/src/frontend/typer/utbetalingAndel.ts
+++ b/src/frontend/typer/utbetalingAndel.ts
@@ -13,6 +13,7 @@ export interface IRestEndretUtbetalingAndel {
     avtaletidspunktDeltBosted?: FamilieIsoDate;
     årsak?: IEndretUtbetalingAndelÅrsak;
     erTilknyttetAndeler?: boolean;
+    erEksplisittAvslagPåSøknad?: boolean;
 }
 
 export enum IEndretUtbetalingAndelÅrsak {


### PR DESCRIPTION
Vi legger til mulighet for å legge til eksplisitt avslag på endret utbetaling.
Det fungerer forsåvidt helt lik som vilkårsvurdering sin, men det er 1-1 kobling mellom avslag og begrunnelse så vi slipper dropdown meny.


https://user-images.githubusercontent.com/110383605/206933580-f5d03294-0f76-4626-a83f-8459556fe7c6.mov

