### PR TITLE
Bytt ut FamilieSelect med Select fra Aksel

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -5,9 +5,18 @@ import classNames from 'classnames';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
-import { BodyShort, Button, Checkbox, Fieldset, Label, Radio, RadioGroup } from '@navikt/ds-react';
+import {
+    BodyShort,
+    Button,
+    Checkbox,
+    Fieldset,
+    Label,
+    Radio,
+    RadioGroup,
+    Select,
+    Textarea,
+} from '@navikt/ds-react';
 import { ABorderAction } from '@navikt/ds-tokens/dist/tokens';
-import { FamilieSelect, FamilieTextarea } from '@navikt/familie-form-elements';
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -48,12 +57,12 @@ const StyledFieldset = styled(Fieldset)`
     max-width: 30rem;
 `;
 
-const StyledPersonvelger = styled(FamilieSelect)`
+const StyledPersonvelger = styled(Select)`
     max-width: 20rem;
     z-index: 1000;
 `;
 
-const StyledSatsvelger = styled(FamilieSelect)`
+const StyledSatsvelger = styled(Select)`
     max-width: 10rem;
 `;
 
@@ -65,7 +74,7 @@ const StyledFerdigKnapp = styled(Button)`
     margin-right: 0.5rem;
 `;
 
-const StyledFamilieTextarea = styled(FamilieTextarea)`
+const StyledTextarea = styled(Textarea)`
     min-height: 8rem;
 `;
 
@@ -166,7 +175,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                         onChange={(event): void => {
                             skjema.felter.person.validerOgSettFelt(event.target.value);
                         }}
-                        erLesevisning={erLesevisning}
+                        readOnly={erLesevisning}
                     >
                         <option value={undefined}>Velg person</option>
                         {åpenBehandling.personer
@@ -223,7 +232,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                 </Feltmargin>
 
                 <Feltmargin>
-                    <FamilieSelect
+                    <Select
                         {...skjema.felter.årsak.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                         value={skjema.felter.årsak.verdi}
                         label={<Label>Årsak</Label>}
@@ -233,10 +242,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 event.target.value as IEndretUtbetalingAndelÅrsak
                             );
                         }}
-                        erLesevisning={erLesevisning}
-                        lesevisningVerdi={
-                            skjema.felter.årsak.verdi ? årsakTekst[skjema.felter.årsak.verdi] : ''
-                        }
+                        readOnly={erLesevisning}
                     >
                         <option value={undefined}>Velg årsak</option>
                         {årsaker.map(årsak => (
@@ -244,7 +250,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 {årsakTekst[årsak]}
                             </option>
                         ))}
-                    </FamilieSelect>
+                    </Select>
                 </Feltmargin>
 
                 <Feltmargin>
@@ -360,9 +366,9 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                 )}
 
                 <Feltmargin>
-                    <StyledFamilieTextarea
+                    <StyledTextarea
                         {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
-                        erLesevisning={erLesevisning}
+                        readOnly={erLesevisning}
                         placeholder={'Begrunn hvorfor utbetalingsperioden er endret.'}
                         label={'Begrunnelse'}
                         value={

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -200,7 +200,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     <Feltmargin>
                         <MånedÅrVelger
                             {...skjema.felter.fom.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                            label={<BodyShort>F.o.m</BodyShort>}
+                            label={'F.o.m'}
                             value={skjema.felter.fom.verdi}
                             antallÅrFrem={finnÅrFremTilStønadTom()}
                             antallÅrTilbake={finnÅrTilbakeTilStønadFra()}
@@ -216,7 +216,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     </Feltmargin>
                     <MånedÅrVelger
                         {...skjema.felter.tom.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        label={<BodyShort>T.o.m (valgfri)</BodyShort>}
+                        label={'T.o.m (valgfri)'}
                         value={skjema.felter.tom.verdi}
                         antallÅrFrem={finnÅrFremTilStønadTom()}
                         antallÅrTilbake={finnÅrTilbakeTilStønadFra()}

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/EøsPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/EøsPeriodeSkjema.tsx
@@ -2,23 +2,14 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import { SkjemaGruppe } from 'nav-frontend-skjema';
-
-import { Label } from '@navikt/ds-react';
+import { Fieldset } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import type { IIsoMånedPeriode } from '../../../../utils/dato';
 import MånedÅrVelger from '../../../Felleskomponenter/MånedÅrInput/MånedÅrVelger';
 
-const StyledLegend = styled.legend`
-    && {
-        display: flex;
-        margin-bottom: 0;
-    }
-`;
-
 const FlexDiv = styled.div`
-    width: ${(props: { maxWidth?: number }) => (props.maxWidth ? `${props.maxWidth}rem` : '28rem')};
+    width: 32rem;
     display: flex;
     justify-content: space-between;
     font-size: 1rem;
