### PR TITLE
Feature/opprett klagebehandling knapp

### DIFF
--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -140,7 +140,7 @@ const [AppContentProvider, useApp] = createUseContext(() => {
     useEffect(() => {
         request<string[], IToggles>({
             method: 'POST',
-            url: '/familie-ks-sak/api/feature',
+            url: '/familie-ks-sak/api/featuretoggles',
             data: Object.values(ToggleNavn),
         }).then((response: Ressurs<IToggles>) => {
             if (response.status === RessursStatus.SUKSESS) {

--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -38,6 +38,22 @@ import { kalenderDiff } from '../utils/kalender';
 import { useApp } from './AppContext';
 import { useFagsakContext } from './FagsakContext';
 
+export interface ManuellJounalføringSkjemaFelter {
+    behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | '';
+    behandlingsårsak: BehandlingÅrsak | '';
+    behandlingstema: IBehandlingstema | undefined;
+    journalpostTittel: string;
+    dokumenter: IDokumentInfo[];
+    bruker: IPersonInfo | undefined;
+    avsenderNavn: string;
+    avsenderIdent: string;
+    knyttTilNyBehandling: boolean;
+    tilknyttedeBehandlingIder: number[];
+    erEnsligMindreårig: boolean;
+    erPåInstitusjon: boolean;
+    samhandler: ISamhandlerInfo | null;
+}
+
 const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() => {
     const { innloggetSaksbehandler, toggles } = useApp();
     const { hentFagsakForPerson } = useFagsakContext();
@@ -94,21 +110,7 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
 
     const [valgtDokumentId, settValgtDokumentId] = React.useState<string | undefined>(undefined);
     const { skjema, nullstillSkjema, onSubmit, hentFeilTilOppsummering } = useSkjema<
-        {
-            journalpostTittel: string;
-            behandlingstema: IBehandlingstema | undefined;
-            dokumenter: IDokumentInfo[];
-            bruker: IPersonInfo | undefined;
-            avsenderNavn: string;
-            avsenderIdent: string;
-            knyttTilNyBehandling: boolean;
-            behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | '';
-            behandlingsårsak: BehandlingÅrsak | '';
-            tilknyttedeBehandlingIder: number[];
-            erEnsligMindreårig: boolean;
-            erPåInstitusjon: boolean;
-            samhandler: ISamhandlerInfo | null;
-        },
+        ManuellJounalføringSkjemaFelter,
         string
     >({
         felter: {

--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -49,8 +49,6 @@ export interface ManuellJournalføringSkjemaFelter {
     avsenderIdent: string;
     knyttTilNyBehandling: boolean;
     tilknyttedeBehandlingIder: number[];
-    erEnsligMindreårig: boolean;
-    erPåInstitusjon: boolean;
     samhandler: ISamhandlerInfo | null;
 }
 
@@ -161,12 +159,6 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
             behandlingsårsak,
             tilknyttedeBehandlingIder: useFelt<number[]>({
                 verdi: [],
-            }),
-            erEnsligMindreårig: useFelt<boolean>({
-                verdi: false,
-            }),
-            erPåInstitusjon: useFelt<boolean>({
-                verdi: false,
             }),
             samhandler: useFelt<ISamhandlerInfo | null>({
                 verdi: null,

--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -38,7 +38,7 @@ import { kalenderDiff } from '../utils/kalender';
 import { useApp } from './AppContext';
 import { useFagsakContext } from './FagsakContext';
 
-export interface ManuellJounalføringSkjemaFelter {
+export interface ManuellJournalføringSkjemaFelter {
     behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | '';
     behandlingsårsak: BehandlingÅrsak | '';
     behandlingstema: IBehandlingstema | undefined;
@@ -110,7 +110,7 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
 
     const [valgtDokumentId, settValgtDokumentId] = React.useState<string | undefined>(undefined);
     const { skjema, nullstillSkjema, onSubmit, hentFeilTilOppsummering } = useSkjema<
-        ManuellJounalføringSkjemaFelter,
+        ManuellJournalføringSkjemaFelter,
         string
     >({
         felter: {

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/KravDatoFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/KravDatoFelt.tsx
@@ -6,20 +6,22 @@ import type { FamilieIsoDate } from '../../../../../utils/kalender';
 import { FixedDatoVelger } from './OpprettBehandlingValg';
 
 interface IProps {
-    kravMotattDato: Felt<FamilieIsoDate>;
+    kravMottattDato: Felt<FamilieIsoDate>;
     visFeilmeldinger: boolean;
 }
 
-export const KravDatoFelt: React.FC<IProps> = ({ kravMotattDato, visFeilmeldinger }) => (
+export const KravDatoFelt: React.FC<IProps> = ({ kravMottattDato, visFeilmeldinger }) => (
     <FixedDatoVelger
-        {...kravMotattDato.hentNavInputProps(visFeilmeldinger)}
-        valgtDato={kravMotattDato.verdi}
+        {...kravMottattDato.hentNavInputProps(visFeilmeldinger)}
+        valgtDato={kravMottattDato.verdi}
         label={'Krav dato'}
         placeholder={'DD.MM.ÅÅÅÅ'}
         limitations={{
             maxDate: new Date().toISOString(),
         }}
-        onChange={input => kravMotattDato.hentNavInputProps(visFeilmeldinger).onChange(input ?? '')}
-        feil={visFeilmeldinger && kravMotattDato.feilmelding}
+        onChange={input =>
+            kravMottattDato.hentNavInputProps(visFeilmeldinger).onChange(input ?? '')
+        }
+        feil={visFeilmeldinger && kravMottattDato.feilmelding}
     />
 );

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/KravDatoFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/KravDatoFelt.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import type { Felt } from '@navikt/familie-skjema';
+
+import type { FamilieIsoDate } from '../../../../../utils/kalender';
+import { FeltFeilmelding, FixedDatoVelger } from './OpprettBehandlingValg';
+
+interface IProps {
+    kravMotattDato: Felt<FamilieIsoDate>;
+    visFeilmeldinger: boolean;
+}
+
+export const KravDatoFelt: React.FC<IProps> = ({ kravMotattDato, visFeilmeldinger }) => {
+    if (!kravMotattDato.erSynlig) {
+        return null;
+    }
+
+    return (
+        <>
+            <FixedDatoVelger
+                {...kravMotattDato.hentNavInputProps(visFeilmeldinger)}
+                valgtDato={kravMotattDato.verdi}
+                label={'Krav dato'}
+                placeholder={'DD.MM.ÅÅÅÅ'}
+                limitations={{
+                    maxDate: new Date().toISOString(),
+                }}
+                onChange={input =>
+                    kravMotattDato.hentNavInputProps(visFeilmeldinger).onChange(input ?? '')
+                }
+            />
+
+            {kravMotattDato.feilmelding && visFeilmeldinger && (
+                <FeltFeilmelding>{kravMotattDato.feilmelding}</FeltFeilmelding>
+            )}
+        </>
+    );
+};

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/KravDatoFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/KravDatoFelt.tsx
@@ -14,8 +14,7 @@ export const KravDatoFelt: React.FC<IProps> = ({ kravMottattDato, visFeilmelding
     <FixedDatoVelger
         {...kravMottattDato.hentNavInputProps(visFeilmeldinger)}
         valgtDato={kravMottattDato.verdi}
-        label={'Krav dato'}
-        placeholder={'DD.MM.ÅÅÅÅ'}
+        label={'Krav mottatt'}
         limitations={{
             maxDate: new Date().toISOString(),
         }}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/KravDatoFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/KravDatoFelt.tsx
@@ -3,36 +3,23 @@ import React from 'react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import type { FamilieIsoDate } from '../../../../../utils/kalender';
-import { FeltFeilmelding, FixedDatoVelger } from './OpprettBehandlingValg';
+import { FixedDatoVelger } from './OpprettBehandlingValg';
 
 interface IProps {
     kravMotattDato: Felt<FamilieIsoDate>;
     visFeilmeldinger: boolean;
 }
 
-export const KravDatoFelt: React.FC<IProps> = ({ kravMotattDato, visFeilmeldinger }) => {
-    if (!kravMotattDato.erSynlig) {
-        return null;
-    }
-
-    return (
-        <>
-            <FixedDatoVelger
-                {...kravMotattDato.hentNavInputProps(visFeilmeldinger)}
-                valgtDato={kravMotattDato.verdi}
-                label={'Krav dato'}
-                placeholder={'DD.MM.ÅÅÅÅ'}
-                limitations={{
-                    maxDate: new Date().toISOString(),
-                }}
-                onChange={input =>
-                    kravMotattDato.hentNavInputProps(visFeilmeldinger).onChange(input ?? '')
-                }
-            />
-
-            {kravMotattDato.feilmelding && visFeilmeldinger && (
-                <FeltFeilmelding>{kravMotattDato.feilmelding}</FeltFeilmelding>
-            )}
-        </>
-    );
-};
+export const KravDatoFelt: React.FC<IProps> = ({ kravMotattDato, visFeilmeldinger }) => (
+    <FixedDatoVelger
+        {...kravMotattDato.hentNavInputProps(visFeilmeldinger)}
+        valgtDato={kravMotattDato.verdi}
+        label={'Krav dato'}
+        placeholder={'DD.MM.ÅÅÅÅ'}
+        limitations={{
+            maxDate: new Date().toISOString(),
+        }}
+        onChange={input => kravMotattDato.hentNavInputProps(visFeilmeldinger).onChange(input ?? '')}
+        feil={visFeilmeldinger && kravMotattDato.feilmelding}
+    />
+);

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -84,9 +84,9 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
                         opprettBehandlingSkjema={opprettBehandlingSkjema}
                         minimalFagsak={minimalFagsak}
                     />
-                    {opprettBehandlingSkjema.felter.kravMotattDato.erSynlig && (
+                    {opprettBehandlingSkjema.felter.kravMottattDato.erSynlig && (
                         <KravDatoFelt
-                            kravMotattDato={opprettBehandlingSkjema.felter.kravMotattDato}
+                            kravMottattDato={opprettBehandlingSkjema.felter.kravMottattDato}
                             visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
                         />
                     )}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -12,6 +12,7 @@ import type { IMinimalFagsak } from '../../../../../typer/fagsak';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
 import UIModalWrapper from '../../../../Felleskomponenter/Modal/UIModalWrapper';
 import SkjultLegend from '../../../../Felleskomponenter/SkjultLegend';
+import { KravDatoFelt } from './KravDatoFelt';
 import OpprettBehandlingValg from './OpprettBehandlingValg';
 import useOpprettBehandling from './useOpprettBehandling';
 
@@ -81,6 +82,10 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
                     <OpprettBehandlingValg
                         opprettBehandlingSkjema={opprettBehandlingSkjema}
                         minimalFagsak={minimalFagsak}
+                    />
+                    <KravDatoFelt
+                        kravMotattDato={opprettBehandlingSkjema.felter.kravMotattDato}
+                        visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
                     />
                 </SkjemaGruppe>
             </UIModalWrapper>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -32,8 +32,6 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
             settVisBekreftelseTilbakekrevingModal(true);
         },
     });
-    const { behandlingsårsak, behandlingstype, behandlingstema, søknadMottattDato } =
-        opprettBehandlingSkjema.felter;
 
     const lukkOpprettBehandlingModal = () => {
         nullstillSkjemaStatus();
@@ -81,12 +79,8 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
                 <SkjemaGruppe feil={hentFrontendFeilmelding(opprettBehandlingSkjema.submitRessurs)}>
                     <SkjultLegend>Opprett ny behandling</SkjultLegend>
                     <OpprettBehandlingValg
-                        behandlingstype={behandlingstype}
-                        behandlingsårsak={behandlingsårsak}
-                        behandlingstema={behandlingstema}
-                        søknadMottattDato={søknadMottattDato}
+                        opprettBehandlingSkjema={opprettBehandlingSkjema}
                         minimalFagsak={minimalFagsak}
-                        visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
                     />
                 </SkjemaGruppe>
             </UIModalWrapper>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -14,6 +14,7 @@ import UIModalWrapper from '../../../../Felleskomponenter/Modal/UIModalWrapper';
 import SkjultLegend from '../../../../Felleskomponenter/SkjultLegend';
 import { KravDatoFelt } from './KravDatoFelt';
 import OpprettBehandlingValg from './OpprettBehandlingValg';
+import { SøknadMottattDatoFelt } from './SøknadMottattDatoFelt';
 import useOpprettBehandling from './useOpprettBehandling';
 
 interface IProps {
@@ -85,6 +86,10 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
                     />
                     <KravDatoFelt
                         kravMotattDato={opprettBehandlingSkjema.felter.kravMotattDato}
+                        visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
+                    />
+                    <SøknadMottattDatoFelt
+                        søknadMottattDato={opprettBehandlingSkjema.felter.søknadMottattDato}
                         visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
                     />
                 </SkjemaGruppe>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -84,14 +84,18 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
                         opprettBehandlingSkjema={opprettBehandlingSkjema}
                         minimalFagsak={minimalFagsak}
                     />
-                    <KravDatoFelt
-                        kravMotattDato={opprettBehandlingSkjema.felter.kravMotattDato}
-                        visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
-                    />
-                    <SøknadMottattDatoFelt
-                        søknadMottattDato={opprettBehandlingSkjema.felter.søknadMottattDato}
-                        visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
-                    />
+                    {opprettBehandlingSkjema.felter.kravMotattDato.erSynlig && (
+                        <KravDatoFelt
+                            kravMotattDato={opprettBehandlingSkjema.felter.kravMotattDato}
+                            visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
+                        />
+                    )}
+                    {opprettBehandlingSkjema.felter.søknadMottattDato.erSynlig && (
+                        <SøknadMottattDatoFelt
+                            søknadMottattDato={opprettBehandlingSkjema.felter.søknadMottattDato}
+                            visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
+                        />
+                    )}
                 </SkjemaGruppe>
             </UIModalWrapper>
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -27,7 +27,7 @@ import { BehandlingstemaSelect } from '../../../../Felleskomponenter/Behandlings
 import type { VisningBehandling } from '../../../Saksoversikt/visningBehandling';
 import type { IOpprettBehandlingSkjemaFelter } from './useOpprettBehandling';
 
-const FixedDatoVelger = styled(FamilieDatovelger)`
+export const FixedDatoVelger = styled(FamilieDatovelger)`
     .nav-datovelger__kalenderPortal__content {
         position: fixed;
     }
@@ -39,7 +39,7 @@ const FixedDatoVelger = styled(FamilieDatovelger)`
     margin-top: 2rem;
 `;
 
-const FeltFeilmelding = styled(BodyShort)`
+export const FeltFeilmelding = styled(BodyShort)`
     margin-top: 0.5rem;
     font-weight: 600;
     color: ${navFarger.redError};
@@ -237,34 +237,6 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                             opprettBehandlingSkjema.visFeilmeldinger && (
                                 <FeltFeilmelding>
                                     {opprettBehandlingSkjema.felter.søknadMottattDato.feilmelding}
-                                </FeltFeilmelding>
-                            )}
-                    </>
-                )}
-
-            {erOpprettBehandlingSkjema(opprettBehandlingSkjema) &&
-                opprettBehandlingSkjema.felter.kravMotattDato?.erSynlig && (
-                    <>
-                        <FixedDatoVelger
-                            {...opprettBehandlingSkjema.felter.kravMotattDato.hentNavInputProps(
-                                opprettBehandlingSkjema.visFeilmeldinger
-                            )}
-                            valgtDato={opprettBehandlingSkjema.felter.kravMotattDato.verdi}
-                            label={'Mottatt dato'}
-                            placeholder={'DD.MM.ÅÅÅÅ'}
-                            limitations={{
-                                maxDate: new Date().toISOString(),
-                            }}
-                            onChange={input =>
-                                opprettBehandlingSkjema.felter.kravMotattDato
-                                    .hentNavInputProps(opprettBehandlingSkjema.visFeilmeldinger)
-                                    .onChange(input ?? '')
-                            }
-                        />
-                        {opprettBehandlingSkjema.felter.kravMotattDato.feilmelding &&
-                            opprettBehandlingSkjema.visFeilmeldinger && (
-                                <FeltFeilmelding>
-                                    {opprettBehandlingSkjema.felter.kravMotattDato.feilmelding}
                                 </FeltFeilmelding>
                             )}
                     </>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -9,7 +9,7 @@ import { FamilieDatovelger, FamilieSelect } from '@navikt/familie-form-elements'
 import type { ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../../../context/AppContext';
-import type { ManuellJounalføringSkjemaFelter } from '../../../../../context/ManuellJournalførContext';
+import type { ManuellJournalføringSkjemaFelter } from '../../../../../context/ManuellJournalførContext';
 import type { IBehandling } from '../../../../../typer/behandling';
 import {
     BehandlingStatus,
@@ -60,7 +60,7 @@ const StyledBehandlingstemaSelect = styled(BehandlingstemaSelect)`
 interface IProps {
     opprettBehandlingSkjema:
         | ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling>
-        | ISkjema<ManuellJounalføringSkjemaFelter, string>;
+        | ISkjema<ManuellJournalføringSkjemaFelter, string>;
     minimalFagsak?: IMinimalFagsak;
     erLesevisning?: boolean;
     manuellJournalfør?: boolean;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import navFarger from 'nav-frontend-core';
-
-import { BodyShort } from '@navikt/ds-react';
 import { FamilieDatovelger, FamilieSelect } from '@navikt/familie-form-elements';
 import type { ISkjema } from '@navikt/familie-skjema';
 
@@ -37,12 +34,6 @@ export const FixedDatoVelger = styled(FamilieDatovelger)`
     }
 
     margin-top: 2rem;
-`;
-
-export const FeltFeilmelding = styled(BodyShort)`
-    margin-top: 0.5rem;
-    font-weight: 600;
-    color: ${navFarger.redError};
 `;
 
 const StyledFamilieSelect = styled(FamilieSelect)`

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -9,6 +9,7 @@ import { FamilieDatovelger, FamilieSelect } from '@navikt/familie-form-elements'
 import type { ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../../../context/AppContext';
+import type { ManuellJounalføringSkjemaFelter } from '../../../../../context/ManuellJournalførContext';
 import type { IBehandling } from '../../../../../typer/behandling';
 import {
     BehandlingStatus,
@@ -30,9 +31,11 @@ const FixedDatoVelger = styled(FamilieDatovelger)`
     .nav-datovelger__kalenderPortal__content {
         position: fixed;
     }
+
     .nav-datovelger__kalenderknapp {
         z-index: 0;
     }
+
     margin-top: 2rem;
 `;
 
@@ -55,7 +58,9 @@ const StyledBehandlingstemaSelect = styled(BehandlingstemaSelect)`
 `;
 
 interface IProps {
-    opprettBehandlingSkjema: ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling>;
+    opprettBehandlingSkjema:
+        | ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling>
+        | ISkjema<ManuellJounalføringSkjemaFelter, string>;
     minimalFagsak?: IMinimalFagsak;
     erLesevisning?: boolean;
     manuellJournalfør?: boolean;
@@ -96,13 +101,13 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
 
     const visFeilmeldinger = opprettBehandlingSkjema.visFeilmeldinger;
 
-    const {
-        behandlingsårsak,
-        behandlingstype,
-        behandlingstema,
-        søknadMottattDato,
-        kravMotattDato,
-    } = opprettBehandlingSkjema.felter;
+    const { behandlingsårsak, behandlingstype, behandlingstema } = opprettBehandlingSkjema.felter;
+    const erOpprettBehandlingSkjema = (
+        opprettBehandlingSkjema:
+            | ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling>
+            | ISkjema<ManuellJounalføringSkjemaFelter, string>
+    ): opprettBehandlingSkjema is ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling> =>
+        'kravMotattDato' in opprettBehandlingSkjema.felter;
 
     return (
         <>
@@ -209,43 +214,61 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                 />
             )}
 
-            {søknadMottattDato?.erSynlig && (
-                <>
-                    <FixedDatoVelger
-                        {...søknadMottattDato.hentNavInputProps(
-                            opprettBehandlingSkjema.visFeilmeldinger
-                        )}
-                        valgtDato={søknadMottattDato.verdi}
-                        label={'Mottatt dato'}
-                        placeholder={'DD.MM.ÅÅÅÅ'}
-                        limitations={{
-                            maxDate: new Date().toISOString(),
-                        }}
-                    />
-                    {søknadMottattDato.feilmelding && opprettBehandlingSkjema.visFeilmeldinger && (
-                        <FeltFeilmelding>{søknadMottattDato.feilmelding}</FeltFeilmelding>
-                    )}
-                </>
-            )}
+            {erOpprettBehandlingSkjema(opprettBehandlingSkjema) &&
+                opprettBehandlingSkjema.felter.søknadMottattDato?.erSynlig && (
+                    <>
+                        <FixedDatoVelger
+                            {...opprettBehandlingSkjema.felter.søknadMottattDato.hentNavInputProps(
+                                opprettBehandlingSkjema.visFeilmeldinger
+                            )}
+                            valgtDato={opprettBehandlingSkjema.felter.søknadMottattDato.verdi}
+                            label={'Mottatt dato'}
+                            placeholder={'DD.MM.ÅÅÅÅ'}
+                            limitations={{
+                                maxDate: new Date().toISOString(),
+                            }}
+                            onChange={input =>
+                                opprettBehandlingSkjema.felter.søknadMottattDato
+                                    .hentNavInputProps(opprettBehandlingSkjema.visFeilmeldinger)
+                                    .onChange(input ?? '')
+                            }
+                        />
+                        {opprettBehandlingSkjema.felter.søknadMottattDato.feilmelding &&
+                            opprettBehandlingSkjema.visFeilmeldinger && (
+                                <FeltFeilmelding>
+                                    {opprettBehandlingSkjema.felter.søknadMottattDato.feilmelding}
+                                </FeltFeilmelding>
+                            )}
+                    </>
+                )}
 
-            {kravMotattDato?.erSynlig && (
-                <>
-                    <FixedDatoVelger
-                        {...kravMotattDato.hentNavInputProps(
-                            opprettBehandlingSkjema.visFeilmeldinger
-                        )}
-                        valgtDato={kravMotattDato.verdi}
-                        label={'Mottatt dato'}
-                        placeholder={'DD.MM.ÅÅÅÅ'}
-                        limitations={{
-                            maxDate: new Date().toISOString(),
-                        }}
-                    />
-                    {kravMotattDato.feilmelding && opprettBehandlingSkjema.visFeilmeldinger && (
-                        <FeltFeilmelding>{kravMotattDato.feilmelding}</FeltFeilmelding>
-                    )}
-                </>
-            )}
+            {erOpprettBehandlingSkjema(opprettBehandlingSkjema) &&
+                opprettBehandlingSkjema.felter.kravMotattDato?.erSynlig && (
+                    <>
+                        <FixedDatoVelger
+                            {...opprettBehandlingSkjema.felter.kravMotattDato.hentNavInputProps(
+                                opprettBehandlingSkjema.visFeilmeldinger
+                            )}
+                            valgtDato={opprettBehandlingSkjema.felter.kravMotattDato.verdi}
+                            label={'Mottatt dato'}
+                            placeholder={'DD.MM.ÅÅÅÅ'}
+                            limitations={{
+                                maxDate: new Date().toISOString(),
+                            }}
+                            onChange={input =>
+                                opprettBehandlingSkjema.felter.kravMotattDato
+                                    .hentNavInputProps(opprettBehandlingSkjema.visFeilmeldinger)
+                                    .onChange(input ?? '')
+                            }
+                        />
+                        {opprettBehandlingSkjema.felter.kravMotattDato.feilmelding &&
+                            opprettBehandlingSkjema.visFeilmeldinger && (
+                                <FeltFeilmelding>
+                                    {opprettBehandlingSkjema.felter.kravMotattDato.feilmelding}
+                                </FeltFeilmelding>
+                            )}
+                    </>
+                )}
         </>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -102,12 +102,6 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
     const visFeilmeldinger = opprettBehandlingSkjema.visFeilmeldinger;
 
     const { behandlingsårsak, behandlingstype, behandlingstema } = opprettBehandlingSkjema.felter;
-    const erOpprettBehandlingSkjema = (
-        opprettBehandlingSkjema:
-            | ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling>
-            | ISkjema<ManuellJounalføringSkjemaFelter, string>
-    ): opprettBehandlingSkjema is ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling> =>
-        'kravMotattDato' in opprettBehandlingSkjema.felter;
 
     return (
         <>
@@ -213,34 +207,6 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                     label="Velg behandlingstema"
                 />
             )}
-
-            {erOpprettBehandlingSkjema(opprettBehandlingSkjema) &&
-                opprettBehandlingSkjema.felter.søknadMottattDato?.erSynlig && (
-                    <>
-                        <FixedDatoVelger
-                            {...opprettBehandlingSkjema.felter.søknadMottattDato.hentNavInputProps(
-                                opprettBehandlingSkjema.visFeilmeldinger
-                            )}
-                            valgtDato={opprettBehandlingSkjema.felter.søknadMottattDato.verdi}
-                            label={'Mottatt dato'}
-                            placeholder={'DD.MM.ÅÅÅÅ'}
-                            limitations={{
-                                maxDate: new Date().toISOString(),
-                            }}
-                            onChange={input =>
-                                opprettBehandlingSkjema.felter.søknadMottattDato
-                                    .hentNavInputProps(opprettBehandlingSkjema.visFeilmeldinger)
-                                    .onChange(input ?? '')
-                            }
-                        />
-                        {opprettBehandlingSkjema.felter.søknadMottattDato.feilmelding &&
-                            opprettBehandlingSkjema.visFeilmeldinger && (
-                                <FeltFeilmelding>
-                                    {opprettBehandlingSkjema.felter.søknadMottattDato.feilmelding}
-                                </FeltFeilmelding>
-                            )}
-                    </>
-                )}
         </>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/SøknadMottattDatoFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/SøknadMottattDatoFelt.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import type { FamilieIsoDate } from '../../../../../utils/kalender';
-import { FeltFeilmelding, FixedDatoVelger } from './OpprettBehandlingValg';
+import { FixedDatoVelger } from './OpprettBehandlingValg';
 
 interface IProps {
     søknadMottattDato: Felt<FamilieIsoDate>;
@@ -13,29 +13,18 @@ interface IProps {
 export const SøknadMottattDatoFelt: React.FC<IProps> = ({
     søknadMottattDato,
     visFeilmeldinger,
-}) => {
-    if (!søknadMottattDato.erSynlig) {
-        return null;
-    }
-
-    return (
-        <>
-            <FixedDatoVelger
-                {...søknadMottattDato.hentNavInputProps(visFeilmeldinger)}
-                valgtDato={søknadMottattDato.verdi}
-                label={'Mottatt dato'}
-                placeholder={'DD.MM.ÅÅÅÅ'}
-                limitations={{
-                    maxDate: new Date().toISOString(),
-                }}
-                onChange={input =>
-                    søknadMottattDato.hentNavInputProps(visFeilmeldinger).onChange(input ?? '')
-                }
-            />
-
-            {søknadMottattDato.feilmelding && visFeilmeldinger && (
-                <FeltFeilmelding>{søknadMottattDato.feilmelding}</FeltFeilmelding>
-            )}
-        </>
-    );
-};
+}) => (
+    <FixedDatoVelger
+        {...søknadMottattDato.hentNavInputProps(visFeilmeldinger)}
+        valgtDato={søknadMottattDato.verdi}
+        label={'Mottatt dato'}
+        placeholder={'DD.MM.ÅÅÅÅ'}
+        limitations={{
+            maxDate: new Date().toISOString(),
+        }}
+        onChange={input =>
+            søknadMottattDato.hentNavInputProps(visFeilmeldinger).onChange(input ?? '')
+        }
+        feil={visFeilmeldinger && søknadMottattDato.feilmelding}
+    />
+);

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/SøknadMottattDatoFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/SøknadMottattDatoFelt.tsx
@@ -18,7 +18,6 @@ export const SøknadMottattDatoFelt: React.FC<IProps> = ({
         {...søknadMottattDato.hentNavInputProps(visFeilmeldinger)}
         valgtDato={søknadMottattDato.verdi}
         label={'Mottatt dato'}
-        placeholder={'DD.MM.ÅÅÅÅ'}
         limitations={{
             maxDate: new Date().toISOString(),
         }}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/SøknadMottattDatoFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/SøknadMottattDatoFelt.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import type { Felt } from '@navikt/familie-skjema';
+
+import type { FamilieIsoDate } from '../../../../../utils/kalender';
+import { FeltFeilmelding, FixedDatoVelger } from './OpprettBehandlingValg';
+
+interface IProps {
+    søknadMottattDato: Felt<FamilieIsoDate>;
+    visFeilmeldinger: boolean;
+}
+
+export const SøknadMottattDatoFelt: React.FC<IProps> = ({
+    søknadMottattDato,
+    visFeilmeldinger,
+}) => {
+    if (!søknadMottattDato.erSynlig) {
+        return null;
+    }
+
+    return (
+        <>
+            <FixedDatoVelger
+                {...søknadMottattDato.hentNavInputProps(visFeilmeldinger)}
+                valgtDato={søknadMottattDato.verdi}
+                label={'Mottatt dato'}
+                placeholder={'DD.MM.ÅÅÅÅ'}
+                limitations={{
+                    maxDate: new Date().toISOString(),
+                }}
+                onChange={input =>
+                    søknadMottattDato.hentNavInputProps(visFeilmeldinger).onChange(input ?? '')
+                }
+            />
+
+            {søknadMottattDato.feilmelding && visFeilmeldinger && (
+                <FeltFeilmelding>{søknadMottattDato.feilmelding}</FeltFeilmelding>
+            )}
+        </>
+    );
+};

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -169,7 +169,7 @@ const useOpprettBehandling = ({
         onSubmit<{ kravMottattDato: FamilieIsoDate }>(
             {
                 method: 'POST',
-                url: `/familie-ks-sak/api/fagsaker/${fagsakId}/opprett-klage`,
+                url: `/familie-ks-sak/api/fagsaker/${fagsakId}/opprett-klagebehandling`,
                 data: { kravMottattDato: kravMottattDato.verdi },
             },
             response => {

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -181,7 +181,7 @@ const useOpprettBehandling = ({
         );
     };
 
-    function opprettTilbakekreving() {
+    const opprettTilbakekreving = () => {
         onSubmit(
             {
                 method: 'GET',
@@ -194,7 +194,7 @@ const useOpprettBehandling = ({
                 }
             }
         );
-    }
+    };
 
     const opprettKontantstøttebehandling = (søkersIdent: string) => {
         onSubmit<IRestNyBehandling>(

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -23,13 +23,13 @@ import { Tilbakekrevingsbehandlingstype } from '../../../../../typer/tilbakekrev
 import type { FamilieIsoDate } from '../../../../../utils/kalender';
 import { erIsoStringGyldig } from '../../../../../utils/kalender';
 
-export type IOpprettBehandlingSkjemaFelter = {
+export interface IOpprettBehandlingSkjemaFelter {
     behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | '';
     behandlingsårsak: BehandlingÅrsak | '';
     behandlingstema: IBehandlingstema | undefined;
     søknadMottattDato: FamilieIsoDate;
     kravMotattDato: FamilieIsoDate;
-};
+}
 
 const useOpprettBehandling = ({
     lukkModal,

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -98,7 +98,7 @@ const useOpprettBehandling = ({
             }
 
             if (erIFremtiden) {
-                return feil(felt, 'Du kan ikke sette en mottatt dato som er frem i tid.');
+                return feil(felt, 'Du kan ikke sette en mottattdato som er frem i tid.');
             }
 
             return ok(felt);
@@ -130,7 +130,7 @@ const useOpprettBehandling = ({
             }
 
             if (erIFremtiden) {
-                return feil(felt, 'Du kan ikke sette en mottatt dato som er frem i tid.');
+                return feil(felt, 'Du kan ikke sette en mottattdato som er frem i tid.');
             }
 
             return ok(felt);

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -98,7 +98,7 @@ const useOpprettBehandling = ({
             }
 
             if (erIFremtiden) {
-                return feil(felt, 'Du kan ikke sette en mottattdato som er frem i tid.');
+                return feil(felt, 'Du kan ikke sette en dato som er frem i tid.');
             }
 
             return ok(felt);
@@ -130,7 +130,7 @@ const useOpprettBehandling = ({
             }
 
             if (erIFremtiden) {
-                return feil(felt, 'Du kan ikke sette en mottattdato som er frem i tid.');
+                return feil(felt, 'Du kan ikke sette en dato som er frem i tid.');
             }
 
             return ok(felt);

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -23,6 +23,14 @@ import { Tilbakekrevingsbehandlingstype } from '../../../../../typer/tilbakekrev
 import type { FamilieIsoDate } from '../../../../../utils/kalender';
 import { erIsoStringGyldig } from '../../../../../utils/kalender';
 
+export type IOpprettBehandlingSkjemaFelter = {
+    behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | '';
+    behandlingsårsak: BehandlingÅrsak | '';
+    behandlingstema: IBehandlingstema | undefined;
+    søknadMottattDato: FamilieIsoDate;
+    kravMotattDato: FamilieIsoDate;
+};
+
 const useOpprettBehandling = ({
     lukkModal,
     onOpprettTilbakekrevingSuccess,
@@ -76,9 +84,9 @@ const useOpprettBehandling = ({
         },
     });
 
-    const søknadMottattDato = useFelt<FamilieIsoDate | undefined>({
-        verdi: undefined,
-        valideringsfunksjon: (felt: FeltState<FamilieIsoDate | undefined>) => {
+    const søknadMottattDato = useFelt<FamilieIsoDate>({
+        verdi: '',
+        valideringsfunksjon: (felt: FeltState<FamilieIsoDate>) => {
             const erGyldigIsoString = felt.verdi && erIsoStringGyldig(felt.verdi);
             const erIFremtiden = felt.verdi && erDatoFremITid(felt.verdi);
 
@@ -108,17 +116,37 @@ const useOpprettBehandling = ({
         },
     });
 
+    const kravMotattDato = useFelt<FamilieIsoDate>({
+        verdi: '',
+        valideringsfunksjon: (felt: FeltState<FamilieIsoDate>) => {
+            const erGyldigIsoString = erIsoStringGyldig(felt.verdi);
+            const erIFremtiden = erDatoFremITid(felt.verdi);
+
+            if (!erGyldigIsoString) {
+                return feil(
+                    felt,
+                    'Mottatt dato for klagen må registreres ved manuell opprettelse av klagebehandling'
+                );
+            }
+
+            if (erIFremtiden) {
+                return feil(felt, 'Du kan ikke sette en mottatt dato som er frem i tid.');
+            }
+
+            return ok(felt);
+        },
+
+        avhengigheter: { behandlingstype },
+        skalFeltetVises: avhengigheter =>
+            avhengigheter.behandlingstype.verdi === Behandlingstype.KLAGE,
+    });
+
     const erDatoFremITid = (dato: FamilieIsoDate): boolean => {
         return Date.parse(dato.toString()) > new Date().getTime();
     };
 
     const { skjema, nullstillSkjema, kanSendeSkjema, onSubmit, settSubmitRessurs } = useSkjema<
-        {
-            behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | '';
-            behandlingsårsak: BehandlingÅrsak | '';
-            behandlingstema: IBehandlingstema | undefined;
-            søknadMottattDato: FamilieIsoDate | undefined;
-        },
+        IOpprettBehandlingSkjemaFelter,
         IBehandling
     >({
         felter: {
@@ -126,75 +154,94 @@ const useOpprettBehandling = ({
             behandlingsårsak,
             behandlingstema,
             søknadMottattDato,
+            kravMotattDato,
         },
         skjemanavn: 'Opprett behandling modal',
     });
 
     useEffect(() => {
-        switch (skjema.felter.behandlingstype.verdi) {
-            case Behandlingstype.FØRSTEGANGSBEHANDLING:
-                skjema.felter.behandlingsårsak.validerOgSettFelt(BehandlingÅrsak.SØKNAD);
-                break;
+        if (behandlingstype.verdi === Behandlingstype.FØRSTEGANGSBEHANDLING) {
+            behandlingsårsak.validerOgSettFelt(BehandlingÅrsak.SØKNAD);
         }
-    }, [skjema.felter.behandlingstype.verdi]);
+    }, [behandlingstype.verdi]);
+
+    const opprettKlagebehandling = () => {
+        onSubmit<{ kravMotattDato: FamilieIsoDate }>(
+            {
+                method: 'POST',
+                url: `/familie-ks-sak/api/fagsaker/${fagsakId}/opprett-klage`,
+                data: { kravMotattDato: kravMotattDato.verdi },
+            },
+            response => {
+                if (response.status === RessursStatus.SUKSESS) {
+                    lukkModal();
+                    nullstillSkjema();
+                }
+            }
+        );
+    };
+
+    function opprettTilbakekreving() {
+        onSubmit(
+            {
+                method: 'GET',
+                url: `/familie-ks-sak/api/fagsaker/${fagsakId}/opprett-tilbakekreving`,
+            },
+            response => {
+                if (response.status === RessursStatus.SUKSESS) {
+                    nullstillSkjemaStatus();
+                    onOpprettTilbakekrevingSuccess();
+                }
+            }
+        );
+    }
+
+    const opprettKontantstøttebehandling = (søkersIdent: string) => {
+        onSubmit<IRestNyBehandling>(
+            {
+                data: {
+                    kategori: skjema.felter.behandlingstema.verdi?.kategori ?? null,
+                    søkersIdent,
+                    behandlingType: behandlingstype.verdi as Behandlingstype,
+                    behandlingÅrsak: behandlingsårsak.verdi as BehandlingÅrsak,
+                    navIdent: innloggetSaksbehandler?.navIdent,
+                    søknadMottattDato: skjema.felter.søknadMottattDato.verdi ?? undefined,
+                },
+                method: 'POST',
+                url: '/familie-ks-sak/api/behandlinger',
+            },
+            response => {
+                if (response.status === RessursStatus.SUKSESS) {
+                    lukkModal();
+                    nullstillSkjema();
+
+                    settÅpenBehandling(response);
+                    const behandling: IBehandling | undefined = hentDataFraRessurs(response);
+
+                    if (behandling && behandling.årsak === BehandlingÅrsak.SØKNAD) {
+                        navigate(
+                            behandling.steg === BehandlingSteg.REGISTRERE_INSTITUSJON_OG_VERGE
+                                ? `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-mottaker`
+                                : `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-soknad`
+                        );
+                    } else {
+                        navigate(
+                            `/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`
+                        );
+                    }
+                }
+            }
+        );
+    };
 
     const onBekreft = (søkersIdent: string) => {
-        const { behandlingstype, behandlingsårsak } = skjema.felter;
         if (kanSendeSkjema()) {
-            if (
-                skjema.felter.behandlingstype.verdi ===
-                Tilbakekrevingsbehandlingstype.TILBAKEKREVING
-            ) {
-                onSubmit(
-                    {
-                        method: 'GET',
-                        url: `/familie-ks-sak/api/fagsaker/${fagsakId}/opprett-tilbakekreving`,
-                    },
-                    response => {
-                        if (response.status === RessursStatus.SUKSESS) {
-                            nullstillSkjemaStatus();
-                            onOpprettTilbakekrevingSuccess();
-                        }
-                    }
-                );
+            if (behandlingstype.verdi === Behandlingstype.KLAGE) {
+                opprettKlagebehandling();
+            } else if (behandlingstype.verdi === Tilbakekrevingsbehandlingstype.TILBAKEKREVING) {
+                opprettTilbakekreving();
             } else {
-                onSubmit<IRestNyBehandling>(
-                    {
-                        data: {
-                            kategori: skjema.felter.behandlingstema.verdi?.kategori ?? null,
-                            søkersIdent,
-                            behandlingType: behandlingstype.verdi as Behandlingstype,
-                            behandlingÅrsak: behandlingsårsak.verdi as BehandlingÅrsak,
-                            navIdent: innloggetSaksbehandler?.navIdent,
-                            søknadMottattDato: skjema.felter.søknadMottattDato.verdi ?? undefined,
-                        },
-                        method: 'POST',
-                        url: '/familie-ks-sak/api/behandlinger',
-                    },
-                    response => {
-                        if (response.status === RessursStatus.SUKSESS) {
-                            lukkModal();
-                            nullstillSkjema();
-
-                            settÅpenBehandling(response);
-                            const behandling: IBehandling | undefined =
-                                hentDataFraRessurs(response);
-
-                            if (behandling && behandling.årsak === BehandlingÅrsak.SØKNAD) {
-                                navigate(
-                                    behandling.steg ===
-                                        BehandlingSteg.REGISTRERE_INSTITUSJON_OG_VERGE
-                                        ? `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-mottaker`
-                                        : `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-soknad`
-                                );
-                            } else {
-                                navigate(
-                                    `/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`
-                                );
-                            }
-                        }
-                    }
-                );
+                opprettKontantstøttebehandling(søkersIdent);
             }
         }
     };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -28,7 +28,7 @@ export interface IOpprettBehandlingSkjemaFelter {
     behandlingsårsak: BehandlingÅrsak | '';
     behandlingstema: IBehandlingstema | undefined;
     søknadMottattDato: FamilieIsoDate;
-    kravMotattDato: FamilieIsoDate;
+    kravMottattDato: FamilieIsoDate;
 }
 
 const useOpprettBehandling = ({
@@ -116,7 +116,7 @@ const useOpprettBehandling = ({
         },
     });
 
-    const kravMotattDato = useFelt<FamilieIsoDate>({
+    const kravMottattDato = useFelt<FamilieIsoDate>({
         verdi: '',
         valideringsfunksjon: (felt: FeltState<FamilieIsoDate>) => {
             const erGyldigIsoString = erIsoStringGyldig(felt.verdi);
@@ -154,7 +154,7 @@ const useOpprettBehandling = ({
             behandlingsårsak,
             behandlingstema,
             søknadMottattDato,
-            kravMotattDato,
+            kravMottattDato: kravMottattDato,
         },
         skjemanavn: 'Opprett behandling modal',
     });
@@ -166,11 +166,11 @@ const useOpprettBehandling = ({
     }, [behandlingstype.verdi]);
 
     const opprettKlagebehandling = () => {
-        onSubmit<{ kravMotattDato: FamilieIsoDate }>(
+        onSubmit<{ kravMottattDato: FamilieIsoDate }>(
             {
                 method: 'POST',
                 url: `/familie-ks-sak/api/fagsaker/${fagsakId}/opprett-klage`,
-                data: { kravMotattDato: kravMotattDato.verdi },
+                data: { kravMottattDato: kravMottattDato.verdi },
             },
             response => {
                 if (response.status === RessursStatus.SUKSESS) {

--- a/src/frontend/komponenter/ManuellJournalfør/KnyttTilNyBehandling.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/KnyttTilNyBehandling.tsx
@@ -21,8 +21,7 @@ const StyledCheckboxDiv = styled.div`
  */
 export const KnyttTilNyBehandling: React.FC = () => {
     const { skjema, minimalFagsak, kanKnytteJournalpostTilBehandling } = useManuellJournalfør();
-    const { knyttTilNyBehandling, behandlingstema, behandlingsårsak, behandlingstype } =
-        skjema.felter;
+    const { knyttTilNyBehandling, behandlingstype } = skjema.felter;
     return (
         <SkjemaGruppe>
             <Heading size={'small'} level={'2'}>
@@ -51,13 +50,10 @@ export const KnyttTilNyBehandling: React.FC = () => {
             </StyledCheckboxDiv>
             {behandlingstype.erSynlig && (
                 <OpprettBehandlingValg
-                    behandlingstype={behandlingstype}
-                    behandlingsårsak={behandlingsårsak}
+                    opprettBehandlingSkjema={skjema}
                     minimalFagsak={minimalFagsak}
-                    visFeilmeldinger={skjema.visFeilmeldinger}
                     erLesevisning={!kanKnytteJournalpostTilBehandling()}
                     manuellJournalfør
-                    behandlingstema={behandlingstema}
                 />
             )}
         </SkjemaGruppe>

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -141,6 +141,7 @@ export enum Behandlingstype {
     FØRSTEGANGSBEHANDLING = 'FØRSTEGANGSBEHANDLING',
     REVURDERING = 'REVURDERING',
     TEKNISK_ENDRING = 'TEKNISK_ENDRING',
+    KLAGE = 'KLAGE',
 }
 
 export enum BehandlingResultat {

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -12,6 +12,7 @@ export enum ToggleNavn {
     støtterInstitusjon = 'familie-ks-sak.stotter-institusjon',
     kanBehandleEøsSekunderland = 'familie-ks-sak.behandling.eos-sekunderland',
     kanBehandleEøsToPrimerland = 'familie-ks-sak.behandling.eos-to-primerland',
+    kanBehandleKlage = 'familie-ks-sak.klage',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10663

Vi trenger en mulighet for å lage klagebehandlinger fra KS-sak, og ønsker å ha "Klage" som et valg under "opprett behandling"-menyen

NB: Ønsker å splitte ut fleltene fra `OpprettBehandlingValg` til egne komponenter, men tar det i en egen PR, så denne ikke blir så stor

Skisse: 
![image](https://user-images.githubusercontent.com/17828446/207265221-8b1b3d85-f6c0-4cae-b5c4-219124a8b154.png)

Skjermbilde fra localhost: 
![image](https://user-images.githubusercontent.com/17828446/207265382-b1600dd9-97fe-4936-9459-36f69140ecbc.png)

