### PR TITLE
NAV-12298 - Reduser kall internt i komponenter til vurderErLesevisning()

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
@@ -12,6 +12,12 @@ import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import EndretUtbetalingAndelTabell from './EndretUtbetalingAndelTabell';
+import KompetanseSkjema from './Kompetanse/KompetanseSkjema';
+import { Oppsummeringsboks } from './Oppsummeringsboks';
+import TilkjentYtelseTidslinje from './TilkjentYtelseTidslinje';
+import UtbetaltAnnetLand from './UtbetaltAnnetLand/UtbetaltAnnetLand';
+import Valutakurser from './Valutakurs/Valutakurser';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useEøs } from '../../../context/Eøs/EøsContext';
@@ -34,12 +40,6 @@ import { formaterIdent, slåSammenListeTilStreng } from '../../../utils/formatte
 import { periodeOverlapperMedValgtDato } from '../../../utils/kalender';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
-import EndretUtbetalingAndelTabell from './EndretUtbetalingAndelTabell';
-import KompetanseSkjema from './Kompetanse/KompetanseSkjema';
-import { Oppsummeringsboks } from './Oppsummeringsboks';
-import TilkjentYtelseTidslinje from './TilkjentYtelseTidslinje';
-import UtbetaltAnnetLand from './UtbetaltAnnetLand/UtbetaltAnnetLand';
-import Valutakurser from './Valutakurs/Valutakurser';
 
 const EndretUtbetalingAndel = styled.div`
     display: flex;

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
@@ -12,12 +12,6 @@ import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import EndretUtbetalingAndelTabell from './EndretUtbetalingAndelTabell';
-import KompetanseSkjema from './Kompetanse/KompetanseSkjema';
-import { Oppsummeringsboks } from './Oppsummeringsboks';
-import TilkjentYtelseTidslinje from './TilkjentYtelseTidslinje';
-import UtbetaltAnnetLand from './UtbetaltAnnetLand/UtbetaltAnnetLand';
-import Valutakurser from './Valutakurs/Valutakurser';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useEøs } from '../../../context/Eøs/EøsContext';
@@ -40,6 +34,12 @@ import { formaterIdent, slåSammenListeTilStreng } from '../../../utils/formatte
 import { periodeOverlapperMedValgtDato } from '../../../utils/kalender';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
+import EndretUtbetalingAndelTabell from './EndretUtbetalingAndelTabell';
+import KompetanseSkjema from './Kompetanse/KompetanseSkjema';
+import { Oppsummeringsboks } from './Oppsummeringsboks';
+import TilkjentYtelseTidslinje from './TilkjentYtelseTidslinje';
+import UtbetaltAnnetLand from './UtbetaltAnnetLand/UtbetaltAnnetLand';
+import Valutakurser from './Valutakurs/Valutakurser';
 
 const EndretUtbetalingAndel = styled.div`
     display: flex;
