### PR TITLE
NAV-16269 Øker z-index på multiselect for "Velg standardtekst i brev"…

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -68,6 +68,7 @@ const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype }) => {
                 container: provided => ({
                     ...provided,
                     maxWidth: '50rem',
+                    zIndex: 2,
                 }),
                 groupHeading: provided => ({
                     ...provided,


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16269

### 💰 Hva forsøker du å løse i denne PR'en
Øker z-index på multiselect for "Velg standardtekst i brev" så ikke komponent under sin onPanelClose trigges av at man velger første element som ovelapper med panel-knappen under.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Empirisk testet.


### 🤷‍♀ ️Hvor er det lurt å starte?
All i ett (mini-endring på z-index)

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei

### 👀 Screen shots
Se Favro kort
