### PR TITLE
NAV-14677 Har fjernet barnehageliste unleash toggle

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/HeaderMedSøk.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 import { Header } from '@navikt/familie-header';
 
 import FagsakDeltagerSøk from './FagsakDeltagerSøk';
-import { useApp } from '../../../context/AppContext';
-import { ToggleNavn } from '../../../typer/toggles';
 
 export interface IHeaderMedSøkProps {
     brukerNavn?: string;
@@ -15,8 +13,6 @@ export const HeaderMedSøk: React.FunctionComponent<IHeaderMedSøkProps> = ({
     brukerNavn,
     brukerEnhet,
 }) => {
-    const { toggles } = useApp();
-
     const genererEksterneLenker = () => {
         const eksterneLenker = [
             {
@@ -25,14 +21,12 @@ export const HeaderMedSøk: React.FunctionComponent<IHeaderMedSøkProps> = ({
                 isExternal: true,
             },
         ];
+        eksterneLenker.push({
+            name: 'Barnehagelister',
+            href: `/barnehagelister`,
+            isExternal: false,
+        });
 
-        if (toggles[ToggleNavn.barnehagelister]) {
-            eksterneLenker.push({
-                name: 'Barnehagelister',
-                href: `/barnehagelister`,
-                isExternal: false,
-            });
-        }
         return eksterneLenker;
     };
 

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -11,7 +11,6 @@ export enum ToggleNavn {
     kanBehandleEøsSekunderland = 'familie-ks-sak.behandling.eos-sekunderland',
     kanBehandleEøsToPrimerland = 'familie-ks-sak.behandling.eos-to-primerland',
     kanBehandleKlage = 'familie-ks-sak.klage',
-    barnehagelister = 'familie-ks-sak.barnehagelister',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
Har fjernet barnehageliste unleash toggle (familie-ks-sak.barnehagelister) som tidligere skjulte lenke til barnehagelister i meny. 
Etter at backend ble oppgradert til unleash-next ble ikke denne med - og nå kan den like gjerne fjernes for godt.

### 💰 Hva forsøker du å løse i denne PR'en
At barnehagelister-lenken ikke ble vist lenger
Ref: https://nav-it.slack.com/archives/C01G9BA8JKZ/p1699893182838159

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Unleash toggle "familie-ks-sak.barnehagelister" fra gammel unleash er slettet fra koden og vil ikke videreføres i unleash-next.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


_Jeg har ikke skrevet tester fordi:_
Det krever ingen tester for verifisere at barnehagelister-lenken nå er synlig

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
![før](https://github.com/navikt/familie-ks-sak-frontend/assets/126786453/54292bac-c569-4744-8b6f-7f43cd9ab890)
![etter](https://github.com/navikt/familie-ks-sak-frontend/assets/126786453/23e2ed0e-005d-481d-91f2-ec9bf8aecb3e)
