### PR TITLE
Framtidig opphør: gjør begrunnelsesvalg ikkeredigerbart for framtidig opphørsperiode

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -26,16 +26,16 @@ import { useVedtaksperiodeMedBegrunnelser } from '../Context/VedtaksperiodeMedBe
 import { mapBegrunnelserTilSelectOptions } from '../Hooks/useVedtaksbegrunnelser';
 
 interface IProps {
-    ikkeRedigerbar: boolean;
+    tillatKunLesevisning: boolean;
 }
 
 const GroupLabel = styled.div`
     color: black;
 `;
 
-const BegrunnelserMultiselect: React.FC<IProps> = ({ ikkeRedigerbar }) => {
+const BegrunnelserMultiselect: React.FC<IProps> = ({ tillatKunLesevisning }) => {
     const { vurderErLesevisning } = useBehandling();
-    const skalIkkeEditeres = vurderErLesevisning() || ikkeRedigerbar;
+    const erLesevisning = vurderErLesevisning() || tillatKunLesevisning;
 
     const {
         id,
@@ -95,7 +95,7 @@ const BegrunnelserMultiselect: React.FC<IProps> = ({ ikkeRedigerbar }) => {
                 }),
             }}
             placeholder={'Velg begrunnelse(r)'}
-            isDisabled={skalIkkeEditeres || begrunnelserPut.status === RessursStatus.HENTER}
+            isDisabled={erLesevisning || begrunnelserPut.status === RessursStatus.HENTER}
             feil={
                 begrunnelserPut.status === RessursStatus.FUNKSJONELL_FEIL ||
                 begrunnelserPut.status === RessursStatus.FEILET
@@ -104,7 +104,7 @@ const BegrunnelserMultiselect: React.FC<IProps> = ({ ikkeRedigerbar }) => {
             }
             label="Velg standardtekst i brev"
             creatable={false}
-            erLesevisning={skalIkkeEditeres}
+            erLesevisning={erLesevisning}
             isMulti={true}
             onChange={(_, action: ActionMeta<ISelectOption>) => {
                 onChangeBegrunnelse(action);

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -28,16 +28,17 @@ import { mapBegrunnelserTilSelectOptions } from '../Hooks/useVedtaksbegrunnelser
 
 interface IProps {
     vedtaksperiodetype: Vedtaksperiodetype;
+    ikkeRedigerbar: boolean;
 }
 
 const GroupLabel = styled.div`
     color: black;
 `;
 
-const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype }) => {
+const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype, ikkeRedigerbar }) => {
     const { vurderErLesevisning } = useBehandling();
     const skalIkkeEditeres =
-        vurderErLesevisning() || vedtaksperiodetype === Vedtaksperiodetype.AVSLAG;
+        vurderErLesevisning() || ikkeRedigerbar || vedtaksperiodetype === Vedtaksperiodetype.AVSLAG;
 
     const {
         id,

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -35,7 +35,7 @@ const GroupLabel = styled.div`
 
 const BegrunnelserMultiselect: React.FC<IProps> = ({ tillatKunLesevisning }) => {
     const { vurderErLesevisning } = useBehandling();
-    const erLesevisning = vurderErLesevisning() || tillatKunLesevisning;
+    const erLesevisning = tillatKunLesevisning || vurderErLesevisning();
 
     const {
         id,

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -16,7 +16,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
 import type { Begrunnelse, BegrunnelseType } from '../../../../../typer/vedtak';
 import { begrunnelseTyper } from '../../../../../typer/vedtak';
-import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
 import {
     finnBegrunnelseType,
     hentBakgrunnsfarge,
@@ -27,7 +26,6 @@ import { useVedtaksperiodeMedBegrunnelser } from '../Context/VedtaksperiodeMedBe
 import { mapBegrunnelserTilSelectOptions } from '../Hooks/useVedtaksbegrunnelser';
 
 interface IProps {
-    vedtaksperiodetype: Vedtaksperiodetype;
     ikkeRedigerbar: boolean;
 }
 
@@ -35,10 +33,9 @@ const GroupLabel = styled.div`
     color: black;
 `;
 
-const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype, ikkeRedigerbar }) => {
+const BegrunnelserMultiselect: React.FC<IProps> = ({ ikkeRedigerbar }) => {
     const { vurderErLesevisning } = useBehandling();
-    const skalIkkeEditeres =
-        vurderErLesevisning() || ikkeRedigerbar || vedtaksperiodetype === Vedtaksperiodetype.AVSLAG;
+    const skalIkkeEditeres = vurderErLesevisning() || ikkeRedigerbar;
 
     const {
         id,

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -89,7 +89,7 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
             />
             {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.AVSLAG && (
                 <BegrunnelserMultiselect
-                    ikkeRedigerbar={vedtaksperiodeInneholderFramtidigOpphørBegrunnelse}
+                    tillatKunLesevisning={vedtaksperiodeInneholderFramtidigOpphørBegrunnelse}
                 />
             )}
             {genererteBrevbegrunnelser.status === RessursStatus.SUKSESS &&

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -32,6 +32,13 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
         Standardbegrunnelse.REDUKSJON_UNDER_18_ÅR,
     ];
 
+    const vedtaksperiodeInneholderFramtidigOpphørBegrunnelse =
+        vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
+            vedtaksBegrunnelser =>
+                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
+                Standardbegrunnelse.OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS
+        ).length > 0;
+
     const vedtaksperiodeInneholderEtterbetaling3MånedBegrunnelse = () =>
         vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
             vedtaksBegrunnelser =>
@@ -81,7 +88,10 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
                 }
             />
             {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.AVSLAG && (
-                <BegrunnelserMultiselect vedtaksperiodetype={vedtaksperiodeMedBegrunnelser.type} />
+                <BegrunnelserMultiselect
+                    ikkeRedigerbar={vedtaksperiodeInneholderFramtidigOpphørBegrunnelse}
+                    vedtaksperiodetype={vedtaksperiodeMedBegrunnelser.type}
+                />
             )}
             {genererteBrevbegrunnelser.status === RessursStatus.SUKSESS &&
                 genererteBrevbegrunnelser.data.length > 0 && (

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -90,7 +90,6 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
             {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.AVSLAG && (
                 <BegrunnelserMultiselect
                     ikkeRedigerbar={vedtaksperiodeInneholderFramtidigOpphørBegrunnelse}
-                    vedtaksperiodetype={vedtaksperiodeMedBegrunnelser.type}
                 />
             )}
             {genererteBrevbegrunnelser.status === RessursStatus.SUKSESS &&

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -48,6 +48,7 @@ export enum Standardbegrunnelse {
     REDUKSJON_UNDER_6_ÅR = 'NasjonalEllerFellesBegrunnelse$REDUKSJON_UNDER_6_ÅR',
     REDUKSJON_UNDER_18_ÅR = 'NasjonalEllerFellesBegrunnelse$REDUKSJON_UNDER_18_ÅR',
     ETTER_ENDRET_UTBETALING_ETTERBETALING = 'NasjonalEllerFellesBegrunnelse$ETTER_ENDRET_UTBETALING_ETTERBETALING',
+    OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS = 'NasjonalEllerFellesBegrunnelse$OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS',
 }
 
 export interface IRestKorrigertVedtak {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: NAV-18152 ved framtidig opphør skal ikke saksbehandler kunne velge andre tekster i opphørsperioden

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Jeg har vurdert om dette er bedre å løse i backend, for å ivareta at man skal kunne legge inn begrunnelser dersom vi i samme periode skal innvilge for et annet barn. Men i så fall ville det ikke ha blitt en opphørsperiode, kun reduksjon, så denne logikken ville ikke ha truffet uansett. Tenker derfor at dette er enkleste løsning for caset fag beskriver

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
