### PR TITLE
Vi går ibort fra set-output, siden det blir deprecated.

### DIFF
--- a/.github/yarn-cache/action.yml
+++ b/.github/yarn-cache/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
     - uses: actions/cache@v3
       id: yarn-cache


### PR DESCRIPTION
 https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d

Før:
![bef](https://user-images.githubusercontent.com/110383605/217208507-09b9e212-9c84-4067-9398-dc8f1903a8cf.png)

Etter:
![aft](https://user-images.githubusercontent.com/110383605/217208521-6793fa69-523b-4ed7-bc86-06c4198e6e7a.png)
