### PR TITLE
Legg til lovlig opphold visning

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOpphold.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOpphold.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Radio } from 'nav-frontend-skjema';
+
+import { Alert, Label } from '@navikt/ds-react';
+import { FamilieRadioGruppe } from '@navikt/familie-form-elements';
+
+import { useLovligOpphold } from './LovligOppholdContext';
+import { Resultat, resultater } from '../../../../../../typer/vilkår';
+import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
+import { VilkårSkjema } from '../../VilkårSkjema';
+import { useVilkårSkjema } from '../../VilkårSkjemaContext';
+
+type LovligOppholdProps = IVilkårSkjemaBaseProps;
+
+const StyledAlert = styled(Alert)`
+    margin-top: 1rem;
+`;
+
+export const LovligOpphold: React.FC<LovligOppholdProps> = ({
+    vilkårResultat,
+    vilkårFraConfig,
+    toggleForm,
+    person,
+    lesevisning,
+}: LovligOppholdProps) => {
+    const { felter, skalViseDatoVarsel } = useLovligOpphold(vilkårResultat, person);
+    const vilkårSkjemaContext = useVilkårSkjema(vilkårResultat, felter, person, toggleForm);
+    const nullstillAvslagBegrunnelser = () => {
+        vilkårSkjemaContext.skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(false);
+        vilkårSkjemaContext.skjema.felter.avslagBegrunnelser.validerOgSettFelt([]);
+    };
+    return (
+        <VilkårSkjema
+            vilkårSkjemaContext={vilkårSkjemaContext}
+            visVurderesEtter={true}
+            visSpørsmål={false}
+            vilkårResultat={vilkårResultat}
+            vilkårFraConfig={vilkårFraConfig}
+            toggleForm={toggleForm}
+            person={person}
+            lesevisning={lesevisning}
+            periodeChildren={
+                skalViseDatoVarsel && (
+                    <StyledAlert inline variant={'warning'} size={'small'}>
+                        Du må dobbeltsjekke at foreslått f.o.m dato er korrekt
+                    </StyledAlert>
+                )
+            }
+        >
+            <br />
+
+            <FamilieRadioGruppe
+                legend={
+                    <Label>
+                        {vilkårFraConfig.spørsmål
+                            ? vilkårFraConfig.spørsmål(person.type.toLowerCase())
+                            : ''}
+                    </Label>
+                }
+                value={resultater[felter.resultat.verdi]}
+                error={
+                    vilkårSkjemaContext.skjema.visFeilmeldinger
+                        ? vilkårSkjemaContext.skjema.felter.resultat.feilmelding
+                        : ''
+                }
+                erLesevisning={lesevisning}
+            >
+                <Radio
+                    label={'Ja'}
+                    name={`${vilkårResultat.vilkårType}_${vilkårResultat.id}`}
+                    checked={vilkårSkjemaContext.skjema.felter.resultat.verdi === Resultat.OPPFYLT}
+                    onChange={() => {
+                        vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
+                            Resultat.OPPFYLT
+                        );
+                        nullstillAvslagBegrunnelser();
+                    }}
+                />
+                <Radio
+                    label={'Nei'}
+                    name={`${vilkårResultat.vilkårType}_${vilkårResultat.id}`}
+                    checked={
+                        vilkårSkjemaContext.skjema.felter.resultat.verdi === Resultat.IKKE_OPPFYLT
+                    }
+                    onChange={() => {
+                        vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
+                            Resultat.IKKE_OPPFYLT
+                        );
+                    }}
+                />
+                <Radio
+                    label={'Ikke aktuelt'}
+                    name={`${vilkårResultat.vilkårType}_${vilkårResultat.id}`}
+                    checked={
+                        vilkårSkjemaContext.skjema.felter.resultat.verdi === Resultat.IKKE_AKTUELT
+                    }
+                    onChange={() => {
+                        vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
+                            Resultat.IKKE_AKTUELT
+                        );
+                        nullstillAvslagBegrunnelser();
+                    }}
+                />
+            </FamilieRadioGruppe>
+        </VilkårSkjema>
+    );
+};

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOppholdContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOppholdContext.ts
@@ -1,0 +1,79 @@
+import { useFelt } from '@navikt/familie-skjema';
+
+import type { IGrunnlagPerson } from '../../../../../../typer/person';
+import type { Begrunnelse } from '../../../../../../typer/vedtak';
+import type {
+    IVilkårResultat,
+    Regelverk as RegelverkType,
+    UtdypendeVilkårsvurdering,
+} from '../../../../../../typer/vilkår';
+import { Resultat } from '../../../../../../typer/vilkår';
+import type { IYearMonthPeriode } from '../../../../../../utils/kalender';
+import {
+    erAvslagBegrunnelserGyldig,
+    erPeriodeGyldig,
+    erResultatGyldig,
+} from '../../../../../../utils/validators';
+import type { IVilkårSkjemaContext } from '../../VilkårSkjemaContext';
+
+export const useLovligOpphold = (vilkår: IVilkårResultat, person: IGrunnlagPerson) => {
+    const vilkårSkjema: IVilkårSkjemaContext = {
+        vurderesEtter: vilkår.vurderesEtter ? vilkår.vurderesEtter : undefined,
+        resultat: vilkår.resultat,
+        utdypendeVilkårsvurdering: vilkår.utdypendeVilkårsvurderinger,
+        periode: vilkår.periode,
+        begrunnelse: vilkår.begrunnelse,
+        erEksplisittAvslagPåSøknad: vilkår.erEksplisittAvslagPåSøknad ?? false,
+        avslagBegrunnelser: vilkår.avslagBegrunnelser,
+    };
+
+    const skalViseDatoVarsel =
+        vilkår.resultat === Resultat.IKKE_VURDERT && vilkår.periode.fom !== undefined;
+
+    const vurderesEtter = useFelt<RegelverkType | undefined>({
+        verdi: vilkårSkjema.vurderesEtter,
+    });
+
+    const resultat = useFelt<Resultat>({
+        verdi: vilkårSkjema.resultat,
+        valideringsfunksjon: erResultatGyldig,
+    });
+
+    const erEksplisittAvslagPåSøknad = useFelt<boolean>({
+        verdi: vilkårSkjema.erEksplisittAvslagPåSøknad,
+    });
+
+    const utdypendeVilkårsvurdering = useFelt<UtdypendeVilkårsvurdering[]>({
+        verdi: vilkårSkjema.utdypendeVilkårsvurdering,
+    });
+
+    const felter = {
+        vurderesEtter,
+        resultat,
+        utdypendeVilkårsvurdering,
+        periode: useFelt<IYearMonthPeriode>({
+            verdi: vilkårSkjema.periode,
+            avhengigheter: {
+                person,
+                erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
+            },
+            valideringsfunksjon: erPeriodeGyldig,
+        }),
+        begrunnelse: useFelt<string>({
+            verdi: vilkårSkjema.begrunnelse,
+        }),
+        erEksplisittAvslagPåSøknad,
+        avslagBegrunnelser: useFelt<Begrunnelse[]>({
+            verdi: vilkårSkjema.avslagBegrunnelser,
+            valideringsfunksjon: erAvslagBegrunnelserGyldig,
+            avhengigheter: {
+                erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
+            },
+        }),
+    };
+
+    return {
+        felter,
+        skalViseDatoVarsel,
+    };
+};

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -11,6 +11,7 @@ import { Barnehageplass } from './Vilkår/Barnehageplass/Barnehageplass';
 import { BarnetsAlder } from './Vilkår/BarnetsAlder/BarnetsAlder';
 import { BorMedSøker } from './Vilkår/BorMedSøker/BorMedSøker';
 import { BosattIRiket } from './Vilkår/BosattIRiket/BosattIRiket';
