### PR TITLE
Tillat barnetsalder tom til å være dødsfallsdato

### DIFF
--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -56,6 +56,14 @@ const datoErPersonsXÅrsdag = (person: IGrunnlagPerson, dato: Date, antallÅr: n
     return isSameDay(dato, personsXÅrsdag);
 };
 
+const datoErPersonsDødsfallsdag = (person: IGrunnlagPerson, dato: Date) => {
+    const personsDødsfallsdag = person.dødsfallDato;
+
+    return (
+        personsDødsfallsdag !== undefined && isSameDay(dato, isoStringTilDate(personsDødsfallsdag))
+    );
+};
+
 const datoDifferanseMerEnn1År = (fom: Date, tom: Date) => {
     const fomDatoPluss1År = addYears(fom, 1);
     return isBefore(fomDatoPluss1År, tom);
@@ -127,7 +135,11 @@ export const erPeriodeGyldig = (
                         if (!datoErPersonsXÅrsdag(person, fom, 1)) {
                             return feil(felt, 'F.o.m datoen må være lik barnets 1 års dag');
                         }
-                        if (tom && !datoErPersonsXÅrsdag(person, tom, 2)) {
+                        if (
+                            tom &&
+                            !datoErPersonsXÅrsdag(person, tom, 2) &&
+                            !datoErPersonsDødsfallsdag(person, tom)
+                        ) {
                             return feil(felt, 'T.o.m datoen må være lik barnets 2 års dag');
                         }
                     }


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17532

![dd](https://github.com/navikt/familie-ks-sak-frontend/assets/110383605/21f208ef-ae6d-4d82-bd89-6b95d5409c63)


Vi må tillate at tom dato på barnetsalder kan bli satt til å være barnets dødsdato hvis det finnes.