@@ -100,6 +100,7 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
         behandlingsstegSubmitressurs,
         settÅpenBehandling,
     } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
     const {
         erEøsInformasjonGyldig,
         kompetanser,
@@ -176,7 +177,7 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
             className="behandlingsresultat"
             forrigeOnClick={forrigeOnClick}
             nesteOnClick={() => {
-                if (vurderErLesevisning()) {
+                if (erLesevisning) {
                     navigate(`/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/simulering`);
                 } else if (harEøs && !erEøsInformasjonGyldig()) {
                     settVisFeilmeldinger(true);
@@ -202,7 +203,7 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
                 grunnlagPersoner={grunnlagPersoner}
                 tidslinjePersoner={tidslinjePersoner}
             />
-            {!vurderErLesevisning() && (
+            {!erLesevisning && (
                 <EndretUtbetalingAndel>
                     <Button
                         variant="tertiary"

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -341,7 +341,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                         onChange={(dato?: ISODateString) =>
                             skjema.felter.søknadstidspunkt.validerOgSettFelt(dato)
                         }
-                        erLesesvisning={vurderErLesevisning()}
+                        erLesesvisning={erLesevisning}
                     />
                     {skjema.felter.søknadstidspunkt.feilmelding && skjema.visFeilmeldinger && (
                         <StyledErrorMessage>
@@ -370,7 +370,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                             onChange={(dato?: ISODateString) =>
                                 skjema.felter.avtaletidspunktDeltBosted.validerOgSettFelt(dato)
                             }
-                            erLesesvisning={vurderErLesevisning()}
+                            erLesesvisning={erLesevisning}
                         />
                         {skjema.felter.avtaletidspunktDeltBosted.feilmelding &&
                             skjema.visFeilmeldinger && (
@@ -419,7 +419,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                 <Feltmargin>
                     <StyledFamilieTextarea
                         {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                         placeholder={'Begrunn hvorfor utbetalingsperioden er endret.'}
                         label={'Begrunnelse'}
                         value={

--- a/src/frontend/komponenter/Fagsak/Søknad/BarnMedOpplysninger.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/BarnMedOpplysninger.tsx
@@ -47,6 +47,7 @@ const FjernBarnKnapp = styled(Button)`
 const BarnMedOpplysninger: React.FunctionComponent<IProps> = ({ barn }) => {
     const { skjema, barnMedLøpendeUtbetaling } = useSøknad();
     const { vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
     const [visHarLøpendeModal, settVisHarLøpendeModal] = useState(false);
 
     const barnetHarLøpendeUtbetaling = barnMedLøpendeUtbetaling.has(barn.ident);
@@ -71,7 +72,7 @@ const BarnMedOpplysninger: React.FunctionComponent<IProps> = ({ barn }) => {
 
     return (
         <CheckboxOgSlettknapp>
-            {vurderErLesevisning() ? (
+            {erLesevisning ? (
                 barn.merket ? (
                     <BodyShort
                         className={classNames('skjemaelement', 'lese-felt')}
@@ -106,7 +107,7 @@ const BarnMedOpplysninger: React.FunctionComponent<IProps> = ({ barn }) => {
                     </LabelContent>
                 </StyledCheckbox>
             )}
-            {barn.manueltRegistrert && !vurderErLesevisning() && (
+            {barn.manueltRegistrert && !erLesevisning && (
                 <FjernBarnKnapp
                     variant={'tertiary'}
                     id={`fjern__${barn.ident}`}

--- a/src/frontend/komponenter/Fagsak/Søknad/RegistrerSøknad.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/RegistrerSøknad.tsx
@@ -7,14 +7,14 @@ import { Feiloppsummering } from 'nav-frontend-skjema';
 import { Alert, BodyShort, Button } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import Annet from './Annet';
+import Barna from './Barna';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useSøknad } from '../../../context/SøknadContext';
 import { BehandlingSteg } from '../../../typer/behandling';
 import UIModalWrapper from '../../Felleskomponenter/Modal/UIModalWrapper';
 import MålformVelger from '../../Felleskomponenter/MålformVelger';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
-import Annet from './Annet';
-import Barna from './Barna';
 
 const FjernVilkårAdvarsel = styled(BodyShort)`
     white-space: pre-wrap;

--- a/src/frontend/komponenter/Fagsak/Søknad/RegistrerSøknad.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/RegistrerSøknad.tsx
@@ -7,14 +7,14 @@ import { Feiloppsummering } from 'nav-frontend-skjema';
 import { Alert, BodyShort, Button } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import Annet from './Annet';
-import Barna from './Barna';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useSøknad } from '../../../context/SøknadContext';
 import { BehandlingSteg } from '../../../typer/behandling';
 import UIModalWrapper from '../../Felleskomponenter/Modal/UIModalWrapper';
 import MålformVelger from '../../Felleskomponenter/MålformVelger';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
+import Annet from './Annet';
+import Barna from './Barna';
 
 const FjernVilkårAdvarsel = styled(BodyShort)`
     white-space: pre-wrap;
@@ -27,6 +27,7 @@ const StyledSkjemasteg = styled(Skjemasteg)`
 
 const RegistrerSøknad: React.FC = () => {
     const { vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
 
     const {
         hentFeilTilOppsummering,
@@ -44,11 +45,11 @@ const RegistrerSøknad: React.FC = () => {
             nesteOnClick={() => {
                 nesteAction(false);
             }}
-            nesteKnappTittel={vurderErLesevisning() ? 'Neste' : 'Bekreft og fortsett'}
+            nesteKnappTittel={erLesevisning ? 'Neste' : 'Bekreft og fortsett'}
             senderInn={skjema.submitRessurs.status === RessursStatus.HENTER}
             steg={BehandlingSteg.REGISTRERE_SØKNAD}
         >
-            {søknadErLastetFraBackend && !vurderErLesevisning() && (
+            {søknadErLastetFraBackend && !erLesevisning && (
                 <>
                     <br />
                     <Alert
@@ -66,7 +67,7 @@ const RegistrerSøknad: React.FC = () => {
             <MålformVelger
                 målformFelt={skjema.felter.målform}
                 visFeilmeldinger={skjema.visFeilmeldinger}
-                erLesevisning={vurderErLesevisning()}
+                erLesevisning={erLesevisning}
             />
 
             <Annet />

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -8,11 +8,6 @@ import { Alert, BodyShort, Button, Heading, Modal } from '@navikt/ds-react';
 import { FamilieSelect } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import FeilutbetaltValuta from './FeilutbetaltValuta/FeilutbetaltValuta';
-import { PeriodetypeIVedtaksbrev, useVedtak } from './useVedtak';
-import { VedtaksbegrunnelseTeksterProvider } from './VedtakBegrunnelserTabell/Context/VedtaksbegrunnelseTeksterContext';
-import VedtaksperioderMedBegrunnelser from './VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser';
-import Vedtaksmeny from './Vedtaksmeny';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import useDokument from '../../../hooks/useDokument';
@@ -27,6 +22,11 @@ import {
     hentStegNummer,
 } from '../../../typer/behandling';
 import PdfVisningModal from '../../Felleskomponenter/PdfVisningModal/PdfVisningModal';
+import FeilutbetaltValuta from './FeilutbetaltValuta/FeilutbetaltValuta';
+import { PeriodetypeIVedtaksbrev, useVedtak } from './useVedtak';
+import { VedtaksbegrunnelseTeksterProvider } from './VedtakBegrunnelserTabell/Context/VedtaksbegrunnelseTeksterContext';
+import VedtaksperioderMedBegrunnelser from './VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser';
+import Vedtaksmeny from './Vedtaksmeny';
 
 interface IOppsummeringVedtakInnholdProps {
     åpenBehandling: IBehandling;
@@ -67,6 +67,7 @@ const OppsummeringVedtakInnhold: React.FunctionComponent<IOppsummeringVedtakInnh
     const { hentSaksbehandlerRolle } = useApp();
     const { fagsakId } = useSakOgBehandlingParams();
     const { vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
 
     const { overstyrFortsattInnvilgetVedtaksperioder, periodetypeIVedtaksbrev } = useVedtak({
         åpenBehandling,
@@ -152,7 +153,7 @@ const OppsummeringVedtakInnhold: React.FunctionComponent<IOppsummeringVedtakInnh
                 {åpenBehandling.resultat === BehandlingResultat.FORTSATT_INNVILGET && (
                     <FamilieSelect
                         label="Velg brev med eller uten perioder"
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                         onChange={(
                             event: React.ChangeEvent<FortsattInnvilgetPerioderSelect>
                         ): void => {
@@ -187,7 +188,7 @@ const OppsummeringVedtakInnhold: React.FunctionComponent<IOppsummeringVedtakInnh
                                 settErUlagretNyFeilutbetaltValutaPeriode={
                                     settErUlagretNyFeilutbetaltValutaPeriode
                                 }
-                                erLesevisning={vurderErLesevisning()}
+                                erLesevisning={erLesevisning}
                                 skjulFeilutbetaltValuta={() => settVisFeilutbetaltValuta(false)}
                             />
                         )}

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -8,6 +8,11 @@ import { Alert, BodyShort, Button, Heading, Modal } from '@navikt/ds-react';
 import { FamilieSelect } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import FeilutbetaltValuta from './FeilutbetaltValuta/FeilutbetaltValuta';
+import { PeriodetypeIVedtaksbrev, useVedtak } from './useVedtak';
+import { VedtaksbegrunnelseTeksterProvider } from './VedtakBegrunnelserTabell/Context/VedtaksbegrunnelseTeksterContext';
+import VedtaksperioderMedBegrunnelser from './VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser';
+import Vedtaksmeny from './Vedtaksmeny';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import useDokument from '../../../hooks/useDokument';
@@ -22,11 +27,6 @@ import {
     hentStegNummer,
 } from '../../../typer/behandling';
 import PdfVisningModal from '../../Felleskomponenter/PdfVisningModal/PdfVisningModal';
-import FeilutbetaltValuta from './FeilutbetaltValuta/FeilutbetaltValuta';
-import { PeriodetypeIVedtaksbrev, useVedtak } from './useVedtak';
-import { VedtaksbegrunnelseTeksterProvider } from './VedtakBegrunnelserTabell/Context/VedtaksbegrunnelseTeksterContext';
-import VedtaksperioderMedBegrunnelser from './VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser';
-import Vedtaksmeny from './Vedtaksmeny';
 
 interface IOppsummeringVedtakInnholdProps {
     åpenBehandling: IBehandling;

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
@@ -77,6 +77,7 @@ const ItalicText = styled(BodyLong)`
 
 const FritekstVedtakbegrunnelser: React.FC = () => {
     const { vurderErLesevisning, søkersMålform } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
     const {
         skjema,
         leggTilFritekst,
@@ -142,7 +143,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                 </StyledTag>
             </InfoBoks>
 
-            {vurderErLesevisning() ? (
+            {erLesevisning ? (
                 <StyledList id={skjemaGruppeId}>
                     {skjema.felter.fritekster.verdi.map((fritekst: FeltState<IFritekstFelt>) => (
                         <li>{fritekst.verdi.tekst}</li>
@@ -201,7 +202,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                             }
                         )}
                     </SkjemaGruppe>
-                    {!erMaksAntallKulepunkter && !vurderErLesevisning() && (
+                    {!erMaksAntallKulepunkter && !erLesevisning && (
                         <Button
                             variant={'tertiary'}
                             onClick={leggTilFritekst}
@@ -214,7 +215,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                     )}
                     <Knapperekke>
                         <FamilieKnapp
-                            erLesevisning={vurderErLesevisning()}
+                            erLesevisning={erLesevisning}
                             onClick={() => {
                                 putVedtaksperiodeMedFritekster();
                             }}
@@ -226,7 +227,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                             Lagre
                         </FamilieKnapp>
                         <FamilieKnapp
-                            erLesevisning={vurderErLesevisning()}
+                            erLesevisning={erLesevisning}
                             onClick={() => {
                                 onPanelClose(false);
                             }}
@@ -239,7 +240,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                 </>
             )}
         </FritekstContainer>
-    ) : !vurderErLesevisning() ? (
+    ) : !erLesevisning ? (
         <Button
             variant={'tertiary'}
             onClick={leggTilFritekst}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
@@ -8,8 +8,6 @@ import { Normaltekst } from 'nav-frontend-typografi';
 import { Button } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { AnnenVurderingSkjema } from './AnnenVurderingSkjema';
-import { annenVurderingFeilmeldingId } from './AnnenVurderingTabell';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import FamilieChevron from '../../../../ikoner/FamilieChevron';
 import ManuellVurdering from '../../../../ikoner/ManuellVurdering';
@@ -17,6 +15,8 @@ import VilkårResultatIkon from '../../../../ikoner/VilkårResultatIkon';
 import type { IGrunnlagPerson } from '../../../../typer/person';
 import type { IAnnenVurderingConfig, IAnnenVurdering } from '../../../../typer/vilkår';
 import { Resultat, uiResultat } from '../../../../typer/vilkår';
+import { AnnenVurderingSkjema } from './AnnenVurderingSkjema';
+import { annenVurderingFeilmeldingId } from './AnnenVurderingTabell';
 
 interface IProps {
     person: IGrunnlagPerson;
@@ -58,9 +58,10 @@ const AnnenVurderingTabellRad: React.FC<IProps> = ({
     annenVurdering,
 }) => {
     const { vurderErLesevisning, åpenBehandling } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
 
     const [ekspandertAnnenVurdering, settEkspandertAnnenVurdering] = useState(
-        vurderErLesevisning() || false || annenVurdering.resultat === Resultat.IKKE_VURDERT
+        erLesevisning || false || annenVurdering.resultat === Resultat.IKKE_VURDERT
     );
     const [redigerbartAnnenVurdering, settRedigerbartAnnenVurdering] =
         useState<IAnnenVurdering>(annenVurdering);
@@ -96,7 +97,7 @@ const AnnenVurderingTabellRad: React.FC<IProps> = ({
                     <BeskrivelseCelle children={annenVurdering.begrunnelse} />
                 </td>
                 <td>
-                    {!vurderErLesevisning() && (
+                    {!erLesevisning && (
                         <Button
                             variant={'tertiary'}
                             onClick={() => toggleForm(true)}
@@ -135,7 +136,7 @@ const AnnenVurderingTabellRad: React.FC<IProps> = ({
                             annenVurderingConfig={annenVurderingConfig}
                             annenVurdering={annenVurdering}
                             toggleForm={toggleForm}
-                            lesevinsing={vurderErLesevisning()}
+                            lesevinsing={erLesevisning}
                         />
                     </EkspandertTd>
                 </tr>

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
@@ -8,6 +8,8 @@ import { Normaltekst } from 'nav-frontend-typografi';
 import { Button } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import { AnnenVurderingSkjema } from './AnnenVurderingSkjema';
+import { annenVurderingFeilmeldingId } from './AnnenVurderingTabell';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import FamilieChevron from '../../../../ikoner/FamilieChevron';
 import ManuellVurdering from '../../../../ikoner/ManuellVurdering';
@@ -15,8 +17,6 @@ import VilkårResultatIkon from '../../../../ikoner/VilkårResultatIkon';
 import type { IGrunnlagPerson } from '../../../../typer/person';
 import type { IAnnenVurderingConfig, IAnnenVurdering } from '../../../../typer/vilkår';
 import { Resultat, uiResultat } from '../../../../typer/vilkår';
-import { AnnenVurderingSkjema } from './AnnenVurderingSkjema';
-import { annenVurderingFeilmeldingId } from './AnnenVurderingTabell';
 
 interface IProps {
     person: IGrunnlagPerson;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -7,6 +7,13 @@ import { AutomaticSystem, People, Settings } from '@navikt/ds-icons';
 import { BodyShort, Table } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import { Barnehageplass } from './Vilkår/Barnehageplass/Barnehageplass';
+import { BarnetsAlder } from './Vilkår/BarnetsAlder/BarnetsAlder';
+import { BorMedSøker } from './Vilkår/BorMedSøker/BorMedSøker';
+import { BosattIRiket } from './Vilkår/BosattIRiket/BosattIRiket';
+import { Medlemskap } from './Vilkår/Medlemskap/Medlemskap';
+import { MedlemskapAnnenForelder } from './Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder';
+import { vilkårFeilmeldingId } from './VilkårTabell';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import VilkårResultatIkon from '../../../../ikoner/VilkårResultatIkon';
@@ -17,13 +24,6 @@ import { Resultat, uiResultat, VilkårType } from '../../../../typer/vilkår';
 import { datoformat, formaterIsoDato } from '../../../../utils/formatter';
 import { periodeToString } from '../../../../utils/kalender';
 import { alleRegelverk } from '../../../../utils/vilkår';
-import { Barnehageplass } from './Vilkår/Barnehageplass/Barnehageplass';
-import { BarnetsAlder } from './Vilkår/BarnetsAlder/BarnetsAlder';
-import { BorMedSøker } from './Vilkår/BorMedSøker/BorMedSøker';
-import { BosattIRiket } from './Vilkår/BosattIRiket/BosattIRiket';
-import { Medlemskap } from './Vilkår/Medlemskap/Medlemskap';
-import { MedlemskapAnnenForelder } from './Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder';
-import { vilkårFeilmeldingId } from './VilkårTabell';
 
 interface IProps {
     person: IGrunnlagPerson;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -7,13 +7,6 @@ import { AutomaticSystem, People, Settings } from '@navikt/ds-icons';
 import { BodyShort, Table } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { Barnehageplass } from './Vilkår/Barnehageplass/Barnehageplass';
-import { BarnetsAlder } from './Vilkår/BarnetsAlder/BarnetsAlder';
-import { BorMedSøker } from './Vilkår/BorMedSøker/BorMedSøker';
-import { BosattIRiket } from './Vilkår/BosattIRiket/BosattIRiket';
-import { Medlemskap } from './Vilkår/Medlemskap/Medlemskap';
-import { MedlemskapAnnenForelder } from './Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder';
-import { vilkårFeilmeldingId } from './VilkårTabell';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import VilkårResultatIkon from '../../../../ikoner/VilkårResultatIkon';
@@ -24,6 +17,13 @@ import { Resultat, uiResultat, VilkårType } from '../../../../typer/vilkår';
 import { datoformat, formaterIsoDato } from '../../../../utils/formatter';
 import { periodeToString } from '../../../../utils/kalender';
 import { alleRegelverk } from '../../../../utils/vilkår';
+import { Barnehageplass } from './Vilkår/Barnehageplass/Barnehageplass';
+import { BarnetsAlder } from './Vilkår/BarnetsAlder/BarnetsAlder';
+import { BorMedSøker } from './Vilkår/BorMedSøker/BorMedSøker';
+import { BosattIRiket } from './Vilkår/BosattIRiket/BosattIRiket';
+import { Medlemskap } from './Vilkår/Medlemskap/Medlemskap';
+import { MedlemskapAnnenForelder } from './Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder';
+import { vilkårFeilmeldingId } from './VilkårTabell';
 
 interface IProps {
     person: IGrunnlagPerson;
@@ -59,9 +59,10 @@ const FlexDiv = styled.div`
 const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårResultat }) => {
     const { toggles } = useApp();
     const { vurderErLesevisning, åpenBehandling, behandlingPåVent } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
 
     const hentInitiellEkspandering = () =>
-        vurderErLesevisning() || vilkårResultat.resultat === Resultat.IKKE_VURDERT;
+        erLesevisning || vilkårResultat.resultat === Resultat.IKKE_VURDERT;
 
     const [ekspandertVilkår, settEkspandertVilkår] = useState(hentInitiellEkspandering());
     const [redigerbartVilkår, settRedigerbartVilkår] = useState<IVilkårResultat>(vilkårResultat);
@@ -90,7 +91,7 @@ const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårR
                         vilkårFraConfig={vilkårFraConfig}
                         toggleForm={toggleForm}
                         person={person}
-                        lesevisning={vurderErLesevisning()}
+                        lesevisning={erLesevisning}
                     />
                 );
             case VilkårType.MEDLEMSKAP:
@@ -100,7 +101,7 @@ const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårR
                         vilkårFraConfig={vilkårFraConfig}
                         toggleForm={toggleForm}
                         person={person}
-                        lesevisning={vurderErLesevisning()}
+                        lesevisning={erLesevisning}
                     />
                 );
             case VilkårType.BARNEHAGEPLASS:
@@ -110,7 +111,7 @@ const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårR
                         vilkårFraConfig={vilkårFraConfig}
                         toggleForm={toggleForm}
                         person={person}
-                        lesevisning={vurderErLesevisning()}
+                        lesevisning={erLesevisning}
                     />
                 );
             case VilkårType.MEDLEMSKAP_ANNEN_FORELDER:
@@ -120,7 +121,7 @@ const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårR
                         vilkårFraConfig={vilkårFraConfig}
                         toggleForm={toggleForm}
                         person={person}
-                        lesevisning={vurderErLesevisning()}
+                        lesevisning={erLesevisning}
                     />
                 );
             case VilkårType.BOR_MED_SØKER:
@@ -130,7 +131,7 @@ const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårR
                         vilkårFraConfig={vilkårFraConfig}
                         toggleForm={toggleForm}
                         person={person}
-                        lesevisning={vurderErLesevisning()}
+                        lesevisning={erLesevisning}
                     />
                 );
             case VilkårType.BARNETS_ALDER:
@@ -140,7 +141,7 @@ const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårR
                         vilkårFraConfig={vilkårFraConfig}
                         toggleForm={toggleForm}
                         person={person}
-                        lesevisning={vurderErLesevisning()}
+                        lesevisning={erLesevisning}
                     />
                 );
             default:

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Vilkårsvurdering.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Vilkårsvurdering.tsx
@@ -13,6 +13,8 @@ import { FamilieKnapp } from '@navikt/familie-form-elements';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
+import { HentetLabel } from './Registeropplysninger/HentetLabel';
+import VilkårsvurderingSkjema from './VilkårsvurderingSkjema';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useVilkårsvurdering } from '../../../context/Vilkårsvurdering/VilkårsvurderingContext';
 import useSakOgBehandlingParams from '../../../hooks/useSakOgBehandlingParams';
@@ -21,8 +23,6 @@ import { BehandlingSteg, BehandlingÅrsak } from '../../../typer/behandling';
 import { datoformat, formaterIsoDato } from '../../../utils/formatter';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
-import { HentetLabel } from './Registeropplysninger/HentetLabel';
-import VilkårsvurderingSkjema from './VilkårsvurderingSkjema';
 
 const UregistrerteBarnListe = styled.ol`
     margin: ${NavdsSpacing2} 0;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Vilkårsvurdering.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Vilkårsvurdering.tsx
@@ -13,8 +13,6 @@ import { FamilieKnapp } from '@navikt/familie-form-elements';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
-import { HentetLabel } from './Registeropplysninger/HentetLabel';
-import VilkårsvurderingSkjema from './VilkårsvurderingSkjema';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useVilkårsvurdering } from '../../../context/Vilkårsvurdering/VilkårsvurderingContext';
 import useSakOgBehandlingParams from '../../../hooks/useSakOgBehandlingParams';
@@ -23,6 +21,8 @@ import { BehandlingSteg, BehandlingÅrsak } from '../../../typer/behandling';
 import { datoformat, formaterIsoDato } from '../../../utils/formatter';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
+import { HentetLabel } from './Registeropplysninger/HentetLabel';
+import VilkårsvurderingSkjema from './VilkårsvurderingSkjema';
 
 const UregistrerteBarnListe = styled.ol`
     margin: ${NavdsSpacing2} 0;
@@ -54,6 +54,7 @@ const Vilkårsvurdering: React.FunctionComponent<IProps> = ({ åpenBehandling })
         vilkårsvurderingNesteOnClick,
         behandlingsstegSubmitressurs,
     } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
 
     const registeropplysningerHentetTidpsunkt =
         vilkårsvurdering[0]?.person?.registerhistorikk?.hentetTidspunkt;
@@ -84,7 +85,7 @@ const Vilkårsvurdering: React.FunctionComponent<IProps> = ({ åpenBehandling })
                 navigate(`/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/registrer-soknad`);
             }}
             nesteOnClick={() => {
-                if (vurderErLesevisning()) {
+                if (erLesevisning) {
                     navigate(`/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/tilkjent-ytelse`);
                 } else if (!erFeilISkjema) {
                     vilkårsvurderingNesteOnClick();
@@ -125,7 +126,7 @@ const Vilkårsvurdering: React.FunctionComponent<IProps> = ({ åpenBehandling })
                         loading={hentOpplysningerRessurs.status === RessursStatus.HENTER}
                         variant="tertiary"
                         size="small"
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                     >
                         {hentOpplysningerRessurs.status !== RessursStatus.HENTER && (
                             <Refresh style={{ fontSize: '1.5rem' }} role="img" focusable="false" />

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -18,9 +18,6 @@ import type { FeltState } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import BarnBrevetGjelder from './BarnBrevetGjelder';
-import type { BrevtypeSelect, ISelectOptionMedBrevtekst } from './typer';
-import { Brevmal, brevmaler, leggTilValuePåOption, opplysningsdokumenter } from './typer';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import { useBrevModul } from '../../../../context/BrevModulContext';
 import useDokument from '../../../../hooks/useDokument';
@@ -37,6 +34,9 @@ import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
 import Knapperekke from '../../Knapperekke';
 import PdfVisningModal from '../../PdfVisningModal/PdfVisningModal';
 import SkjultLegend from '../../SkjultLegend';
+import BarnBrevetGjelder from './BarnBrevetGjelder';
+import { Brevmal, brevmaler, leggTilValuePåOption, opplysningsdokumenter } from './typer';
+import type { BrevtypeSelect, ISelectOptionMedBrevtekst } from './typer';
 
 interface IProps {
     onSubmitSuccess: () => void;
@@ -91,6 +91,7 @@ const StyledFamilieInput = styled(FamilieInput)`
 
 const Brevskjema = ({ onSubmitSuccess }: IProps) => {
     const { åpenBehandling, settÅpenBehandling, vurderErLesevisning, hentLogg } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
     const { hentForhåndsvisning, hentetDokument } = useDokument();
 
     const {
@@ -234,7 +235,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                             </LabelOgEtikett>
                         }
                         creatable={false}
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                         isMulti={true}
                         onChange={valgteOptions => {
                             skjema.felter.dokumenter.onChange(
@@ -249,7 +250,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                 {skjema.felter.fritekster.erSynlig && (
                     <FritekstWrapper>
                         <Label htmlFor={skjemaGruppeId}>Legg til kulepunkt</Label>
-                        {vurderErLesevisning() ? (
+                        {erLesevisning ? (
                             <StyledList id={skjemaGruppeId}>
                                 {skjema.felter.fritekster.verdi.map(
                                     (fritekst: FeltState<IFritekstFelt>) => (
@@ -328,7 +329,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                                     )}
                                 </SkjemaGruppe>
 
-                                {!erMaksAntallKulepunkter && !vurderErLesevisning() && (
+                                {!erMaksAntallKulepunkter && !erLesevisning && (
                                     <Button
                                         onClick={() => leggTilFritekst()}
                                         id={`legg-til-fritekst`}
@@ -377,7 +378,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                 )}
             </SkjemaGruppe>
             <Knapperekke>
-                {!vurderErLesevisning() && (
+                {!erLesevisning && (
                     <Button
                         id={'forhandsvis-vedtaksbrev'}
                         variant={'tertiary'}

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -18,6 +18,9 @@ import type { FeltState } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import BarnBrevetGjelder from './BarnBrevetGjelder';
+import { Brevmal, brevmaler, leggTilValuePåOption, opplysningsdokumenter } from './typer';
+import type { BrevtypeSelect, ISelectOptionMedBrevtekst } from './typer';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import { useBrevModul } from '../../../../context/BrevModulContext';
 import useDokument from '../../../../hooks/useDokument';
@@ -34,9 +37,6 @@ import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
 import Knapperekke from '../../Knapperekke';
 import PdfVisningModal from '../../PdfVisningModal/PdfVisningModal';
 import SkjultLegend from '../../SkjultLegend';
-import BarnBrevetGjelder from './BarnBrevetGjelder';
-import { Brevmal, brevmaler, leggTilValuePåOption, opplysningsdokumenter } from './typer';
-import type { BrevtypeSelect, ISelectOptionMedBrevtekst } from './typer';
 
 interface IProps {
     onSubmitSuccess: () => void;


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12298

💰 Hva forsøker du å løse i denne PR'en
Begrense kall til vurderErLesevisning() ved å opprette en lokal variabel i relevante komponent (som kaller fra mer enn 1 sted) og benytte den lokale variabelen i stedet for å kalle metoden direkte.

🔎️ Er det noe spesielt du ønsker å fremheve?
Usikker på om det i alle tilfeller er greit å benytte "lokal variabel" - som beskrevet i oppgaven - eller om det i spesielle tilfeller kan være påkrevd å kalle metoden direkte..

✅ Checklist
Har du husket alle punktene i listen?
Testet lokalt etter beste evne..

💬 Ønsker du en muntlig gjennomgang?
 Ja
 Nei
👀 Screen shots
Har det visuelle endret seg? Legg til før- og etterbilder!
Dette skal ikke medføre visuelle endringer