### PR TITLE
Bytter til POST-endepunktet for journalposter for bruker for å ikke logge ident

### DIFF
--- a/src/frontend/komponenter/Fagsak/journalposter/JournalpostListe.tsx
+++ b/src/frontend/komponenter/Fagsak/journalposter/JournalpostListe.tsx
@@ -128,9 +128,12 @@ const JournalpostListe: React.FC<IProps> = ({ bruker }) => {
     useEffect(() => {
         settJournalposterRessurs(byggHenterRessurs());
 
-        request<undefined, IJournalpost[]>({
-            method: 'GET',
-            url: `/familie-ks-sak/api/journalpost/bruker/${bruker.personIdent}`,
+        const ident = bruker.personIdent;
+
+        request<{ ident: string }, IJournalpost[]>({
+            method: 'POST',
+            data: { ident },
+            url: `/familie-ks-sak/api/journalpost/bruker`,
             påvirkerSystemLaster: true,
         }).then(journalposterRessurs => {
             settJournalposterRessurs(journalposterRessurs);


### PR DESCRIPTION
Bytter til POST-endepunktet for JournalpostListe for å stoppe logging av url og dermed logging av identer

Denne er avhengig av at https://github.com/navikt/familie-ks-sak/pull/296 er merget