### PR TITLE
Fritekst-valg basert på 'støtterFritekst'-felt

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -35,10 +35,16 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
                 Standardbegrunnelse.ETTER_ENDRET_UTBETALING_ETTERBETALING
         ).length > 0;
 
+    const vedtaksperiodeInneholderBegrunnelseSomStøtterFritekst = () =>
+        vedtaksperiodeMedBegrunnelser.begrunnelser.some(
+            vedtaksbegrunnelse => vedtaksbegrunnelse.støtterFritekst
+        );
+
     const visFritekster = () =>
         (vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.UTBETALING &&
             vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.ENDRET_UTBETALING) ||
         vedtaksperiodeInneholderEtterbetaling3MånedBegrunnelse() ||
+        vedtaksperiodeInneholderBegrunnelseSomStøtterFritekst() ||
         vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
             vedtaksBegrunnelse =>
                 !ugyldigeReduksjonsteksterForÅTriggeFritekst.includes(

--- a/src/frontend/typer/vedtaksperiode.ts
+++ b/src/frontend/typer/vedtaksperiode.ts
@@ -17,6 +17,7 @@ export interface IVedtaksperiodeMedBegrunnelser {
 export interface IRestVedtaksbegrunnelse {
     begrunnelse: Begrunnelse;
     begrunnelseType: BegrunnelseType;
+    støtterFritekst: boolean;
 }
 
 export interface IRestPutVedtaksperiodeMedFritekster {

--- a/src/frontend/utils/test/vedtak/vedtaksperiode.mock.ts
+++ b/src/frontend/utils/test/vedtak/vedtaksperiode.mock.ts
@@ -16,6 +16,7 @@ const mockBegrunnelse = (): IRestVedtaksbegrunnelse => {
     return {
         begrunnelse: 'Test',
         begrunnelseType: BegrunnelseType.INNVILGET,
+        støtterFritekst: false,
     };
 };
 


### PR DESCRIPTION
Har utvidet `IRestVedtaksbegrunnelse` med feltet `støtterFritekst` og utvidet logikken for når fritekst valg skal dukke opp. Dersom en valgt begrunnelse har `støtterFritekst = true` så vises nå fritekst-valg. Eksisterende fritekst-logikk er også fortsatt gjeldende.  