### PR TITLE
Chore: flere datovelger oppgraderinger

### DIFF
--- a/src/frontend/context/KorrigerVedtak/KorrigerVedtakSkjemaContext.ts
+++ b/src/frontend/context/KorrigerVedtak/KorrigerVedtakSkjemaContext.ts
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
 
-import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
+import { ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { FeltState } from '@navikt/familie-skjema';
 import { byggHenterRessurs, RessursStatus } from '@navikt/familie-typer';
 import type { Ressurs } from '@navikt/familie-typer';
 
 import type { IBehandling } from '../../typer/behandling';
 import type { IRestKorrigertVedtak } from '../../typer/vedtak';
-import { isEmpty } from '../../utils/eøsValidators';
+import { dateTilIsoDatoString, validerGyldigDato } from '../../utils/dato';
 import { useBehandling } from '../behandlingContext/BehandlingContext';
 
 interface IProps {
@@ -15,9 +15,6 @@ interface IProps {
     behandlingId: number;
     korrigertVedtak?: IRestKorrigertVedtak;
 }
-
-const erVedtaksdatoGyldig = (felt: FeltState<string | undefined>): FeltState<string | undefined> =>
-    !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Dato for vedtaket med feil er påkrevd');
 
 export const useKorrigerVedtakSkjemaContext = ({
     behandlingId,
@@ -35,18 +32,17 @@ export const useKorrigerVedtakSkjemaContext = ({
         onSubmit,
         nullstillSkjema,
         settSubmitRessurs,
-        validerAlleSynligeFelter,
     } = useSkjema<
         {
-            vedtaksdato: string | undefined;
+            vedtaksdato: Date | undefined;
             begrunnelse: string;
         },
         IBehandling
     >({
         felter: {
-            vedtaksdato: useFelt<string | undefined>({
-                verdi: korrigertVedtak?.vedtaksdato,
-                valideringsfunksjon: erVedtaksdatoGyldig,
+            vedtaksdato: useFelt<Date | undefined>({
+                verdi: undefined,
+                valideringsfunksjon: validerGyldigDato,
             }),
             begrunnelse: useFelt<string>({
                 verdi: korrigertVedtak?.begrunnelse || '',
@@ -57,23 +53,11 @@ export const useKorrigerVedtakSkjemaContext = ({
     });
 
     useEffect(() => {
-        nullstillSkjema();
-    }, [korrigertVedtak?.vedtaksdato, korrigertVedtak?.begrunnelse]);
-
-    const valideringsstatuser = [
-        skjema.felter.vedtaksdato.valideringsstatus,
-        skjema.felter.begrunnelse.valideringsstatus,
-    ];
-
-    useEffect(() => {
-        if (
-            valideringsstatuser.some(
-                valideringsstatus => valideringsstatus === Valideringsstatus.IKKE_VALIDERT
-            )
-        ) {
-            validerAlleSynligeFelter();
-        }
-    }, [valideringsstatuser]);
+        const opprinneligVedtaksdato = korrigertVedtak
+            ? new Date(korrigertVedtak.vedtaksdato)
+            : undefined;
+        skjema.felter.vedtaksdato.validerOgSettFelt(opprinneligVedtaksdato);
+    }, []);
 
     const korrigertVedtakURL = `/familie-ks-sak/api/korrigertvedtak/behandling/${behandlingId}`;
 
@@ -81,11 +65,11 @@ export const useKorrigerVedtakSkjemaContext = ({
         if (kanSendeSkjema()) {
             settVisfeilmeldinger(false);
             settSubmitRessurs(byggHenterRessurs());
-            onSubmit(
+            onSubmit<IRestKorrigertVedtak>(
                 {
                     method: 'POST',
                     data: {
-                        vedtaksdato: skjema.felter.vedtaksdato.verdi,
+                        vedtaksdato: dateTilIsoDatoString(skjema.felter.vedtaksdato.verdi),
                         begrunnelse: skjema.felter.begrunnelse.verdi,
                     },
                     url: korrigertVedtakURL,

--- a/src/frontend/komponenter/Fagsak/Søknad/LeggTilUregistrertBarn.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/LeggTilUregistrertBarn.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import styled from 'styled-components';
 
-import { BodyShort, Checkbox, Label } from '@navikt/ds-react';
-import { FamilieInput } from '@navikt/familie-form-elements';
+import { BodyShort, Checkbox, Label, TextField } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
 
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
@@ -66,7 +65,7 @@ const LeggTilUregistrertBarn: React.FC<IProps> = ({ registrerBarnSkjema }) => {
                             visFeilmeldinger={registrerBarnSkjema.visFeilmeldinger}
                             kanKunVelgeFortid
                         />
-                        <FamilieInput
+                        <TextField
                             {...registrerBarnSkjema.felter.uregistrertBarnNavn.hentNavInputProps(
                                 registrerBarnSkjema.visFeilmeldinger
                             )}

--- a/src/frontend/komponenter/Fagsak/Søknad/LeggTilUregistrertBarn.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/LeggTilUregistrertBarn.tsx
@@ -4,12 +4,12 @@ import classNames from 'classnames';
 import styled from 'styled-components';
 
 import { BodyShort, Checkbox, Label } from '@navikt/ds-react';
-import { FamilieDatovelger } from '@navikt/familie-datovelger';
 import { FamilieInput } from '@navikt/familie-form-elements';
 import type { ISkjema } from '@navikt/familie-skjema';
 
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import type { IPersonInfo } from '../../../typer/person';
+import Datovelger from '../../Felleskomponenter/Datovelger/Datovelger';
 import type { IRegistrerBarnSkjema } from '../../Felleskomponenter/LeggTilBarn';
 
 interface IProps {
@@ -22,10 +22,9 @@ const Container = styled.div`
 
 const UregistrertBarnInputs = styled.div`
     margin: 1rem 0 1rem 1rem;
-`;
-
-const StyledFamilieDatovelger = styled(FamilieDatovelger)`
-    margin: 1rem 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 `;
 
 const LeggTilUregistrertBarn: React.FC<IProps> = ({ registrerBarnSkjema }) => {
@@ -60,13 +59,12 @@ const LeggTilUregistrertBarn: React.FC<IProps> = ({ registrerBarnSkjema }) => {
                 registrerBarnSkjema.felter.uregistrertBarnNavn.erSynlig && (
                     <UregistrertBarnInputs>
                         <Label>Tilgjengelige opplysninger om barnet</Label>
-                        <StyledFamilieDatovelger
-                            {...registrerBarnSkjema.felter.uregistrertBarnFødselsdato.hentNavInputProps(
-                                registrerBarnSkjema.visFeilmeldinger
-                            )}
-                            value={registrerBarnSkjema.felter.uregistrertBarnFødselsdato.verdi}
+                        <Datovelger
+                            felt={registrerBarnSkjema.felter.uregistrertBarnFødselsdato}
                             label={'Fødselsdato (valgfri)'}
-                            placeholder={'DD.MM.ÅÅÅÅ'}
+                            datoMåFyllesUt={false}
+                            visFeilmeldinger={registrerBarnSkjema.visFeilmeldinger}
+                            kanKunVelgeFortid
                         />
                         <FamilieInput
                             {...registrerBarnSkjema.felter.uregistrertBarnNavn.hentNavInputProps(

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
@@ -34,31 +34,30 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
     behandlingId,
 }) => {
     const [erRadEkspandert, settErRadEkspandert] = useState<boolean>(false);
-    const [forrigeFeilutbetaltValuta, settForrigeFeilutbetaltValuta] = useState(feilutbetaltValuta);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const { skjema, oppdaterEksisterendePeriode, nullstillSkjema, fjernPeriode, valideringErOk } =
-        useFeilutbetaltValuta({
-            behandlingId: behandlingId,
-            feilutbetaltValuta,
-            settFeilmelding: settFeilmelding,
-        });
+    const {
+        skjema,
+        oppdaterEksisterendePeriode,
+        fjernPeriode,
+        valideringErOk,
+        tilbakestillSkjemafelterTilDefault,
+    } = useFeilutbetaltValuta({
+        behandlingId,
+        feilutbetaltValuta,
+        settFeilmelding,
+    });
 
-    const nullstillOgLukkSkjema = () => {
-        nullstillSkjema();
+    const tilbakestillOgLukkSkjema = () => {
         settErRadEkspandert(false);
+        tilbakestillSkjemafelterTilDefault();
     };
-
-    if (feilutbetaltValuta !== forrigeFeilutbetaltValuta) {
-        nullstillOgLukkSkjema();
-        settForrigeFeilutbetaltValuta(feilutbetaltValuta);
-    }
 
     const håndterLukkingOgÅpningAvPanel = () => {
         if (erLesevisning) return;
 
         if (erRadEkspandert) {
-            nullstillOgLukkSkjema();
+            tilbakestillOgLukkSkjema();
         } else {
             settErRadEkspandert(true);
         }
@@ -70,7 +69,12 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
             onOpenChange={håndterLukkingOgÅpningAvPanel}
             content={
                 <FlexColumnDiv>
-                    <FeilutbetaltValutaSkjema skjema={skjema} />
+                    <FeilutbetaltValutaSkjema
+                        skjema={skjema}
+                        key={`${feilutbetaltValuta.id}-$${
+                            erRadEkspandert ? 'ekspandert' : 'lukket'
+                        }`}
+                    />
                     <FlexRowDiv>
                         <Button
                             size="small"
@@ -79,7 +83,7 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
                         >
                             Lagre periode
                         </Button>
-                        <Button size="small" variant="tertiary" onClick={nullstillOgLukkSkjema}>
+                        <Button size="small" variant="tertiary" onClick={tilbakestillOgLukkSkjema}>
                             Avbryt
                         </Button>
                     </FlexRowDiv>

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Label } from '@navikt/ds-react';
-import { FamilieInput } from '@navikt/familie-form-elements';
+import { Label, TextField } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
 
 import type { IBehandling } from '../../../../typer/behandling';
@@ -24,7 +23,7 @@ const FlexRowDiv = styled.div`
     display: flex;
 `;
 
-const StyledFamilieInput = styled(FamilieInput)`
+const StyledTextField = styled(TextField)`
     width: 7.5rem;
     .navds-label {
         width: 18rem;
@@ -58,7 +57,7 @@ const FeilutbetaltValutaSkjema: React.FunctionComponent<IFeilutbetaltValutaSkjem
                 />
             </FlexRowDiv>
         </FlexDatoInputWrapper>
-        <StyledFamilieInput
+        <StyledTextField
             {...skjema.felter.feilutbetaltBeløp.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
             size="small"
             label="Feilutbetalt beløp"

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
@@ -3,21 +3,12 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Label } from '@navikt/ds-react';
-import type { ISODateString } from '@navikt/familie-datovelger';
-import { FamilieDatovelger } from '@navikt/familie-datovelger';
 import { FamilieInput } from '@navikt/familie-form-elements';
 import type { ISkjema } from '@navikt/familie-skjema';
 
 import type { IBehandling } from '../../../../typer/behandling';
 import type { IFeilutbetaltValutaSkjemaFelter } from '../../../../typer/eøs-feilutbetalt-valuta';
-import type { FamilieIsoDate } from '../../../../utils/kalender';
-import {
-    erIsoStringGyldig,
-    FamilieIsoTilFørsteDagIMåneden,
-    FamilieIsoTilSisteDagIMåneden,
-    serializeIso8601String,
-    sisteDagIInneværendeMåned,
-} from '../../../../utils/kalender';
+import Månedvelger, { DagIMåneden } from '../../../Felleskomponenter/Datovelger/Månedvelger';
 
 interface IFeilutbetaltValutaSkjemaProps {
     skjema: ISkjema<IFeilutbetaltValutaSkjemaFelter, IBehandling>;
@@ -43,15 +34,6 @@ const StyledFamilieInput = styled(FamilieInput)`
     }
 `;
 
-const gjørOmDatoHvisGyldigInput = (
-    dato: string | undefined,
-    omgjøringsfunksjon: (dato: FamilieIsoDate) => FamilieIsoDate
-): string => {
-    if (dato === undefined) return '';
-    if (erIsoStringGyldig(dato)) return omgjøringsfunksjon(dato);
-    else return dato;
-};
-
 const FeilutbetaltValutaSkjema: React.FunctionComponent<IFeilutbetaltValutaSkjemaProps> = ({
     skjema,
 }) => (
@@ -59,33 +41,20 @@ const FeilutbetaltValutaSkjema: React.FunctionComponent<IFeilutbetaltValutaSkjem
         <FlexDatoInputWrapper>
             <Label size="small">Angi periode med feilutbetalt valuta</Label>
             <FlexRowDiv style={{ gap: '2rem' }}>
-                <FamilieDatovelger
-                    {...skjema.felter.fom?.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    id="fom-dato"
+                <Månedvelger
                     label="F.o.m"
-                    value={skjema.felter.fom.verdi}
-                    onChange={(dato?: ISODateString) => {
-                        skjema.felter.fom?.validerOgSettFelt(
-                            gjørOmDatoHvisGyldigInput(dato, FamilieIsoTilFørsteDagIMåneden)
-                        );
-                    }}
-                    limitations={{
-                        maxDate: serializeIso8601String(sisteDagIInneværendeMåned()),
-                    }}
+                    felt={skjema.felter.fom}
+                    visFeilmeldinger={skjema.visFeilmeldinger}
+                    dagIMåneden={DagIMåneden.FØRSTE_DAG}
+                    kanKunVelgeFortid
                 />
-                <FamilieDatovelger
-                    {...skjema.felter.tom?.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    id="fom-dato"
+                <Månedvelger
+                    felt={skjema.felter.tom}
                     label="T.o.m"
-                    value={skjema.felter.tom.verdi}
-                    onChange={(dato?: ISODateString) =>
-                        skjema.felter.tom?.validerOgSettFelt(
-                            gjørOmDatoHvisGyldigInput(dato, FamilieIsoTilSisteDagIMåneden)
-                        )
-                    }
-                    limitations={{
-                        maxDate: serializeIso8601String(sisteDagIInneværendeMåned()),
-                    }}
+                    visFeilmeldinger={skjema.visFeilmeldinger}
+                    dagIMåneden={DagIMåneden.SISTE_DAG}
+                    tilhørendeFomFelt={skjema.felter.fom}
+                    kanKunVelgeFortid
                 />
             </FlexRowDiv>
         </FlexDatoInputWrapper>

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaUtil.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaUtil.tsx
@@ -1,58 +1,7 @@
 import type { FeltState } from '@navikt/familie-skjema';
 import { feil, ok } from '@navikt/familie-skjema';
 
-import type { FamilieIsoDate } from '../../../../utils/kalender';
-import {
-    erFør,
-    erIsoStringGyldig,
-    kalenderDato,
-    kalenderDatoMedFallback,
-    sisteDagIInneværendeMåned,
-    TIDENES_ENDE,
-    TIDENES_MORGEN,
-} from '../../../../utils/kalender';
 import { erPositivtHeltall } from '../../../../utils/validators';
-
-const datoErFremITid = (dato: FamilieIsoDate): boolean => {
-    const nå = sisteDagIInneværendeMåned();
-
-    return erFør(nå, kalenderDato(dato));
-};
-
-export const validerFom = (felt: FeltState<FamilieIsoDate>) => {
-    const fom = felt.verdi;
-
-    if (fom === '') return feil(felt, 'Du må velge en f.o.m-dato');
-    if (!erIsoStringGyldig(fom)) {
-        return feil(felt, 'Du må velge en gyldig f.o.m-dato');
-    }
-    if (datoErFremITid(fom)) {
-        return feil(felt, 'F.o.m kan ikke være senere enn inneværende måned');
-    }
-    return ok(felt);
-};
-
-export const validerTom = (felt: FeltState<FamilieIsoDate>, fom: FamilieIsoDate) => {
-    const tom = felt.verdi;
-
-    if (tom === '') return feil(felt, 'Du må velge en t.o.m-dato');
-    if (!erIsoStringGyldig(tom)) {
-        return feil(felt, 'Du må velge en gyldig t.o.m-dato');
-    }
-    if (datoErFremITid(tom)) {
-        return feil(felt, 'T.o.m. kan ikke være senere enn inneværende måned');
-    }
-
-    const fomKalenderDato = kalenderDatoMedFallback(fom, TIDENES_MORGEN);
-    const tomKalenderDato = kalenderDatoMedFallback(tom, TIDENES_ENDE);
-    const fomDatoErFørTomDato = erFør(fomKalenderDato, tomKalenderDato);
-
-    if (!fomDatoErFørTomDato) {
-        return feil(felt, 'T.o.m. må være senere enn f.o.m');
-    }
-
-    return ok(felt);
-};
 
 export const validerFeilutbetaltBeløp = (felt: FeltState<string>) => {
     if (felt.verdi === '') {

--- a/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
@@ -5,14 +5,12 @@ import styled, { css } from 'styled-components';
 import { Cancel, Warning } from '@navikt/ds-icons';
 import { Alert, BodyLong, Button, Modal } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
-import { FamilieDatovelger } from '@navikt/familie-datovelger';
-import type { ISODateString } from '@navikt/familie-datovelger';
 import { FamilieTextarea } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useKorrigerVedtakSkjemaContext } from '../../../../context/KorrigerVedtak/KorrigerVedtakSkjemaContext';
 import type { IRestKorrigertVedtak } from '../../../../typer/vedtak';
-import { datoformatNorsk } from '../../../../utils/formatter';
+import Datovelger from '../../../Felleskomponenter/Datovelger/Datovelger';
 
 const AngreKnapp = styled(Button)`
     margin: 0.5rem 0;
@@ -20,10 +18,6 @@ const AngreKnapp = styled(Button)`
 
 const baseSkjemaelementStyle = css`
     margin-bottom: 1.5rem;
-`;
-
-const StyledFamilieDatovelger = styled(FamilieDatovelger)`
-    ${baseSkjemaelementStyle}
 `;
 
 const StyledFamilieTextarea = styled(FamilieTextarea)`
@@ -43,25 +37,14 @@ const KorrigerVedtak: React.FC<IKorrigerVedtak> = ({
 }) => {
     const [visModal, settVisModal] = React.useState<boolean>(false);
 
-    const {
-        skjema,
-        valideringErOk,
-        lagreKorrigertVedtak,
-        nullstillSkjema,
-        angreKorrigering,
-        settVisfeilmeldinger,
-        settRestFeil,
-        restFeil,
-    } = useKorrigerVedtakSkjemaContext({
-        onSuccess: () => settVisModal(false),
-        korrigertVedtak,
-        behandlingId,
-    });
+    const { skjema, valideringErOk, lagreKorrigertVedtak, angreKorrigering, restFeil } =
+        useKorrigerVedtakSkjemaContext({
+            onSuccess: () => settVisModal(false),
+            korrigertVedtak,
+            behandlingId,
+        });
 
     const lukkModal = () => {
-        nullstillSkjema();
-        settVisfeilmeldinger(false);
-        settRestFeil(undefined);
         settVisModal(false);
     };
 
@@ -97,22 +80,12 @@ const KorrigerVedtak: React.FC<IKorrigerVedtak> = ({
                                 vurdert saken din på nytt.
                             </li>
                         </ul>
-                        <StyledFamilieDatovelger
-                            {...skjema.felter.vedtaksdato?.hentNavBaseSkjemaProps(
-                                skjema.visFeilmeldinger
-                            )}
-                            id={'korriger-vedtak-dato'}
+                        <Datovelger
+                            felt={skjema.felter.vedtaksdato}
                             label={'Vedtaksdato'}
-                            erLesesvisning={erLesevisning}
-                            placeholder={datoformatNorsk.DATO}
-                            onChange={(dato?: ISODateString) =>
-                                skjema.felter.vedtaksdato?.validerOgSettFelt(dato)
-                            }
-                            value={
-                                skjema.felter.vedtaksdato?.verdi !== null
-                                    ? skjema.felter.vedtaksdato?.verdi
-                                    : undefined
-                            }
+                            visFeilmeldinger={skjema.visFeilmeldinger}
+                            readOnly={erLesevisning}
+                            kanKunVelgeFortid
                         />
                         <StyledFamilieTextarea
                             {...skjema.felter.begrunnelse?.hentNavBaseSkjemaProps(

--- a/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import styled, { css } from 'styled-components';
 
 import { Cancel, Warning } from '@navikt/ds-icons';
-import { Alert, BodyLong, Button, Modal } from '@navikt/ds-react';
+import { BodyLong, Button, Fieldset, Modal } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
 import { FamilieTextarea } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -80,33 +80,35 @@ const KorrigerVedtak: React.FC<IKorrigerVedtak> = ({
                                 vurdert saken din på nytt.
                             </li>
                         </ul>
-                        <Datovelger
-                            felt={skjema.felter.vedtaksdato}
-                            label={'Vedtaksdato'}
-                            visFeilmeldinger={skjema.visFeilmeldinger}
-                            readOnly={erLesevisning}
-                            kanKunVelgeFortid
-                        />
-                        <StyledFamilieTextarea
-                            {...skjema.felter.begrunnelse?.hentNavBaseSkjemaProps(
-                                skjema.visFeilmeldinger
-                            )}
-                            id={'korriger-vedtak-begrunnelse'}
-                            label={'Begrunnelse (valgfri)'}
-                            description={'Begrunn hva som er gjort feil i tidligere vedtak'}
-                            erLesevisning={erLesevisning}
-                            value={skjema.felter.begrunnelse.verdi}
-                            onChange={changeEvent =>
-                                skjema.felter.begrunnelse.validerOgSettFelt(
-                                    changeEvent.target.value
-                                )
-                            }
-                        />
-                        {restFeil && (
-                            <Alert variant="error" style={{ marginBottom: '1.5rem' }} inline>
-                                {restFeil}
-                            </Alert>
-                        )}
+                        <Fieldset
+                            legend={'Korriger vedtak'}
+                            hideLegend
+                            errorPropagation={false}
+                            error={skjema.visFeilmeldinger && restFeil}
+                        >
+                            <Datovelger
+                                felt={skjema.felter.vedtaksdato}
+                                label={'Vedtaksdato'}
+                                visFeilmeldinger={skjema.visFeilmeldinger}
+                                readOnly={erLesevisning}
+                                kanKunVelgeFortid
+                            />
+                            <StyledFamilieTextarea
+                                {...skjema.felter.begrunnelse?.hentNavBaseSkjemaProps(
+                                    skjema.visFeilmeldinger
+                                )}
+                                id={'korriger-vedtak-begrunnelse'}
+                                label={'Begrunnelse (valgfri)'}
+                                description={'Begrunn hva som er gjort feil i tidligere vedtak'}
+                                erLesevisning={erLesevisning}
+                                value={skjema.felter.begrunnelse.verdi}
+                                onChange={changeEvent =>
+                                    skjema.felter.begrunnelse.validerOgSettFelt(
+                                        changeEvent.target.value
+                                    )
+                                }
+                            />
+                        </Fieldset>
                     </Modal.Body>
                     <Modal.Footer>
                         {!erLesevisning && (

--- a/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
@@ -20,7 +20,7 @@ import { useBehandling } from '../../context/behandlingContext/BehandlingContext
 import type { IPersonInfo, IRestTilgang } from '../../typer/person';
 import { adressebeskyttelsestyper } from '../../typer/person';
 import type { IBarnMedOpplysninger } from '../../typer/søknad';
-import type { FamilieIsoDate } from '../../utils/kalender';
+import { dateTilIsoDatoStringEllerUndefined } from '../../utils/dato';
 import { identValidator } from '../../utils/validators';
 import LeggTilUregistrertBarn from '../Fagsak/Søknad/LeggTilUregistrertBarn';
 
@@ -49,7 +49,7 @@ const DrekLenkeContainer = styled.div`
 export interface IRegistrerBarnSkjema {
     ident: string;
     erFolkeregistrert: boolean;
-    uregistrertBarnFødselsdato: FamilieIsoDate | undefined;
+    uregistrertBarnFødselsdato: Date | undefined;
     uregistrertBarnNavn: string;
 }
 
@@ -94,7 +94,7 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
         {
             ident: string;
             erFolkeregistrert: boolean;
-            uregistrertBarnFødselsdato: FamilieIsoDate | undefined;
+            uregistrertBarnFødselsdato: Date | undefined;
             uregistrertBarnNavn: string;
         },
         IPersonInfo
@@ -112,7 +112,7 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
                 avhengigheter: { erFolkeregistrert: erFolkeregistrert.verdi },
             }),
             erFolkeregistrert,
-            uregistrertBarnFødselsdato: useFelt<FamilieIsoDate | undefined>({
+            uregistrertBarnFødselsdato: useFelt<Date | undefined>({
                 verdi: undefined,
                 skalFeltetVises: (avhengigheter: Avhengigheter) => {
                     const { erFolkeregistrert } = avhengigheter;
@@ -153,7 +153,9 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
                 barnaMedOpplysninger.validerOgSettFelt([
                     ...barnaMedOpplysninger.verdi,
                     {
-                        fødselsdato: registrerBarnSkjema.felter.uregistrertBarnFødselsdato.verdi,
+                        fødselsdato: dateTilIsoDatoStringEllerUndefined(
+                            registrerBarnSkjema.felter.uregistrertBarnFødselsdato.verdi
+                        ),
                         ident: '',
                         merket: true,
                         manueltRegistrert: true,

--- a/src/frontend/typer/eøs-feilutbetalt-valuta.ts
+++ b/src/frontend/typer/eøs-feilutbetalt-valuta.ts
@@ -1,20 +1,20 @@
-import type { FamilieIsoDate } from '../utils/kalender';
+import type { IsoDatoString } from '../utils/dato';
 
 export interface IRestFeilutbetaltValuta {
     id: number;
-    fom: FamilieIsoDate;
-    tom: FamilieIsoDate;
+    fom: IsoDatoString;
+    tom: IsoDatoString;
     feilutbetaltBeløp: number;
 }
 
 export interface IRestNyFeilutbetaltValutaPeriode {
-    fom: FamilieIsoDate;
-    tom: FamilieIsoDate;
+    fom: IsoDatoString;
+    tom: IsoDatoString;
     feilutbetaltBeløp: number;
 }
 
 export interface IFeilutbetaltValutaSkjemaFelter {
-    fom: FamilieIsoDate;
-    tom: FamilieIsoDate;
+    fom: Date | undefined;
+    tom: Date | undefined;
     feilutbetaltBeløp: string;
 }

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -1,5 +1,6 @@
 import type { IVedtaksperiodeMedBegrunnelser } from './vedtaksperiode';
 import type { VilkårType } from './vilkår';
+import type { IsoDatoString } from '../utils/dato';
 
 export interface IVedtakForBehandling {
     aktiv: boolean;
@@ -48,6 +49,6 @@ export enum Standardbegrunnelse {
 }
 
 export interface IRestKorrigertVedtak {
-    vedtaksdato: string;
+    vedtaksdato: IsoDatoString;
     begrunnelse: string | undefined;
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16054

Oppgraderer til ny datovelger for:
- å legge til uregistrert barn
- feilutbetalt valuta
- korrigert vedtak

Oppgraderer også FamilieInput -> TextField i samme skjema, når jeg først er borti koden.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ja! Det er en liten bug i korriger vedtak i dag. Skal lage backend-PR for å fikse. Når du har korrigert et vedtak, så skulle teksten i menyen ha vært "Vis korrigert vedtak", men backend sender aldri med korrigert vedtak-objekt. Det betyr også at det er umulig å slette denne typen endringer. Kan i praksis klare å få endret det fordi du overstyrer når du legger inn ny dato i det tomme skjemaet.

![image](https://github.com/navikt/familie-ks-sak-frontend/assets/25459913/840d3484-b92a-4251-83bf-dca1f17998fc)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Bytter ut komponenter

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Bilder i kommentarer