### PR TITLE
NAV-14677 - oppdatert default sortering til kommuneNavn 

### DIFF
--- a/src/frontend/context/BarnehagebarnContext.tsx
+++ b/src/frontend/context/BarnehagebarnContext.tsx
@@ -31,7 +31,7 @@ const defaultBarnehagebarnRequestParams: IBarnehagebarnRequestParams = {
     kunLøpendeFagsak: false,
     limit: 20,
     offset: 0,
-    sortBy: 'endretTidspunkt',
+    sortBy: 'kommuneNavn',
     sortAsc: false,
 };
 

--- a/src/frontend/typer/barnehagebarn.ts
+++ b/src/frontend/typer/barnehagebarn.ts
@@ -21,11 +21,6 @@ export interface IBarnehagebarn {
     endringstype: string;
     kommuneNavn: string;
     kommuneNr: string;
-    versjon: number;
-    opprettetAv: string;
-    opprettetTidspunkt: string;
-    endretAv: string;
-    endretTidspunkt: string;
     fagsakId: number;
     behandlingId: number;
     fagsakstatus: string;


### PR DESCRIPTION
…er i IBarnehagebarn inteface fra "baseEntitet": versjon,opprettetAv,opprettetTidspunkt,endretAv,endretTidspunkt)

### 💰 Hva forsøker du å løse i denne PR'en
* Fjernet baseEintitet verdier fra IBarnehagebarn
* Endret default sortering til kommuneNavn

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Testet lokalt

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

