### PR TITLE
Legg til sisteVedtaksperiodeVisningdato til i behandling respons

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -40,7 +40,8 @@ const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
     const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
         åpenBehandling.vedtak?.vedtaksperioderMedBegrunnelser ?? [],
         åpenBehandling.resultat,
-        åpenBehandling.status
+        åpenBehandling.status,
+        åpenBehandling.sisteVedtaksperiodeVisningDato
     );
 
     if (

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
@@ -30,7 +30,8 @@ describe('VedtakBegrunnelserContext', () => {
             const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                 vedtaksperioder,
                 BehandlingResultat.AVSLÅTT_ENDRET_OG_OPPHØRT,
-                BehandlingStatus.UTREDES
+                BehandlingStatus.UTREDES,
+                undefined
             );
             expect(perioder.length).toBe(3);
             expect(perioder[0].type).toBe(Vedtaksperiodetype.UTBETALING);
@@ -47,7 +48,8 @@ describe('VedtakBegrunnelserContext', () => {
                 const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                     vedtaksperioder,
                     BehandlingResultat.INNVILGET_OG_OPPHØRT,
-                    BehandlingStatus.AVSLUTTET
+                    BehandlingStatus.AVSLUTTET,
+                    undefined
                 );
                 expect(perioder.length).toBe(1);
                 expect(perioder[0].type).toEqual(Vedtaksperiodetype.OPPHØR);
@@ -74,7 +76,8 @@ describe('VedtakBegrunnelserContext', () => {
                         }),
                     ],
                     BehandlingResultat.INNVILGET,
-                    BehandlingStatus.UTREDES
+                    BehandlingStatus.UTREDES,
+                    undefined
                 );
                 expect(perioder.length).toBe(1);
             });
@@ -98,7 +101,8 @@ describe('VedtakBegrunnelserContext', () => {
                         }),
                     ],
                     BehandlingResultat.INNVILGET,
-                    BehandlingStatus.UTREDES
+                    BehandlingStatus.UTREDES,
+                    undefined
                 );
                 expect(perioder.length).toBe(0);
             });
@@ -111,7 +115,8 @@ describe('VedtakBegrunnelserContext', () => {
                 const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                     vedtaksperioder,
                     BehandlingResultat.OPPHØRT,
-                    BehandlingStatus.UTREDES
+                    BehandlingStatus.UTREDES,
+                    undefined
                 );
                 expect(perioder.length).toBe(1);
                 expect(perioder[0].type).toBe(Vedtaksperiodetype.OPPHØR);

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -1,5 +1,6 @@
 import type { ISODateString } from '@navikt/familie-form-elements';
 
+import type { FamilieIsoDate } from '../utils/kalender';
 import type { BehandlingKategori } from './behandlingstema';
 import type { IPersonMedAndelerTilkjentYtelse } from './beregning';
 import type { INøkkelPar } from './common';
@@ -229,6 +230,7 @@ export interface IBehandling {
     utenlandskePeriodebeløp: IRestUtenlandskPeriodeBeløp[];
     valutakurser: IRestValutakurs[];
     korrigertVedtak?: IRestKorrigertVedtak;
+    sisteVedtaksperiodeVisningDato?: FamilieIsoDate;
 }
 
 export interface IArbeidsfordelingPåBehandling {


### PR DESCRIPTION
Vi ønsker å vise alle vedtaksperioder i frontend selvom de er lengre enn 2mnd fram i tid, hvis det er slik at noen vilkår som f.eks barnehageplass eller barnetsalder har en tom som ligger lengre fram i tid enn det.