### PR TITLE
Vis informasjonstekstene kun når vilkåret vurderes etter EØS-forordningen

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Medlemskap/Medlemskap.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Medlemskap/Medlemskap.tsx
@@ -52,11 +52,15 @@ export const Medlemskap: React.FC<MedlemskapProps> = ({
         >
             <br />
 
-            <StyledAlert variant="info" inline>
-                Du må vurdere dette vilkåret når søker er omfattet av norsk lovgivning
-            </StyledAlert>
-
-            <br />
+            {vilkårSkjemaContext.skjema.felter.vurderesEtter.verdi ===
+                Regelverk.EØS_FORORDNINGEN && (
+                <>
+                    <StyledAlert variant="info" inline>
+                        Du må vurdere dette vilkåret når søker er omfattet av norsk lovgivning
+                    </StyledAlert>
+                    <br />
+                </>
+            )}
 
             <FamilieRadioGruppe
                 legend={

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
@@ -8,7 +8,7 @@ import { Alert, Label } from '@navikt/ds-react';
 import { FamilieRadioGruppe } from '@navikt/familie-form-elements';
 
 import { useMedlemskapAnnenForelder } from './MedlemskapAnnenForelderContext';
-import { Resultat, resultater } from '../../../../../../typer/vilkår';
+import { Regelverk, Resultat, resultater } from '../../../../../../typer/vilkår';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
@@ -47,12 +47,16 @@ export const MedlemskapAnnenForelder: React.FC<MedlemskapAnnenForelderProps> = (
         >
             <br />
 
-            <StyledAlert variant="info" inline>
-                Du må vurdere dette vilkåret når den andre forelderen er omfattet av norsk
-                lovgivning og søker har selvstendig rett
-            </StyledAlert>
-
-            <br />
+            {vilkårSkjemaContext.skjema.felter.vurderesEtter.verdi ===
+                Regelverk.EØS_FORORDNINGEN && (
+                <>
+                    <StyledAlert variant="info" inline>
+                        Du må vurdere dette vilkåret når den andre forelderen er omfattet av norsk
+                        lovgivning og søker har selvstendig rett
+                    </StyledAlert>
+                    <br />
+                </>
+            )}
 
             <FamilieRadioGruppe
                 legend={


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
NAV-16970
Fikser kommentar fra Birgitte:
Det er et ønske at informasjonstekstene på begge vilkårene kun kommer når vilkåret vurderes etter "EØS-forordningen".


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] 
### 👀 Screen shots
![Screenshot 2023-11-20 at 15 28 16](https://github.com/navikt/familie-ks-sak-frontend/assets/1121978/0831e0fb-0649-4e2d-80ad-ff6b6861411a)
![Screenshot 2023-11-20 at 15 28 08](https://github.com/navikt/familie-ks-sak-frontend/assets/1121978/8fe10511-6bdd-4101-922e-edd4a2343dc2)
