### PR TITLE
Unngå å parse isoString hvis den er null

### DIFF
--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -59,9 +59,7 @@ const datoErPersonsXÅrsdag = (person: IGrunnlagPerson, dato: Date, antallÅr: n
 const datoErPersonsDødsfallsdag = (person: IGrunnlagPerson, dato: Date) => {
     const personsDødsfallsdag = person.dødsfallDato;
 
-    return (
-        personsDødsfallsdag !== undefined && isSameDay(dato, isoStringTilDate(personsDødsfallsdag))
-    );
+    return !!personsDødsfallsdag && isSameDay(dato, isoStringTilDate(personsDødsfallsdag));
 };
 
 const datoDifferanseMerEnn1År = (fom: Date, tom: Date) => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17839)

Vi får en prodfeil der vi ikke klarer å parse en `personsDødsfallsdag` fra isoString til Date, ettersom verdien er `null`.
Valideringsfunksjonen hadde en guard for undefined-verdier men trenger også en guard for null. Endrer til å sjekke at verdien er truthy (dette feiler for både undefined og null)
<img width="518" alt="image" src="https://github.com/navikt/familie-ks-sak-frontend/assets/2379098/038fda98-770b-4c78-8e8e-25a9a013bd89">

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
