### PR TITLE
Nullstill avslagbegrunnelser når man ved endring på radio button

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
@@ -22,6 +22,12 @@ export const MedlemskapAnnenForelder: React.FC<MedlemskapAnnenForelderProps> = (
 }: MedlemskapAnnenForelderProps) => {
     const { felter } = useMedlemskapAnnenForelder(vilkårResultat, person);
     const vilkårSkjemaContext = useVilkårSkjema(vilkårResultat, felter, person, toggleForm);
+
+    const nullstillAvslagBegrunnelser = () => {
+        vilkårSkjemaContext.skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(false);
+        vilkårSkjemaContext.skjema.felter.avslagBegrunnelser.validerOgSettFelt([]);
+    };
+
     return (
         <VilkårSkjema
             vilkårSkjemaContext={vilkårSkjemaContext}
@@ -58,6 +64,7 @@ export const MedlemskapAnnenForelder: React.FC<MedlemskapAnnenForelderProps> = (
                         vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
                             Resultat.OPPFYLT
                         );
+                        nullstillAvslagBegrunnelser();
                     }}
                 />
                 <Radio
@@ -82,6 +89,7 @@ export const MedlemskapAnnenForelder: React.FC<MedlemskapAnnenForelderProps> = (
                         vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
                             Resultat.IKKE_AKTUELT
                         );
+                        nullstillAvslagBegrunnelser();
                     }}
                 />
             </FamilieRadioGruppe>

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
@@ -174,9 +174,15 @@ export const VilkårSkjema = <T extends IVilkårSkjemaContext>({
                             label={'Ja'}
                             name={`${vilkårResultat.vilkårType}_${vilkårResultat.id}`}
                             checked={skjema.felter.resultat.verdi === Resultat.OPPFYLT}
-                            onChange={() =>
-                                skjema.felter.resultat.validerOgSettFelt(Resultat.OPPFYLT)
-                            }
+                            onChange={() => {
+                                skjema.felter.resultat.validerOgSettFelt(Resultat.OPPFYLT);
+                                vilkårSkjemaContext.skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
+                                    false
+                                );
+                                vilkårSkjemaContext.skjema.felter.avslagBegrunnelser.validerOgSettFelt(
+                                    []
+                                );
+                            }}
                         />
                         <Radio
                             label={'Nei'}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=NAV-12425

Da vilkårsvurderings-koden ble refaktorert ved overskriving til kontantstøtte så glemte vi denne logikken.
Vi må nullstille avslagstekster som tidligere er valgt når man bytter radio button til ja/ikke_aktuelt.
Ellers blir disse fortsatt sendt til backend, og det oppstår feil på vedtak siden.