### PR TITLE
Legg til validering på at fom dato ikke kan være senere enn nåværende måned

### DIFF
--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -164,6 +164,16 @@ export const erPeriodeGyldig = (
         const fomDatoErLikDødsfallDato = fom === person?.dødsfallDato;
 
         const idag = kalenderDatoMedFallback(familieDayjs().toISOString(), TIDENES_ENDE);
+
+        const fomKalenderDato = kalenderDatoMedFallback(fom, TIDENES_MORGEN);
+
+        if (valgtDatoErNesteMånedEllerSenere(fomKalenderDato, idag)) {
+            return feil(
+                felt,
+                'Du kan ikke legge inn fra og med dato som er i neste måned eller senere'
+            );
+        }
+
         if (
             tom &&
             !erBarnetsAlderVilkår &&


### PR DESCRIPTION
Det er ønsket lik validering som vi har i ba-sak, altså at fom dato ikke kan settes enn senere enn nåværende måned.

Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=Tea-11434