### PR TITLE
NAV-14677 - Fjernet bannehagbarn.id fra IBarnehagebarn

### DIFF
--- a/src/frontend/typer/barnehagebarn.ts
+++ b/src/frontend/typer/barnehagebarn.ts
@@ -13,7 +13,6 @@ export interface IBarnehagebarnRequestParams {
     sortAsc: boolean;
 }
 export interface IBarnehagebarn {
-    id: string;
     ident: string;
     fom: string;
     tom?: string;


### PR DESCRIPTION
(https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14677)


### 💰 Hva forsøker du å løse i denne PR'en

Fjernet barnehagbarn.id fra IBarnehagebarn da den er fjernet fra backend for at DISTINCT skal fungere som tiltenkt

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei
