### PR TITLE
Lagre sortering oppgavebenk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ cypress/videos
 cypress/screenshots
 cypress.env.json
 .eslintcache
+node_dist
 

--- a/src/frontend/context/OppgaverContext.tsx
+++ b/src/frontend/context/OppgaverContext.tsx
@@ -42,6 +42,7 @@ import { erIsoStringGyldig } from '../utils/kalender';
 import { hentFnrFraOppgaveIdenter } from '../utils/oppgave';
 import { hentFrontendFeilmelding } from '../utils/ressursUtils';
 
+const OPPGAVEBENK_SORTERINGSNØKKEL = 'OPPGAVEBENK_SORTERINGSNØKKEL';
 export const oppgaveSideLimit = 15;
 
 export const maksAntallOppgaver = 150;
@@ -67,6 +68,8 @@ const [OppgaverProvider, useOppgaver] = createUseContext(() => {
             : [];
     }, [oppgaver]);
 
+    const lagretSortering = localStorage.getItem(OPPGAVEBENK_SORTERINGSNØKKEL);
+
     const tableInstance: TableInstance<IOppgaveRad> &
         UseSortByInstanceProps<IOppgaveRad> &
         UsePaginationInstanceProps<IOppgaveRad> = useTable<IOppgaveRad>(
@@ -76,11 +79,21 @@ const [OppgaverProvider, useOppgaver] = createUseContext(() => {
             initialState: {
                 pageSize: oppgaveSideLimit,
                 pageIndex: 0,
+                sortBy: lagretSortering
+                    ? JSON.parse(lagretSortering)
+                    : [{ id: 'opprettetTidspunkt', desc: false }],
             },
         },
         useSortBy,
         usePagination
     );
+
+    useEffect(() => {
+        localStorage.setItem(
+            OPPGAVEBENK_SORTERINGSNØKKEL,
+            JSON.stringify(tableInstance.state.sortBy)
+        );
+    }, [tableInstance.state.sortBy]);
 
     useEffect(() => {
         settOppgaveFelter(initialOppgaveFelter(innloggetSaksbehandler));


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17106)

Det er et ønske fra saksbehandlerene at vi lagrer sortering og filtrering de gjør i oppgavebenken mellom sessjoner. Filtreringen lagres allerede.

Legger til lagring av sortering i oppgavebenken i localstorage. 
