### PR TITLE
Feilutbetalt valuta på KS skal alltid vises uavhengig av årsak (men det må fortsatt være EØS)

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/Vedtaksmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/Vedtaksmeny.tsx
@@ -11,7 +11,6 @@ import KorrigerVedtak from './KorrigerVedtakModal/KorrigerVedtak';
 import EndreEndringstidspunkt from './VedtakBegrunnelserTabell/EndreEndringstidspunkt';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import type { IBehandling } from '../../../typer/behandling';
-import { BehandlingÅrsak } from '../../../typer/behandling';
 import { BehandlingKategori } from '../../../typer/behandlingstema';
 
 interface IVedtakmenyProps {
@@ -60,13 +59,12 @@ const Vedtaksmeny: React.FunctionComponent<IVedtakmenyProps> = ({
                     {åpenBehandling.endringstidspunkt && (
                         <EndreEndringstidspunkt åpenBehandling={åpenBehandling} />
                     )}
-                    {åpenBehandling.årsak === BehandlingÅrsak.ÅRLIG_KONTROLL &&
-                        åpenBehandling.kategori === BehandlingKategori.EØS && (
-                            <Dropdown.Menu.List.Item onClick={visFeilutbetaltValuta}>
-                                <Calculator />
-                                Legg til feilutbetalt valuta
-                            </Dropdown.Menu.List.Item>
-                        )}
+                    {åpenBehandling.kategori === BehandlingKategori.EØS && (
+                        <Dropdown.Menu.List.Item onClick={visFeilutbetaltValuta}>
+                            <Calculator />
+                            Legg til feilutbetalt valuta
+                        </Dropdown.Menu.List.Item>
+                    )}
                 </Dropdown.Menu.List>
             </StyledDropdownMeny>
         </Dropdown>


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17034
Vi ønsker å kunne velge feilutbetalt valuta uavhengig om det er årlig kontroll eller ikke.