+import { LovligOpphold } from './Vilkår/LovligOpphold/LovligOpphold';
 import { Medlemskap } from './Vilkår/Medlemskap/Medlemskap';
 import { MedlemskapAnnenForelder } from './Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder';
 import { vilkårFeilmeldingId } from './VilkårTabell';
@@ -88,6 +89,16 @@ const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårR
             case VilkårType.BOSATT_I_RIKET:
                 return (
                     <BosattIRiket
+                        vilkårResultat={vilkårResultat}
+                        vilkårFraConfig={vilkårFraConfig}
+                        toggleForm={toggleForm}
+                        person={person}
+                        lesevisning={erLesevisning}
+                    />
+                );
+            case VilkårType.LOVLIG_OPPHOLD:
+                return (
+                    <LovligOpphold
                         vilkårResultat={vilkårResultat}
                         vilkårFraConfig={vilkårFraConfig}
                         toggleForm={toggleForm}

--- a/src/frontend/typer/vilkår.ts
+++ b/src/frontend/typer/vilkår.ts
@@ -36,6 +36,7 @@ export enum VilkårType {
     MEDLEMSKAP_ANNEN_FORELDER = 'MEDLEMSKAP_ANNEN_FORELDER',
     BOR_MED_SØKER = 'BOR_MED_SØKER',
     BARNETS_ALDER = 'BARNETS_ALDER',
+    LOVLIG_OPPHOLD = 'LOVLIG_OPPHOLD',
 }
 
 export enum Regelverk {
@@ -50,6 +51,7 @@ export interface IPersonResultat {
     andreVurderinger: IAnnenVurdering[];
     person: IGrunnlagPerson;
 }
+
 export interface IAnnenVurdering {
     id: number;
     begrunnelse: string;
@@ -151,6 +153,13 @@ export const vilkårConfig: Record<VilkårType, IVilkårConfig> = {
         tittel: 'Bosatt i riket',
         spørsmål: (part?: string) => `Er ${part} bosatt i riket?`,
         parterDetteGjelderFor: [PersonType.BARN, PersonType.SØKER],
+    },
+    LOVLIG_OPPHOLD: {
+        beskrivelse: 'lovlig opphold',
+        key: 'LOVLIG_OPPHOLD',
+        tittel: 'Lovlig opphold',
+        spørsmål: (part?: string) => `Har ${part} lovlig opphold?`,
+        parterDetteGjelderFor: [PersonType.SØKER],
     },
     BOR_MED_SØKER: {
         beskrivelse: 'Bor med søker',


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16951

Vi legger til lovlig opphold som vilkår for KS når det er EØS.
Logikken er satt opp slik at vilkåret bare vises når backend returnerer vilkårresultater som inneholder LOVLIG_OPPHOLD.
Alt styring av om det er EØS sak, eller om noe vilkår er vurdert etter eøs forordninger er derfor håndtert i backend.

Bilde:
![lovligopphold](https://github.com/navikt/familie-ks-sak-frontend/assets/110383605/c3c9d943-62c5-41fd-88cb-bbb9a3e18ab1)