@@ -39,6 +30,7 @@ interface IProps {
     visFeilmeldinger: boolean;
     lesevisning: boolean;
     maxWidth?: number;
+    className?: string;
 }
 
 const EøsPeriodeSkjema: React.FC<IProps> = ({
@@ -47,22 +39,21 @@ const EøsPeriodeSkjema: React.FC<IProps> = ({
     initielFom,
     visFeilmeldinger,
     lesevisning,
-    maxWidth,
+    className,
 }) => {
     const finnÅrTilbakeTil = (): number => {
         return new Date().getFullYear() - new Date(initielFom.verdi).getFullYear();
     };
 
     return (
-        <SkjemaGruppe
-            className={lesevisning ? 'lesevisning' : ''}
-            feilmeldingId={periodeFeilmeldingId}
-            feil={visFeilmeldinger && periode.feilmelding}
+        <Fieldset
+            className={`${className} ${lesevisning ? 'lesevisning' : ''}`}
+            errorId={periodeFeilmeldingId}
+            error={visFeilmeldinger && periode.feilmelding}
+            legend={'Periode'}
+            size={'medium'}
         >
-            <StyledLegend>
-                <Label size="small">Periode</Label>
-            </StyledLegend>
-            <FlexDiv maxWidth={maxWidth}>
+            <FlexDiv>
                 <MånedÅrVelger
                     lesevisning={lesevisning}
                     id={`periode_fom`}
@@ -100,7 +91,7 @@ const EøsPeriodeSkjema: React.FC<IProps> = ({
                     }}
                 />
             </FlexDiv>
-        </SkjemaGruppe>
+        </Fieldset>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/fellesKomponenter.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/fellesKomponenter.tsx
@@ -19,7 +19,6 @@ import { Datoformat, isoMånedPeriodeTilFormatertString } from '../../../../util
 import { lagPersonLabel } from '../../../../utils/formatter';
 
 interface IEøsPeriodeSkjemaContainerProps {
-    maxWidth?: number;
     lesevisning: boolean;
     status: EøsPeriodeStatus;
 }
@@ -35,13 +34,6 @@ export const EøsPeriodeSkjemaContainer = styled.div`
         }};
     padding-left: 2rem;
     margin-left: -3rem;
-`;
-
-export const StyledLegend = styled.legend`
-    && {
-        display: flex;
-        margin-bottom: 0;
-    }
 `;
 
 export const Knapperad = styled.div`

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/fellesKomponenter.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/fellesKomponenter.tsx
@@ -25,8 +25,7 @@ interface IEøsPeriodeSkjemaContainerProps {
 }
 
 export const EøsPeriodeSkjemaContainer = styled.div`
-    max-width: ${(props: IEøsPeriodeSkjemaContainerProps) =>
-        props.maxWidth ? `${props.maxWidth}rem` : '30rem'};
+    max-width: 34rem;
     border-left: 0.125rem solid
         ${(props: IEøsPeriodeSkjemaContainerProps) => {
             if (props.lesevisning) return ABorderDefault;

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { SkjemaGruppe } from 'nav-frontend-skjema';
-
 import { Delete } from '@navikt/ds-icons';
-import { Alert, Button, Select } from '@navikt/ds-react';
+import { Alert, Button, Fieldset, Select } from '@navikt/ds-react';
 import { FamilieKnapp, FamilieReactSelect } from '@navikt/familie-form-elements';
 import type { OptionType } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
@@ -52,6 +50,10 @@ const StyledFamilieLandvelger = styled(FamilieLandvelger)`
 `;
 
 const StyledSelect = styled(Select)`
+    margin-top: 1.5rem;
+`;
+
+const StyledFamilieReactSelect = styled(FamilieReactSelect)`
     margin-top: 0.5rem;
 `;
 
@@ -87,21 +89,23 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
     const toPrimærland = skjema.felter.resultat?.verdi === KompetanseResultat.TO_PRIMÆRLAND;
 
     return (
-        <SkjemaGruppe feil={skjema.visFeilmeldinger && visSubmitFeilmelding()}>
+        <Fieldset
+            error={skjema.visFeilmeldinger && visSubmitFeilmelding()}
+            legend={'Kompetanseskjema'}
+            hideLegend
+        >
             <EøsPeriodeSkjemaContainer lesevisning={lesevisning} status={status}>
-                <div className={'skjemaelement'}>
-                    <FamilieReactSelect
-                        {...skjema.felter.barnIdenter.hentNavInputProps(skjema.visFeilmeldinger)}
-                        erLesevisning={lesevisning}
-                        label={'Barn'}
-                        isMulti
-                        options={tilgjengeligeBarn}
-                        value={skjema.felter.barnIdenter.verdi}
-                        onChange={options =>
-                            skjema.felter.barnIdenter.validerOgSettFelt(options as OptionType[])
-                        }
-                    />
-                </div>
+                <StyledFamilieReactSelect
+                    {...skjema.felter.barnIdenter.hentNavInputProps(skjema.visFeilmeldinger)}
+                    erLesevisning={lesevisning}
+                    label={'Barn'}
+                    isMulti
+                    options={tilgjengeligeBarn}
+                    value={skjema.felter.barnIdenter.verdi}
+                    onChange={options =>
+                        skjema.felter.barnIdenter.validerOgSettFelt(options as OptionType[])
+                    }
+                />
                 <StyledEøsPeriodeSkjema
                     periode={skjema.felter.periode}
                     periodeFeilmeldingId={kompetansePeriodeFeilmeldingId(skjema)}
@@ -115,7 +119,7 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                         perioden
                     </StyledAlert>
                 )}
-                <Select
+                <StyledSelect
                     {...skjema.felter.søkersAktivitet.hentNavInputProps(skjema.visFeilmeldinger)}
                     readOnly={lesevisning}
                     label={'Søkers aktivitet'}
@@ -143,7 +147,7 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                                 </option>
                             );
                         })}
-                </Select>
+                </StyledSelect>
                 <StyledSelect
                     className="unset-margin-bottom"
                     {...skjema.felter.annenForeldersAktivitet.hentNavInputProps(
@@ -323,7 +327,7 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                         )}
                 </Knapperad>
             </EøsPeriodeSkjemaContainer>
-        </SkjemaGruppe>
+        </Fieldset>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -5,8 +5,8 @@ import styled from 'styled-components';
 import { SkjemaGruppe } from 'nav-frontend-skjema';
 
 import { Delete } from '@navikt/ds-icons';
-import { Alert, Button } from '@navikt/ds-react';
-import { FamilieKnapp, FamilieReactSelect, FamilieSelect } from '@navikt/familie-form-elements';
+import { Alert, Button, Select } from '@navikt/ds-react';
+import { FamilieKnapp, FamilieReactSelect } from '@navikt/familie-form-elements';
 import type { OptionType } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { ISkjema } from '@navikt/familie-skjema';
@@ -51,7 +51,7 @@ const StyledFamilieLandvelger = styled(FamilieLandvelger)`
     margin-top: 1.5rem;
 `;
 
-const StyledFamilieSelect = styled(FamilieSelect)`
+const StyledSelect = styled(Select)`
     margin-top: 0.5rem;
 `;
 
@@ -115,16 +115,11 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                         perioden
                     </StyledAlert>
                 )}
-                <FamilieSelect
+                <Select
                     {...skjema.felter.søkersAktivitet.hentNavInputProps(skjema.visFeilmeldinger)}
-                    erLesevisning={lesevisning}
+                    readOnly={lesevisning}
                     label={'Søkers aktivitet'}
                     value={skjema.felter.søkersAktivitet.verdi || undefined}
-                    lesevisningVerdi={
-                        skjema.felter.søkersAktivitet.verdi
-                            ? kompetanseAktiviteter[skjema.felter.søkersAktivitet.verdi]
-                            : 'Ikke utfylt'
-                    }
                     onChange={event =>
                         skjema.felter.søkersAktivitet.validerOgSettFelt(
                             event.target.value as KompetanseAktivitet
@@ -148,20 +143,15 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                                 </option>
                             );
                         })}
-                </FamilieSelect>
-                <StyledFamilieSelect
+                </Select>
+                <StyledSelect
                     className="unset-margin-bottom"
                     {...skjema.felter.annenForeldersAktivitet.hentNavInputProps(
                         skjema.visFeilmeldinger
                     )}
-                    erLesevisning={lesevisning}
+                    readOnly={lesevisning}
                     label={'Annen forelders aktivitet'}
                     value={skjema.felter.annenForeldersAktivitet.verdi || undefined}
-                    lesevisningVerdi={
-                        skjema.felter.annenForeldersAktivitet?.verdi
-                            ? kompetanseAktiviteter[skjema.felter.annenForeldersAktivitet?.verdi]
-                            : 'Ikke utfylt'
-                    }
                     onChange={event => {
                         skjema.felter.annenForeldersAktivitet.validerOgSettFelt(
                             event.target.value as KompetanseAktivitet
@@ -180,7 +170,7 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                             </option>
                         );
                     })}
-                </StyledFamilieSelect>
+                </StyledSelect>
                 {skjema.felter.annenForeldersAktivitet.verdi ===
                     AnnenForelderAktivitet.IKKE_AKTUELT && (
                     <StyledAlert variant="info" size="small" inline>
@@ -250,16 +240,11 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                             : ''
                     }
                 />
-                <FamilieSelect
+                <Select
                     {...skjema.felter.resultat.hentNavInputProps(skjema.visFeilmeldinger)}
-                    erLesevisning={lesevisning}
+                    readOnly={lesevisning}
                     label={'Kompetanse'}
                     value={skjema.felter.resultat.verdi || undefined}
-                    lesevisningVerdi={
-                        skjema.felter.resultat.verdi
-                            ? kompetanseResultater[skjema.felter.resultat.verdi]
-                            : 'Ikke utfylt'
-                    }
                     onChange={event => {
                         skjema.felter.resultat.validerOgSettFelt(
                             event.target.value as KompetanseResultat
@@ -286,7 +271,7 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                     >
                         {kompetanseResultater[KompetanseResultat.TO_PRIMÆRLAND]}
                     </option>
-                </FamilieSelect>
+                </Select>
                 {toPrimærland && (
                     <Alert
                         variant={'warning'}

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
@@ -114,7 +114,7 @@ const UtenlandskPeriodeBeløpTabellRadEndre: React.FC<IProps> = ({
             legend={'Endre utenlandsk periodebeløp'}
             hideLegend
         >
-            <EøsPeriodeSkjemaContainer maxWidth={34} lesevisning={lesevisning} status={status}>
+            <EøsPeriodeSkjemaContainer lesevisning={lesevisning} status={status}>
                 <UtbetaltBeløpInfo variant="info" inline>
                     <UtbetaltBeløpText size="small">
                         Dersom det er ulike beløp per barn utbetalt i det andre landet, må barna

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -106,7 +106,7 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
             legend={'Endre valutakurs'}
             hideLegend
         >
-            <EøsPeriodeSkjemaContainer maxWidth={34} lesevisning={lesevisning} status={status}>
+            <EøsPeriodeSkjemaContainer lesevisning={lesevisning} status={status}>
                 <FamilieReactSelect
                     {...skjema.felter.barnIdenter.hentNavInputProps(skjema.visFeilmeldinger)}
                     erLesevisning={lesevisning}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -2,9 +2,8 @@ import React, { useState } from 'react';
 
 import { SkjemaGruppe } from 'nav-frontend-skjema';
 
-import { Button } from '@navikt/ds-react';
+import { Button, Select, Textarea } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
-import { FamilieSelect, FamilieTextarea } from '@navikt/familie-form-elements';
 import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
 
 import useEndreBehandlendeEnhet from './useEndreBehandlendeEnhet';
@@ -37,10 +36,6 @@ const EndreBehandlendeEnhet: React.FC = () => {
         settSubmitRessurs,
         submitRessurs,
     } = useEndreBehandlendeEnhet(() => settVisModal(false));
-
-    const valgtArbeidsfordelingsenhet = behandendeEnheter.find(
-        (enhet: IArbeidsfordelingsenhet) => enhet.enhetId === enhetId
-    );
 
     const lukkBehandlendeEnhetModal = () => {
         fjernState();
@@ -99,9 +94,8 @@ const EndreBehandlendeEnhet: React.FC = () => {
             >
                 <SkjemaGruppe feil={hentFrontendFeilmelding(submitRessurs)}>
                     <SkjultLegend>Endre enhet</SkjultLegend>
-                    <FamilieSelect
-                        erLesevisning={erLesevisningPåBehandling()}
-                        lesevisningVerdi={valgtArbeidsfordelingsenhet?.enhetNavn}
+                    <Select
+                        readOnly={erLesevisningPåBehandling()}
                         name="enhet"
                         value={enhetId}
                         label={'Velg ny enhet'}
@@ -126,11 +120,11 @@ const EndreBehandlendeEnhet: React.FC = () => {
                                 </option>
                             );
                         })}
-                    </FamilieSelect>
+                    </Select>
 
-                    <FamilieTextarea
+                    <Textarea
                         disabled={submitRessurs.status === RessursStatus.HENTER}
-                        erLesevisning={erLesevisningPåBehandling()}
+                        readOnly={erLesevisningPåBehandling()}
                         label={'Begrunnelse'}
                         value={begrunnelse}
                         maxLength={4000}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstema.tsx
@@ -68,7 +68,7 @@ const EndreBehandlingstema: React.FC = () => {
                 >
                     <BehandlingstemaSelect
                         behandlingstema={skjema.felter.behandlingstema}
-                        erLesevisning={vurderErLesevisning()}
+                        readOnly={vurderErLesevisning()}
                         label="Behandlingstema"
                     />
                 </Fieldset>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
@@ -6,9 +6,8 @@ import styled from 'styled-components';
 import Lenke from 'nav-frontend-lenker';
 import { SkjemaGruppe } from 'nav-frontend-skjema';
 
-import { BodyShort, Button } from '@navikt/ds-react';
+import { BodyShort, Button, Select, Textarea } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
-import { FamilieSelect, FamilieTextarea } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import useHenleggBehandling from './useHenleggBehandling';
@@ -161,7 +160,7 @@ const HenleggBehandling: React.FC<IProps> = ({ fagsakId, behandling }) => {
                     }
                     legend={SkjultLegend({ children: 'Henlegg behandling' })}
                 >
-                    <FamilieSelect
+                    <Select
                         {...skjema.felter.årsak.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                         label={'Velg årsak'}
                         value={skjema.felter.årsak.verdi}
@@ -191,12 +190,11 @@ const HenleggBehandling: React.FC<IProps> = ({ fagsakId, behandling }) => {
                                     </option>
                                 );
                             })}
-                    </FamilieSelect>
+                    </Select>
 
-                    <FamilieTextarea
+                    <Textarea
                         {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
                         label={'Begrunnelse'}
-                        erLesevisning={false}
                         maxLength={4000}
                     />
                 </SkjemaGruppe>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { BodyShort, Button, Fieldset, Modal } from '@navikt/ds-react';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { BodyShort, Button, Fieldset, Modal, Select } from '@navikt/ds-react';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -90,7 +89,7 @@ export const SettBehandlingPåVentModal: React.FC<IProps> = ({ lukkModal, behand
                             kanKunVelgeFremtid
                         />
                     </Feltmargin>
-                    <FamilieSelect
+                    <Select
                         {...årsak.hentNavInputProps(skjema.visFeilmeldinger)}
                         label={'Årsak'}
                         placeholder={'Årsak'}
@@ -101,7 +100,7 @@ export const SettBehandlingPåVentModal: React.FC<IProps> = ({ lukkModal, behand
                                 {settPåVentÅrsaker[årsak]}
                             </option>
                         ))}
-                    </FamilieSelect>
+                    </Select>
                 </Fieldset>
             </Modal.Body>
             <Modal.Footer>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/BehandlingstypeFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/BehandlingstypeFelt.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { Select } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import { kanOppretteFørstegangsbehandling, kanOppretteRevurdering } from './opprettBehandlingUtils';
@@ -47,9 +47,9 @@ const BehandlingstypeFelt: React.FC<IProps> = ({
     const kanOppretteTilbakekreving = !manuellJournalfør;
 
     return (
-        <FamilieSelect
+        <Select
             {...behandlingstype.hentNavBaseSkjemaProps(visFeilmeldinger)}
-            erLesevisning={erLesevisning}
+            readOnly={erLesevisning}
             name={'Behandling'}
             label={'Velg type behandling'}
             onChange={(event: React.ChangeEvent<BehandlingstypeSelect>): void => {
@@ -104,7 +104,7 @@ const BehandlingstypeFelt: React.FC<IProps> = ({
                     Klage
                 </option>
             )}
-        </FamilieSelect>
+        </Select>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/BehandlingsårsakFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/BehandlingsårsakFelt.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { Select } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../../../context/AppContext';
@@ -25,9 +25,9 @@ export const BehandlingårsakFelt: React.FC<IProps> = ({
     const { toggles } = useApp();
 
     return (
-        <FamilieSelect
+        <Select
             {...behandlingsårsak.hentNavBaseSkjemaProps(visFeilmeldinger)}
-            erLesevisning={erLesevisning}
+            readOnly={erLesevisning}
             name={'Behandlingsårsak'}
             label={'Velg årsak'}
             onChange={(event: React.ChangeEvent<BehandlingÅrsakSelect>): void => {
@@ -55,6 +55,6 @@ export const BehandlingårsakFelt: React.FC<IProps> = ({
                         </option>
                     );
                 })}
-        </FamilieSelect>
+        </Select>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -4,8 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { FileContent } from '@navikt/ds-icons';
-import { Alert, BodyShort, Button, Modal } from '@navikt/ds-react';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { Alert, BodyShort, Button, Modal, Select } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import FeilutbetaltValuta from './FeilutbetaltValuta/FeilutbetaltValuta';
@@ -149,9 +148,9 @@ const OppsummeringVedtakInnhold: React.FunctionComponent<IOppsummeringVedtakInnh
                     </BehandlingKorrigertAlert>
                 )}
                 {åpenBehandling.resultat === BehandlingResultat.FORTSATT_INNVILGET && (
-                    <FamilieSelect
+                    <Select
                         label="Velg brev med eller uten perioder"
-                        erLesevisning={erLesevisning}
+                        readOnly={erLesevisning}
                         onChange={(
                             event: React.ChangeEvent<FortsattInnvilgetPerioderSelect>
                         ): void => {
@@ -165,7 +164,7 @@ const OppsummeringVedtakInnhold: React.FunctionComponent<IOppsummeringVedtakInnh
                         <option value={PeriodetypeIVedtaksbrev.MED_PERIODER}>
                             Fortsatt innvilget: Med perioder
                         </option>
-                    </FamilieSelect>
+                    </Select>
                 )}
                 {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL ||
                 åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
@@ -6,14 +6,9 @@ import styled from 'styled-components';
 import { Radio } from 'nav-frontend-skjema';
 
 import { Delete } from '@navikt/ds-icons';
-import { Button, Fieldset, Label } from '@navikt/ds-react';
+import { Button, Fieldset, Label, Select, Textarea } from '@navikt/ds-react';
 import { ABorderDefault, ABorderWarning, ASurfaceAction } from '@navikt/ds-tokens/dist/tokens';
-import {
-    FamilieKnapp,
-    FamilieRadioGruppe,
-    FamilieSelect,
-    FamilieTextarea,
-} from '@navikt/familie-form-elements';
+import { FamilieKnapp, FamilieRadioGruppe } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import AvslagSkjema from './AvslagSkjema';
@@ -114,14 +109,8 @@ export const VilkårSkjema = <T extends IVilkårSkjemaContext>({
         <Fieldset error={feilmelding} errorPropagation={false} legend={'Endre vilkår'} hideLegend>
             <Container lesevisning={false} vilkårResultat={undefined}>
                 {visVurderesEtter && (
-                    <FamilieSelect
-                        erLesevisning={lesevisning}
-                        lesevisningVerdi={
-                            skjema.felter.vurderesEtter.verdi
-                                ? alleRegelverk[skjema.felter.vurderesEtter.verdi as Regelverk]
-                                      .tekst
-                                : 'Generell vurdering'
-                        }
+                    <Select
+                        readOnly={lesevisning}
                         value={skjema.felter.vurderesEtter.verdi}
                         label={'Vurderes etter'}
                         onChange={event => {
@@ -158,7 +147,7 @@ export const VilkårSkjema = <T extends IVilkårSkjemaContext>({
                                 );
                             }
                         )}
-                    </FamilieSelect>
+                    </Select>
                 )}
                 {visSpørsmål && (
                     <StyledFamilieRadioGruppe
@@ -223,8 +212,8 @@ export const VilkårSkjema = <T extends IVilkårSkjemaContext>({
                     visFeilmeldinger={skjema.visFeilmeldinger}
                     children={periodeChildren}
                 />
-                <FamilieTextarea
-                    erLesevisning={lesevisning}
+                <Textarea
+                    readOnly={lesevisning}
                     id={vilkårBegrunnelseFeilmeldingId(vilkårResultat)}
                     label={`Begrunnelse ${
                         erBegrunnelsePåkrevd(

--- a/src/frontend/komponenter/Felleskomponenter/BehandlingstemaSelect.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/BehandlingstemaSelect.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { FamilieSelect } from '@navikt/familie-form-elements';
-import type { IFamilieSelectProps } from '@navikt/familie-form-elements/src/select/FamilieSelect';
+import { Select, type SelectProps } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import { useApp } from '../../context/AppContext';
@@ -12,22 +11,20 @@ import { ToggleNavn } from '../../typer/toggles';
 interface EgneProps {
     behandlingstema: Felt<IBehandlingstema | undefined>;
     visFeilmeldinger?: boolean;
-    erLesevisning?: boolean;
 }
 
-type Props = EgneProps & Omit<IFamilieSelectProps, 'children'>;
+type Props = EgneProps & Omit<SelectProps, 'children'>;
 
 export const BehandlingstemaSelect = ({
     behandlingstema,
     visFeilmeldinger = false,
-    erLesevisning = false,
-    ...familieSelectProps
+    ...selectProps
 }: Props) => {
     const { toggles } = useApp();
     const { verdi } = behandlingstema;
     return (
-        <FamilieSelect
-            {...familieSelectProps}
+        <Select
+            {...selectProps}
             {...behandlingstema.hentNavInputProps(visFeilmeldinger)}
             value={verdi !== undefined ? verdi.id : ''}
             onChange={evt => {
@@ -35,8 +32,6 @@ export const BehandlingstemaSelect = ({
                     behandlingstemaer[evt.target.value as Behandlingstema]
                 );
             }}
-            erLesevisning={erLesevisning}
-            lesevisningVerdi={verdi !== undefined ? verdi.navn : ''}
         >
             {verdi === undefined && (
                 <option
@@ -62,6 +57,6 @@ export const BehandlingstemaSelect = ({
                     </option>
                 );
             })}
-        </FamilieSelect>
+        </Select>
     );
 };

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -7,13 +7,8 @@ import navFarger from 'nav-frontend-core';
 import { Label, SkjemaGruppe } from 'nav-frontend-skjema';
 
 import { AddCircle, Delete, FileContent } from '@navikt/ds-icons';
-import { Button, Tag } from '@navikt/ds-react';
-import {
-    FamilieInput,
-    FamilieReactSelect,
-    FamilieSelect,
-    FamilieTextarea,
-} from '@navikt/familie-form-elements';
+import { Button, Select, Tag, Textarea } from '@navikt/ds-react';
+import { FamilieInput, FamilieReactSelect } from '@navikt/familie-form-elements';
 import type { FeltState } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -47,7 +42,7 @@ const StyledList = styled.ul`
     margin: 0;
 `;
 
-const StyledFamilieSelect = styled(FamilieSelect)`
+const StyledSelect = styled(Select)`
     margin-top: 1rem;
 `;
 
@@ -58,7 +53,7 @@ const StyledFamilieFritekstFelt = styled.div`
     }
 `;
 
-const FamilieTextareaBegrunnelseFritekst = styled(FamilieTextarea)`
+const TextareaBegrunnelseFritekst = styled(Textarea)`
     .navds-textarea__wrapper {
         margin-top: 0.5rem;
         margin-bottom: 0.5rem;
@@ -167,7 +162,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                 }
             >
                 <SkjultLegend>Send brev</SkjultLegend>
-                <FamilieSelect
+                <Select
                     {...skjema.felter.mottakerIdent.hentNavInputProps(skjema.visFeilmeldinger)}
                     label={'Velg mottaker'}
                     placeholder={'Velg mottaker'}
@@ -191,8 +186,8 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                                 </option>
                             );
                         })}
-                </FamilieSelect>
-                <StyledFamilieSelect
+                </Select>
+                <StyledSelect
                     {...skjema.felter.brevmal.hentNavInputProps(skjema.visFeilmeldinger)}
                     label={'Velg brevmal'}
                     placeholder={'Velg brevmal'}
@@ -213,7 +208,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                             </option>
                         );
                     })}
-                </StyledFamilieSelect>
+                </StyledSelect>
 
                 {skjema.felter.dokumenter.erSynlig && (
                     <FamilieReactSelect
@@ -276,8 +271,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                                                     key={`fritekst-${fritekstId}`}
                                                 >
                                                     <SkjultLegend>{`Kulepunkt ${fritekstId}`}</SkjultLegend>
-                                                    <FamilieTextareaBegrunnelseFritekst
-                                                        erLesevisning={false}
+                                                    <TextareaBegrunnelseFritekst
                                                         key={`fritekst-${fritekstId}`}
                                                         id={`${fritekstId}`}
                                                         label={`Kulepunkt ${fritekstId}`}

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedVelger.tsx
@@ -6,8 +6,6 @@ interface MånedProps {
     måned: string | undefined;
     settMåned: (måned: string | undefined) => void;
     lesevisning?: boolean;
-    disabled?: boolean;
-    className?: string;
     feil?: boolean;
 }
 
@@ -30,8 +28,6 @@ const MånedVelger: React.FC<MånedProps> = ({
     måned,
     settMåned,
     lesevisning = false,
-    disabled = false,
-    className,
     feil = false,
 }) => {
     return (
@@ -39,12 +35,10 @@ const MånedVelger: React.FC<MånedProps> = ({
             readOnly={lesevisning}
             value={måned ?? ''}
             label={'Måned'}
-            className={className}
             onChange={event => {
                 event.persist();
                 settMåned(event.target.value !== '' ? event.target.value : undefined);
             }}
-            disabled={disabled}
             error={feil}
         >
             <option value="">Måned</option>

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedVelger.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { Select } from '@navikt/ds-react';
 
 interface MånedProps {
     måned: string | undefined;
@@ -35,9 +35,8 @@ const MånedVelger: React.FC<MånedProps> = ({
     feil = false,
 }) => {
     return (
-        <FamilieSelect
-            erLesevisning={lesevisning}
-            lesevisningVerdi={måned ? månedValg.find(mnd => mnd.mndNr === måned)?.verdi : ''}
+        <Select
+            readOnly={lesevisning}
             value={måned ?? ''}
             label={'Måned'}
             className={className}
@@ -54,7 +53,7 @@ const MånedVelger: React.FC<MånedProps> = ({
                     {mnd.verdi}
                 </option>
             ))}
-        </FamilieSelect>
+        </Select>
     );
 };
 

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedVelger.tsx
@@ -7,6 +7,7 @@ interface MånedProps {
     settMåned: (måned: string | undefined) => void;
     lesevisning?: boolean;
     feil?: boolean;
+    label: string;
 }
 
 const månedValg = [
@@ -29,12 +30,13 @@ const MånedVelger: React.FC<MånedProps> = ({
     settMåned,
     lesevisning = false,
     feil = false,
+    label,
 }) => {
     return (
         <Select
             readOnly={lesevisning}
             value={måned ?? ''}
-            label={'Måned'}
+            label={label}
             onChange={event => {
                 event.persist();
                 settMåned(event.target.value !== '' ? event.target.value : undefined);

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedVelger.tsx
@@ -8,6 +8,7 @@ interface MånedProps {
     lesevisning?: boolean;
     feil?: boolean;
     label: string;
+    className?: string;
 }
 
 const månedValg = [
@@ -31,6 +32,7 @@ const MånedVelger: React.FC<MånedProps> = ({
     lesevisning = false,
     feil = false,
     label,
+    className,
 }) => {
     return (
         <Select
@@ -42,6 +44,7 @@ const MånedVelger: React.FC<MånedProps> = ({
                 settMåned(event.target.value !== '' ? event.target.value : undefined);
             }}
             error={feil}
+            className={className}
         >
             <option value="">Måned</option>
             {månedValg.map(mnd => (

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedÅrVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedÅrVelger.tsx
@@ -12,7 +12,7 @@ interface Props {
     id: string;
     feil?: ReactNode | undefined;
     value: string | undefined;
-    label?: ReactNode;
+    label: string;
     onEndret: (årMåned?: string) => void;
     antallÅrTilbake: number;
     antallÅrFrem: number;
@@ -75,6 +75,7 @@ const MånedÅrVelger: React.FC<Props> = ({
                     settMåned={settMåned}
                     lesevisning={lesevisning}
                     feil={!!feil && !måned}
+                    label={label}
                 />
                 <Årvelger
                     år={år}

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedÅrVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedÅrVelger.tsx
@@ -24,10 +24,6 @@ const Knapperad = styled.div`
     flex-direction: row;
 `;
 
-const DatolabelStyle = styled.label`
-    margin-bottom: 0.5em;
-`;
-
 const StyledMånedVelger = styled(MånedVelger)`
     padding-right: 1em;
 `;
@@ -38,7 +34,6 @@ const StyledErrorMessage = styled(ErrorMessage)`
 `;
 
 const MånedÅrVelger: React.FC<Props> = ({
-    id,
     feil,
     value,
     label,
@@ -67,8 +62,7 @@ const MånedÅrVelger: React.FC<Props> = ({
     }, [value]);
 
     return (
-        <div style={lesevisning ? { minWidth: '140px' } : {}}>
-            {label && <DatolabelStyle htmlFor={id}>{label}</DatolabelStyle>}
+        <div>
             <Knapperad>
                 <StyledMånedVelger
                     måned={måned}

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedÅrVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedÅrVelger.tsx
@@ -35,7 +35,7 @@ const StyledMånedVelger = styled(MånedVelger)`
 `;
 
 const StyledErrorMessage = styled(ErrorMessage)`
-    margin-top: 0rem;
+    margin-top: 0;
     margin-bottom: 0.5rem;
 `;
 
@@ -43,7 +43,6 @@ const MånedÅrVelger: React.FC<Props> = ({
     id,
     feil,
     value,
-    className,
     label,
     onEndret,
     antallÅrTilbake = 10,
@@ -71,7 +70,7 @@ const MånedÅrVelger: React.FC<Props> = ({
     }, [value]);
 
     return (
-        <div className={className} style={lesevisning ? { minWidth: '140px' } : {}}>
+        <div style={lesevisning ? { minWidth: '140px' } : {}}>
             {label && <DatolabelStyle htmlFor={id}>{label}</DatolabelStyle>}
             <Knapperad>
                 <StyledMånedVelger

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedÅrVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/MånedÅrVelger.tsx
@@ -12,13 +12,11 @@ interface Props {
     id: string;
     feil?: ReactNode | undefined;
     value: string | undefined;
-    className?: string;
     label?: ReactNode;
     onEndret: (årMåned?: string) => void;
     antallÅrTilbake: number;
     antallÅrFrem: number;
     lesevisning?: boolean;
-    disabled?: boolean;
 }
 
 const Knapperad = styled.div`
@@ -48,7 +46,6 @@ const MånedÅrVelger: React.FC<Props> = ({
     antallÅrTilbake = 10,
     antallÅrFrem = 4,
     lesevisning = false,
-    disabled = false,
 }) => {
     const årFraVerdi = () => (value ? parseInt(value.split('-')[0], 10) : undefined);
     const månedFraVerdi = () => (value ? value.split('-')[1] : undefined);
@@ -77,7 +74,6 @@ const MånedÅrVelger: React.FC<Props> = ({
                     måned={måned}
                     settMåned={settMåned}
                     lesevisning={lesevisning}
-                    disabled={disabled}
                     feil={!!feil && !måned}
                 />
                 <Årvelger
@@ -86,7 +82,6 @@ const MånedÅrVelger: React.FC<Props> = ({
                     antallÅrTilbake={antallÅrTilbake}
                     antallÅrFrem={antallÅrFrem}
                     lesevisning={lesevisning}
-                    disabled={disabled}
                     feil={!!feil && !år}
                 />
             </Knapperad>

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/ÅrVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/ÅrVelger.tsx
@@ -47,6 +47,8 @@ const Årvelger: React.FC<ÅrProps> = ({
             readOnly={lesevisning}
             error={feil}
             label={'År'}
+            hideLabel
+            style={{ marginTop: '2rem' }}
         >
             <option value="">År</option>
             {årOptions}

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/ÅrVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/ÅrVelger.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { Select } from '@navikt/ds-react';
 
 interface ÅrProps {
     år: number | undefined;
@@ -39,22 +39,21 @@ const Årvelger: React.FC<ÅrProps> = ({
 }) => {
     const årOptions = lagÅrOptions(år, antallÅrFrem, antallÅrTilbake);
     return (
-        <FamilieSelect
-            lesevisningVerdi={år ? år.toString() : ''}
+        <Select
             value={år ?? ''}
             size={'medium'}
             onChange={event => {
                 event.persist();
                 settÅr(event.target.value !== '' ? parseInt(event.target.value) : undefined);
             }}
-            erLesevisning={lesevisning}
+            readOnly={lesevisning}
             disabled={disabled}
             error={feil}
             label={'År'}
         >
             <option value="">År</option>
             {årOptions}
-        </FamilieSelect>
+        </Select>
     );
 };
 

--- a/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/ÅrVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MånedÅrInput/ÅrVelger.tsx
@@ -8,7 +8,6 @@ interface ÅrProps {
     antallÅrFrem: number;
     antallÅrTilbake: number;
     lesevisning?: boolean;
-    disabled?: boolean;
     feil?: boolean;
 }
 
@@ -34,7 +33,6 @@ const Årvelger: React.FC<ÅrProps> = ({
     antallÅrFrem,
     antallÅrTilbake,
     lesevisning = false,
-    disabled = false,
     feil = false,
 }) => {
     const årOptions = lagÅrOptions(år, antallÅrFrem, antallÅrTilbake);
@@ -47,7 +45,6 @@ const Årvelger: React.FC<ÅrProps> = ({
                 settÅr(event.target.value !== '' ? parseInt(event.target.value) : undefined);
             }}
             readOnly={lesevisning}
-            disabled={disabled}
             error={feil}
             label={'År'}
         >

--- a/src/frontend/komponenter/ManuellJournalfør/KnyttTilNyBehandling.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/KnyttTilNyBehandling.tsx
@@ -75,7 +75,7 @@ export const KnyttTilNyBehandling: React.FC = () => {
             {behandlingstema.erSynlig && (
                 <BehandlingstemaSelect
                     behandlingstema={behandlingstema}
-                    erLesevisning={!kanKnytteJournalpostTilBehandling()}
+                    readOnly={!kanKnytteJournalpostTilBehandling()}
                     visFeilmeldinger={skjema.visFeilmeldinger}
                     name="Behandlingstema"
                     label="Velg behandlingstema"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Oppgradering av typescript (https://github.com/navikt/familie-ks-sak-frontend/pull/434) feiler fordi FamilieSelect importerer SelectProps fra ds-react på feil måte. Siden FamilieSelect uansett skulle byttes ut med Select fra Aksel på sikt fant jeg ut at det var raskere å bare gjøre det nå heller enn å oppgradere FamilieSelect til å funke med typescript 5.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Ingen visuelle endringer utenom i lesevisning.
Vilkårsvurdering
Før
![image](https://github.com/navikt/familie-ks-sak-frontend/assets/25459913/c102a2c9-1778-4f7c-930e-a8f6912de338)

Etter
![image](https://github.com/navikt/familie-ks-sak-frontend/assets/25459913/b9089769-73d0-465c-bc36-f926a18d1ffc)

Kompetanse
Før
![image](https://github.com/navikt/familie-ks-sak-frontend/assets/25459913/50a56136-309f-4aca-b629-105559a5fd56)

Etter
![image](https://github.com/navikt/familie-ks-sak-frontend/assets/25459913/2d1ce24e-00c3-42ad-b8f0-4159d31b48f4)
