### PR TITLE
Fix lesevisning manglende opplysninger vilkårsvurdering

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
@@ -6,7 +6,11 @@ import { Radio } from 'nav-frontend-skjema';
 
 import { FamilieInput, FamilieRadioGruppe } from '@navikt/familie-form-elements';
 
-import { Resultat, UtdypendeVilkårsvurderingGenerell } from '../../../../../../typer/vilkår';
+import {
+    Resultat,
+    resultater,
+    UtdypendeVilkårsvurderingGenerell,
+} from '../../../../../../typer/vilkår';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
@@ -92,6 +96,7 @@ export const Barnehageplass: React.FC<BarnehageplassProps> = ({
                         ? vilkårSkjemaContext.skjema.felter.resultat.feilmelding
                         : ''
                 }
+                value={resultater[felter.resultat.verdi]}
                 erLesevisning={lesevisning}
             >
                 <Radio

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
@@ -75,7 +75,7 @@ export const Barnehageplass: React.FC<BarnehageplassProps> = ({
         <VilkårSkjema
             vilkårSkjemaContext={vilkårSkjemaContext}
             visVurderesEtter={false}
-            visSpørsmål={false}
+            visSpørsmål={true}
             muligeUtdypendeVilkårsvurderinger={
                 harBarnehageplass ? [] : muligeUtdypendeVilkårsvurderinger
             }

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
@@ -75,7 +75,7 @@ export const Barnehageplass: React.FC<BarnehageplassProps> = ({
         <VilkårSkjema
             vilkårSkjemaContext={vilkårSkjemaContext}
             visVurderesEtter={false}
-            visSpørsmål={true}
+            visSpørsmål={false}
             muligeUtdypendeVilkårsvurderinger={
                 harBarnehageplass ? [] : muligeUtdypendeVilkårsvurderinger
             }

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
@@ -26,7 +26,7 @@ export const MedlemskapAnnenForelder: React.FC<MedlemskapAnnenForelderProps> = (
         <VilkårSkjema
             vilkårSkjemaContext={vilkårSkjemaContext}
             visVurderesEtter={true}
-            visSpørsmål={true}
+            visSpørsmål={false}
             vilkårResultat={vilkårResultat}
             vilkårFraConfig={vilkårFraConfig}
             toggleForm={toggleForm}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
@@ -26,7 +26,7 @@ export const MedlemskapAnnenForelder: React.FC<MedlemskapAnnenForelderProps> = (
         <VilkårSkjema
             vilkårSkjemaContext={vilkårSkjemaContext}
             visVurderesEtter={true}
-            visSpørsmål={false}
+            visSpørsmål={true}
             vilkårResultat={vilkårResultat}
             vilkårFraConfig={vilkårFraConfig}
             toggleForm={toggleForm}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
@@ -5,7 +5,7 @@ import { Radio } from 'nav-frontend-skjema';
 import { Label } from '@navikt/ds-react';
 import { FamilieRadioGruppe } from '@navikt/familie-form-elements';
 
-import { Resultat } from '../../../../../../typer/vilkår';
+import { Resultat, resultater } from '../../../../../../typer/vilkår';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
@@ -42,6 +42,7 @@ export const MedlemskapAnnenForelder: React.FC<MedlemskapAnnenForelderProps> = (
                             : ''}
                     </Label>
                 }
+                value={resultater[felter.resultat.verdi]}
                 error={
                     vilkårSkjemaContext.skjema.visFeilmeldinger
                         ? vilkårSkjemaContext.skjema.felter.resultat.feilmelding


### PR DESCRIPTION
Det er noen opplysninger som ikke viste seg i vilkårsvurderingen hvis man var i lesevisningen.
Grunnen til dette var fordi at man ikke hadde lagt til value i FamilieRadioGruppe

Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=Tea-11435