### PR TITLE
Legg til delt bosted som case i barnehageplass beskrivelse

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/OppsummeringsboksUtils.ts
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/OppsummeringsboksUtils.ts
@@ -1,8 +1,10 @@
 export const hentBarnehageplassBeskrivelse = (prosent: number, erPåvirketAvEndring: boolean) => {
+    const prosentVedDeltBosted = 50;
+
     switch (true) {
         case erPåvirketAvEndring:
             return 'Ikke relevant';
-        case prosent === 100:
+        case prosent === 100 || prosentVedDeltBosted:
             return 'Ingen plass';
         case prosent === 80:
             return 'Under 9 timer';


### PR DESCRIPTION
Ved deltbosted er prosenten 50, og da skal det stå "Ingen plass" i barnehage kolonna.
Det står nå over 33 timer, siden vi har ingen case for 50%.
![image-3](https://user-images.githubusercontent.com/110383605/208536571-12d1e5a1-e064-4ed9-92ec-6703736d11c6.png)


Favrokort:
https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=Tea-10722