### PR TITLE
Vi refresher siden når vi tar gjenopptar behandlingen

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -17,7 +17,7 @@ const Environment = () => {
         return {
             buildPath: 'frontend_development',
             namespace: 'local',
-            proxyUrl: 'https://familie-kontantstotte-sak.intern.dev.nav.no',
+            proxyUrl: 'http://localhost:8083',
             familieTilbakeUrl: 'https://familie-tilbake.intern.dev.nav.no',
             familieKlageUrl: 'https://familie-klage.intern.dev.nav.no',
             endringsloggProxyUrl: 'https://familie-endringslogg.intern.dev.nav.no',

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/TaBehandlingAvVent.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/TaBehandlingAvVent.tsx
@@ -13,7 +13,6 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
-import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
 import type { IBehandling } from '../../../../../typer/behandling';
 import { settPåVentÅrsaker } from '../../../../../typer/behandling';
 import { defaultFunksjonellFeil } from '../../../../../typer/feilmeldinger';
@@ -33,7 +32,6 @@ interface IProps {
 
 const TaBehandlingAvVent: React.FC<IProps> = ({ behandling }) => {
     const { request } = useHttp();
-    const { settÅpenBehandling } = useBehandling();
 
     const [visModal, settVisModal] = useState<boolean>(false);
     const [submitRessurs, settSubmitRessurs] = useState(byggTomRessurs());
@@ -50,9 +48,8 @@ const TaBehandlingAvVent: React.FC<IProps> = ({ behandling }) => {
             url: `/familie-ks-sak/api/behandlinger/${behandling.behandlingId}/sett-på-vent/gjenoppta`,
         })
             .then((ressurs: Ressurs<IBehandling>) => {
-                settÅpenBehandling(ressurs, true);
                 settSubmitRessurs(ressurs);
-                lukkModal();
+                window.location.reload();
             })
             .catch(() => {
                 settSubmitRessurs(byggFeiletRessurs(defaultFunksjonellFeil));


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=NAV-13238

Bug som har eksistert i barnetrygd lenge, men siden flyten til kontantstøtte saksbehandlere er litt annerledes, så merker det dette oftere.

Buggen oppstår fordi man ikke tar et kall til api/person ved gjenopprettelse av behandlingen.
Siden man tidligere har vært i lesevisning, så har dette heller ikke blitt gjort.

Før:
https://github.com/navikt/familie-ks-sak-frontend/assets/110383605/5e81b2ea-b926-4f38-8185-a7ca15977305


Etter:
https://github.com/navikt/familie-ks-sak-frontend/assets/110383605/39d32a82-2f69-48ad-a9b7-46f2ecc0ec29

Trenger litt innspill på løsningen.
Raskeste måten å få dette på plass er jo å bare refreshe siden ved gjenopprettelse, og det koster ikke så mye tid.
Med mine begrensende frontend kunnskaper så er jeg litt usikker på om det er verdt å investere tiden i å gjøre det på en annen måte?