### PR TITLE
Hent node-express fra ghcr navikt/baseimage i stedet for dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/node-express:16
+FROM ghcr.io/navikt/baseimages/node-express:16-alpine
 USER root
 RUN apk --no-cache add curl
 USER apprunner


### PR DESCRIPTION
Bytter til å bruke node fra navikt/baseimage fra ghcr i stedet for dockerhub.