### PR TITLE
NAV-16269 Fiks for vedtaksbegrunnelse-multiselect-zindex

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -4,6 +4,7 @@ import type { GroupBase } from 'react-select';
 import styled from 'styled-components';
 
 import { BodyShort, Label } from '@navikt/ds-react';
+import { AZIndexPopover } from '@navikt/ds-tokens/dist/tokens';
 import type {
     ActionMeta,
     FormatOptionLabelMeta,
@@ -65,10 +66,10 @@ const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype }) => {
             id={`${id}`}
             value={begrunnelser}
             propSelectStyles={{
-                container: provided => ({
+                container: (provided, props) => ({
                     ...provided,
                     maxWidth: '50rem',
-                    zIndex: 2,
+                    zIndex: props.isFocused ? AZIndexPopover : 1,
                 }),
                 groupHeading: provided => ({
                     ...provided,


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16269

### 💰 Hva forsøker du å løse i denne PR'en
Etter siste fiks hadde fortsatt multiselect for "Velg standardtekst i brev" en z-index som tilsier at selve select kommer over options listen når de overlapper. Det er nå endret til dynamisk z-index avhengig av om select har focus (ref: ba-sak-frontend)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei

### 👀 Screen shots
Screen-shots i favro-kortet
