### PR TITLE
Legger til manuell brevmottaker på fagsak/dokumentutsendings-siden

### DIFF
--- a/src/frontend/context/DokumentutsendingContext.ts
+++ b/src/frontend/context/DokumentutsendingContext.ts
@@ -37,7 +37,7 @@ const hentBarnMedOpplysningerFraBruker = () => {
     const { bruker: brukerRessurs } = useFagsakContext();
 
     if (brukerRessurs.status === RessursStatus.SUKSESS) {
-        const iBarnMedOpplysningers =
+        return (
             brukerRessurs.data.forelderBarnRelasjon
                 .filter(
                     (relasjon: IForelderBarnRelasjon) =>
@@ -52,9 +52,8 @@ const hentBarnMedOpplysningerFraBruker = () => {
                         manueltRegistrert: false,
                         erFolkeregistrert: true,
                     })
-                ) ?? [];
-
-        return iBarnMedOpplysningers;
+                ) ?? []
+        );
     } else return [];
 };
 

--- a/src/frontend/context/DokumentutsendingContext.ts
+++ b/src/frontend/context/DokumentutsendingContext.ts
@@ -3,8 +3,8 @@ import { useEffect, useState } from 'react';
 import createUseContext from 'constate';
 import deepEqual from 'deep-equal';
 
-import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { FeltState } from '@navikt/familie-skjema';
+import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useFagsakContext } from './fagsak/FagsakContext';
@@ -60,7 +60,8 @@ const hentBarnMedOpplysningerFraBruker = () => {
 
 export const [DokumentutsendingProvider, useDokumentutsending] = createUseContext(
     ({ fagsakId }: { fagsakId: number }) => {
-        const { bruker } = useFagsakContext();
+        const { bruker, manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } =
+            useFagsakContext();
         const [visInnsendtBrevModal, settVisInnsendtBrevModal] = useState(false);
         const { hentForhåndsvisning, hentetDokument } = useDokument();
 
@@ -141,6 +142,7 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
                             bruker: bruker,
                             målform: målform.verdi ?? Målform.NB,
                             brevmal: Informasjonsbrev.INFORMASJONSBREV_KAN_SØKE_EØS,
+                            manuelleBrevmottakerePåFagsak,
                         });
                     case DokumentÅrsak.TIL_FORELDER_OMFATTET_NORSK_LOVGIVNING_VARSEL_OM_REVURDERING:
                         return hentBarnSøktForSkjemaData(
@@ -184,6 +186,7 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
                     },
                     () => {
                         settVisInnsendtBrevModal(true);
+                        settManuelleBrevmottakerePåFagsak([]);
                         nullstillSkjema();
                     }
                 );
@@ -212,6 +215,7 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
                     mottakerMålform: målform,
                     mottakerNavn: bruker.data.navn,
                     brevmal: brevmal,
+                    manuelleBrevmottakere: manuelleBrevmottakerePåFagsak,
                 };
             } else {
                 throw Error('Bruker ikke hentet inn og vi kan ikke sende inn skjema');

--- a/src/frontend/context/fagsak/FagsakContext.tsx
+++ b/src/frontend/context/fagsak/FagsakContext.tsx
@@ -16,6 +16,7 @@ import {
 import type { Ressurs } from '@navikt/familie-typer';
 
 import { useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg } from './useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg';
+import type { SkjemaBrevmottaker } from '../../komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import type { IMinimalFagsak, IInternstatistikk } from '../../typer/fagsak';
 import type { IKlagebehandling } from '../../typer/klage';
 import type { IPersonInfo } from '../../typer/person';
@@ -29,6 +30,9 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
     const [internstatistikk, settInternstatistikk] =
         React.useState<Ressurs<IInternstatistikk>>(byggTomRessurs());
     const [klagebehandlinger, settKlagebehandlinger] = useState<IKlagebehandling[]>([]);
+    const [manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak] = useState<
+        SkjemaBrevmottaker[]
+    >([]);
 
     const { request } = useHttp();
 
@@ -152,6 +156,8 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
         hentBruker,
         klagebehandlinger,
         oppdaterKlagebehandlingerPåFagsak,
+        manuelleBrevmottakerePåFagsak,
+        settManuelleBrevmottakerePåFagsak,
     };
 });
 

--- a/src/frontend/context/fagsak/FagsakContext.tsx
+++ b/src/frontend/context/fagsak/FagsakContext.tsx
@@ -143,6 +143,7 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
         oppdaterBrukerHvisFagsakEndres,
         bruker,
         oppdaterKlagebehandlingerPåFagsak,
+        settManuelleBrevmottakerePåFagsak,
     });
 
     return {

--- a/src/frontend/context/fagsak/useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg.ts
+++ b/src/frontend/context/fagsak/useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
 
+import type { SkjemaBrevmottaker } from '../../komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import type { IMinimalFagsak } from '../../typer/fagsak';
 import type { IPersonInfo } from '../../typer/person';
 
@@ -15,6 +16,7 @@ interface Props {
     ) => void;
     bruker: Ressurs<IPersonInfo>;
     oppdaterKlagebehandlingerPåFagsak: () => void;
+    settManuelleBrevmottakerePåFagsak: (manuelleBrevmottakere: SkjemaBrevmottaker[]) => void;
 }
 
 export const useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg = ({
@@ -23,6 +25,7 @@ export const useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg = ({
     oppdaterBrukerHvisFagsakEndres,
     bruker,
     oppdaterKlagebehandlingerPåFagsak,
+    settManuelleBrevmottakerePåFagsak,
 }: Props) =>
     useEffect(() => {
         if (
@@ -36,6 +39,6 @@ export const useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg = ({
                 hentDataFraRessurs(minimalFagsak)?.søkerFødselsnummer
             );
         }
-
         oppdaterKlagebehandlingerPåFagsak();
+        settManuelleBrevmottakerePåFagsak([]);
     }, [minimalFagsak]);

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/BarnSøktFor/BarnSøktForSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/BarnSøktFor/BarnSøktForSkjema.tsx
@@ -6,6 +6,7 @@ import { CheckboxGroup } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import BarnCheckbox from './BarnCheckbox';
+import { useFagsakContext } from '../../../../context/fagsak/FagsakContext';
 import type { IBarnMedOpplysninger } from '../../../../typer/søknad';
 import { isoStringTilDate } from '../../../../utils/dato';
 import LeggTilBarn from '../../../Felleskomponenter/LeggTilBarn';
@@ -17,6 +18,8 @@ interface IProps {
 }
 
 const BarnSøktForSkjema = (props: IProps) => {
+    const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
+
     const { barnSøktForFelt, visFeilmeldinger, settVisFeilmeldinger } = props;
 
     const sorterteBarn = barnSøktForFelt.verdi.sort(
@@ -72,7 +75,10 @@ const BarnSøktForSkjema = (props: IProps) => {
                 />
             ))}
 
-            <LeggTilBarn barnaMedOpplysninger={barnSøktForFelt} />
+            <LeggTilBarn
+                barnaMedOpplysninger={barnSøktForFelt}
+                manuelleBrevmottakere={manuelleBrevmottakerePåFagsak}
+            />
         </CheckboxGroup>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/Dokumentutsending.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/Dokumentutsending.tsx
@@ -8,7 +8,12 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import DokumentutsendingSkjema from './DokumentutsendingSkjema';
 import { useDokumentutsending } from '../../../context/DokumentutsendingContext';
+import type { IPersonInfo } from '../../../typer/person';
 import { fagsakHeaderHøydeRem } from '../../../typer/styling';
+
+interface Props {
+    bruker: IPersonInfo;
+}
 
 const Container = styled.div`
     display: grid;
@@ -17,7 +22,7 @@ const Container = styled.div`
     height: calc(100vh - ${fagsakHeaderHøydeRem}rem);
 `;
 
-const Dokumentutsending: React.FC = () => {
+const Dokumentutsending: React.FC<Props> = ({ bruker }) => {
     const navigate = useNavigate();
 
     const { fagsakId, hentetDokument, settVisInnsendtBrevModal, visInnsendtBrevModal } =
@@ -55,7 +60,7 @@ const Dokumentutsending: React.FC = () => {
                     </Modal.Footer>
                 </Modal>
             )}
-            <DokumentutsendingSkjema />
+            <DokumentutsendingSkjema bruker={bruker} />
 
             <iframe
                 title={'dokument'}

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -12,7 +12,14 @@ import {
     DokumentÅrsak,
     useDokumentutsending,
 } from '../../../context/DokumentutsendingContext';
+import { useFagsakContext } from '../../../context/fagsak/FagsakContext';
+import type { IPersonInfo } from '../../../typer/person';
+import { BrevmottakereAlert } from '../../Felleskomponenter/BrevmottakereAlert';
 import MålformVelger from '../../Felleskomponenter/MålformVelger';
+
+interface Props {
+    bruker: IPersonInfo;
+}
 
 const Container = styled.div`
     padding: 2rem;
@@ -42,7 +49,11 @@ const SendBrevKnapp = styled(Button)`
     margin-right: 1rem;
 `;
 
-const DokumentutsendingSkjema: React.FC = () => {
+const StyledBrevmottakereAlert = styled(BrevmottakereAlert)`
+    margin: 1rem 0;
+`;
+
+const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
     const {
         hentForhåndsvisningPåFagsak,
         hentetDokument,
@@ -56,6 +67,8 @@ const DokumentutsendingSkjema: React.FC = () => {
         visForhåndsvisningBeskjed,
     } = useDokumentutsending();
 
+    const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
+
     const årsakVerdi = skjema.felter.årsak.verdi;
 
     const barnSøktForÅrsaker = [
@@ -67,6 +80,15 @@ const DokumentutsendingSkjema: React.FC = () => {
     return (
         <Container>
             <Heading size={'large'} level={'1'} children={'Send informasjonsbrev'} />
+
+            {manuelleBrevmottakerePåFagsak.length > 0 && (
+                <StyledBrevmottakereAlert
+                    erPåBehandling={false}
+                    brevmottakere={manuelleBrevmottakerePåFagsak}
+                    bruker={bruker}
+                />
+            )}
+
             <StyledFieldset
                 error={hentSkjemaFeilmelding()}
                 errorPropagation={false}

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/Informasjonsbrev/enkeltInformasjonsbrevUtils.ts
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/Informasjonsbrev/enkeltInformasjonsbrevUtils.ts
@@ -5,17 +5,20 @@ import type { IManueltBrevRequestPåFagsak } from '../../../../typer/dokument';
 import type { IPersonInfo } from '../../../../typer/person';
 import type { Målform } from '../../../../typer/søknad';
 import type { Informasjonsbrev } from '../../../Felleskomponenter/Hendelsesoversikt/BrevModul/typer';
+import type { SkjemaBrevmottaker } from '../../Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 
 interface IHentEnkeltInformasjonsbrevRequestInput {
     bruker: Ressurs<IPersonInfo>;
     målform: Målform;
     brevmal: Informasjonsbrev;
+    manuelleBrevmottakerePåFagsak: SkjemaBrevmottaker[];
 }
 
 export const hentEnkeltInformasjonsbrevRequest = ({
     bruker,
     målform,
     brevmal,
+    manuelleBrevmottakerePåFagsak,
 }: IHentEnkeltInformasjonsbrevRequestInput): IManueltBrevRequestPåFagsak => {
     if (bruker.status === RessursStatus.SUKSESS) {
         return {
@@ -25,6 +28,7 @@ export const hentEnkeltInformasjonsbrevRequest = ({
             mottakerMålform: målform,
             mottakerNavn: bruker.data.navn,
             brevmal: brevmal,
+            manuelleBrevmottakere: manuelleBrevmottakerePåFagsak,
         };
     } else {
         throw Error('Bruker ikke hentet inn og vi kan ikke sende inn skjema');

--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -107,7 +107,7 @@ const FagsakContainer: React.FunctionComponent = () => {
                                                 <DokumentutsendingProvider
                                                     fagsakId={minimalFagsak.data.id}
                                                 >
-                                                    <Dokumentutsending />
+                                                    <Dokumentutsending bruker={bruker.data} />
                                                 </DokumentutsendingProvider>
                                             }
                                         />

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { Fieldset, HStack, Select, Spacer, TextField, VStack } from '@navikt/ds-react';
@@ -24,7 +25,11 @@ interface Props {
 }
 
 const BrevmottakerSkjema = ({ erLesevisning, skjema, navnErPreutfylt }: Props) => {
-    const gyldigeMottakerTyper = Object.values(Mottaker);
+    const erPåDokumentutsending = useLocation().pathname.includes('dokumentutsending');
+
+    const gyldigeMottakerTyper = erPåDokumentutsending
+        ? Object.values(Mottaker).filter(mottakerType => mottakerType !== Mottaker.DØDSBO)
+        : Object.values(Mottaker);
 
     return (
         <>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -25,9 +25,9 @@ interface Props {
 }
 
 const BrevmottakerSkjema = ({ erLesevisning, skjema, navnErPreutfylt }: Props) => {
-    const erPåDokumentutsending = useLocation().pathname.includes('dokumentutsending');
+    const erPåDokumentutsendingPåFagsak = useLocation().pathname.includes('dokumentutsending');
 
-    const gyldigeMottakerTyper = erPåDokumentutsending
+    const gyldigeMottakerTyper = erPåDokumentutsendingPåFagsak
         ? Object.values(Mottaker).filter(mottakerType => mottakerType !== Mottaker.DØDSBO)
         : Object.values(Mottaker);
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { PlusCircleIcon } from '@navikt/aksel-icons';
@@ -65,6 +66,8 @@ export const LeggTilBrevmottakerModal = <T extends SkjemaBrevmottaker | IRestBre
         (brevmottakere.length === 0 && !erLesevisning) ||
         (brevmottakere.length === 1 && visSkjemaNårDetErÉnBrevmottaker);
 
+    const erPåDokumentutsending = useLocation().pathname.includes('dokumentutsending');
+
     const lukkModalOgSkjema = () => {
         lukkModal();
         settVisSkjemaNårDetErÉnBrevmottaker(false);
@@ -81,13 +84,13 @@ export const LeggTilBrevmottakerModal = <T extends SkjemaBrevmottaker | IRestBre
             <Modal.Body>
                 <StyledAlert variant="info">
                     Brev sendes til brukers folkeregistrerte adresse eller annen foretrukken kanal.
-                    Legg til mottaker dersom brev skal sendes til utenlandsk adresse, fullmektig,
-                    verge eller dødsbo'.
+                    Legg til mottaker dersom brev skal sendes til utenlandsk adresse, fullmektig
+                    {erPåDokumentutsending ? ' eller verge' : ', verge eller dødsbo'}.
                 </StyledAlert>
-                {brevmottakere.map(mottaker => (
+                {brevmottakere.map((mottaker, index) => (
                     <BrevmottakerTabell
                         mottaker={mottaker}
-                        key={`mottaker-${mottaker}`}
+                        key={`mottaker-${index}`}
                         fjernMottaker={fjernMottaker}
                         erLesevisning={erLesevisning}
                     />

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
@@ -66,7 +66,7 @@ export const LeggTilBrevmottakerModal = <T extends SkjemaBrevmottaker | IRestBre
         (brevmottakere.length === 0 && !erLesevisning) ||
         (brevmottakere.length === 1 && visSkjemaNårDetErÉnBrevmottaker);
 
-    const erPåDokumentutsending = useLocation().pathname.includes('dokumentutsending');
+    const erPåDokumentutsendingPåFagsak = useLocation().pathname.includes('dokumentutsending');
 
     const lukkModalOgSkjema = () => {
         lukkModal();
@@ -85,7 +85,7 @@ export const LeggTilBrevmottakerModal = <T extends SkjemaBrevmottaker | IRestBre
                 <StyledAlert variant="info">
                     Brev sendes til brukers folkeregistrerte adresse eller annen foretrukken kanal.
                     Legg til mottaker dersom brev skal sendes til utenlandsk adresse, fullmektig
-                    {erPåDokumentutsending ? ' eller verge' : ', verge eller dødsbo'}.
+                    {erPåDokumentutsendingPåFagsak ? ' eller verge' : ', verge eller dødsbo'}.
                 </StyledAlert>
                 {brevmottakere.map((mottaker, index) => (
                     <BrevmottakerTabell

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { LeggTilBrevmottakerModal } from './LeggTilBrevmottakerModal';
+import type { BrevmottakerUseSkjema, SkjemaBrevmottaker } from './useBrevmottakerSkjema';
+import { felterTilSkjemaBrevmottaker } from './useBrevmottakerSkjema';
+import { useFagsakContext } from '../../../../../context/fagsak/FagsakContext';
+
+interface IFagsakModalProps {
+    lukkModal: () => void;
+}
+export const LeggTilBrevmottakerModalFagsak: React.FC<IFagsakModalProps> = ({ lukkModal }) => {
+    const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } = useFagsakContext();
+
+    const lagreMottaker = (useSkjema: BrevmottakerUseSkjema) => {
+        if (useSkjema.kanSendeSkjema()) {
+            const nyMottaker = felterTilSkjemaBrevmottaker(useSkjema.skjema.felter);
+            const mottakere: SkjemaBrevmottaker[] = [...manuelleBrevmottakerePåFagsak, nyMottaker];
+            useSkjema.nullstillSkjema();
+            return settManuelleBrevmottakerePåFagsak(mottakere);
+        }
+    };
+
+    const fjernMottaker = (mottaker: SkjemaBrevmottaker) => {
+        const mottakereUtenFjernetPerson = manuelleBrevmottakerePåFagsak.filter(
+            mottakerPåFagsak => mottakerPåFagsak !== mottaker
+        );
+        settManuelleBrevmottakerePåFagsak(mottakereUtenFjernetPerson);
+    };
+
+    return (
+        <LeggTilBrevmottakerModal
+            brevmottakere={manuelleBrevmottakerePåFagsak}
+            lagreMottaker={lagreMottaker}
+            fjernMottaker={fjernMottaker}
+            erLesevisning={false}
+            lukkModal={lukkModal}
+        />
+    );
+};

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere.tsx
@@ -3,11 +3,20 @@ import React, { useState } from 'react';
 import { Dropdown } from '@navikt/ds-react';
 
 import { LeggTilBrevmottakerModalBehandling } from './LeggTilBrevmottakerModalBehandling';
+import { LeggTilBrevmottakerModalFagsak } from './LeggTilBrevmottakerModalFagsak';
+import type { SkjemaBrevmottaker } from './useBrevmottakerSkjema';
 import type { IBehandling } from '../../../../../typer/behandling';
 
 interface BehandlingProps {
+    erPåBehandling: true;
     behandling: IBehandling;
     erLesevisning: boolean;
+}
+
+interface FagsakProps {
+    erPåBehandling: false;
+    erLesevisning?: never;
+    brevmottakere: SkjemaBrevmottaker[];
 }
 
 const utledMenyinnslag = (antallMottakere: number, erLesevisning: boolean) => {
@@ -22,12 +31,14 @@ const utledMenyinnslag = (antallMottakere: number, erLesevisning: boolean) => {
     }
 };
 
-export const LeggTilEllerFjernBrevmottakere = (props: BehandlingProps) => {
+export const LeggTilEllerFjernBrevmottakere = (props: BehandlingProps | FagsakProps) => {
     const [visModal, settVisModal] = useState(false);
 
-    const brevmottakere = props.behandling.brevmottakere;
+    const brevmottakere = props.erPåBehandling
+        ? props.behandling.brevmottakere
+        : props.brevmottakere;
 
-    const menyinnslag = utledMenyinnslag(brevmottakere.length, props.erLesevisning);
+    const menyinnslag = utledMenyinnslag(brevmottakere.length, !!props.erLesevisning);
 
     return (
         <>
@@ -35,13 +46,16 @@ export const LeggTilEllerFjernBrevmottakere = (props: BehandlingProps) => {
                 {menyinnslag}
             </Dropdown.Menu.List.Item>
 
-            {visModal && (
-                <LeggTilBrevmottakerModalBehandling
-                    lukkModal={() => settVisModal(false)}
-                    behandling={props.behandling}
-                    erLesevisning={props.erLesevisning}
-                />
-            )}
+            {visModal &&
+                (props.erPåBehandling ? (
+                    <LeggTilBrevmottakerModalBehandling
+                        lukkModal={() => settVisModal(false)}
+                        behandling={props.behandling}
+                        erLesevisning={props.erLesevisning}
+                    />
+                ) : (
+                    <LeggTilBrevmottakerModalFagsak lukkModal={() => settVisModal(false)} />
+                ))}
         </>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import type { FieldDictionary } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { UseSkjemaVerdi } from '@navikt/familie-skjema/dist/typer';
 import { hentDataFraRessurs } from '@navikt/familie-typer';
@@ -201,4 +202,23 @@ export const useBrevmottakerSkjema = ({ eksisterendeMottakere }: Props) => {
     });
 
     return { verdierFraBrevmottakerUseSkjema: verdierFraUseSkjema, navnErPreutfylt };
+};
+
+export const felterTilSkjemaBrevmottaker = (
+    felter: FieldDictionary<ILeggTilFjernBrevmottakerSkjemaFelter>
+): SkjemaBrevmottaker => {
+    if (felter.mottaker.verdi !== '') {
+        return {
+            type: felter.mottaker.verdi,
+            navn: felter.navn.verdi,
+            adresselinje1: felter.adresselinje1.verdi,
+            adresselinje2:
+                felter.adresselinje2.verdi !== '' ? felter.adresselinje2.verdi : undefined,
+            postnummer: felter.postnummer.verdi,
+            poststed: felter.poststed.verdi,
+            landkode: felter.land.verdi,
+        };
+    } else {
+        throw new Error('Mottaker ikke satt');
+    }
 };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/MenyvalgFagsak.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/MenyvalgFagsak.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Dropdown } from '@navikt/ds-react';
 
+import { LeggTilEllerFjernBrevmottakere } from './LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere';
 import OpprettBehandling from './OpprettBehandling/OpprettBehandling';
+import { useApp } from '../../../../context/AppContext';
+import { useFagsakContext } from '../../../../context/fagsak/FagsakContext';
 import type { IMinimalFagsak } from '../../../../typer/fagsak';
+import { ToggleNavn } from '../../../../typer/toggles';
 
 interface IProps {
     minimalFagsak: IMinimalFagsak;
@@ -13,15 +17,26 @@ interface IProps {
 
 const MenyvalgFagsak = ({ minimalFagsak }: IProps) => {
     const navigate = useNavigate();
+    const { toggles } = useApp();
+
+    const erPåDokumentutsending = useLocation().pathname.includes('dokumentutsending');
+    const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
 
     return (
         <>
             <OpprettBehandling minimalFagsak={minimalFagsak} />
-            <Dropdown.Menu.List.Item
-                onClick={() => navigate(`/fagsak/${minimalFagsak.id}/dokumentutsending`)}
-            >
-                Send informasjonsbrev
-            </Dropdown.Menu.List.Item>
+            {toggles[ToggleNavn.manuellBrevmottaker] && erPåDokumentutsending ? (
+                <LeggTilEllerFjernBrevmottakere
+                    erPåBehandling={false}
+                    brevmottakere={manuelleBrevmottakerePåFagsak}
+                />
+            ) : (
+                <Dropdown.Menu.List.Item
+                    onClick={() => navigate(`/fagsak/${minimalFagsak.id}/dokumentutsending`)}
+                >
+                    Send informasjonsbrev
+                </Dropdown.Menu.List.Item>
+            )}
         </>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettFagsak/MenyvalgBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettFagsak/MenyvalgBehandling.tsx
@@ -50,6 +50,7 @@ const MenyvalgBehandling = ({ minimalFagsak, åpenBehandling }: IProps) => {
                 (åpenBehandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING ||
                     åpenBehandling.type === Behandlingstype.REVURDERING) && (
                     <LeggTilEllerFjernBrevmottakere
+                        erPåBehandling={true}
                         behandling={åpenBehandling}
                         erLesevisning={erLesevisning}
                     />

--- a/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
@@ -263,6 +263,7 @@ const TilbakekrevingSkjema: React.FC<{
                                             erPåBehandling={true}
                                             erLesevisning={erLesevisning}
                                             åpenBehandling={åpenBehandling.data}
+                                            brevmottakere={åpenBehandling.data.brevmottakere}
                                         />
                                     )}
                                 {fritekstVarsel.erSynlig && (

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -151,6 +151,7 @@ const OppsummeringVedtakInnhold: React.FunctionComponent<IOppsummeringVedtakInnh
                     erPåBehandling={true}
                     erLesevisning={erLesevisning}
                     åpenBehandling={åpenBehandling}
+                    brevmottakere={åpenBehandling.brevmottakere}
                 />
                 {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL ||
                 åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||

--- a/src/frontend/komponenter/Felleskomponenter/BrevmottakereAlert.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/BrevmottakereAlert.tsx
@@ -13,6 +13,11 @@ import type { IBehandling } from '../../typer/behandling';
 import type { IPersonInfo } from '../../typer/person';
 import { hentSideHref } from '../../utils/miljø';
 import { LeggTilBrevmottakerModalBehandling } from '../Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalBehandling';
+import { LeggTilBrevmottakerModalFagsak } from '../Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak';
+import type {
+    IRestBrevmottaker,
+    SkjemaBrevmottaker,
+} from '../Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 
 interface Props {
     bruker: IPersonInfo;
@@ -22,20 +27,26 @@ interface Props {
 export interface BrevmottakereAlertBehandlingProps extends Props {
     erPåBehandling: true;
     erLesevisning: boolean;
+    brevmottakere: IRestBrevmottaker[];
     åpenBehandling: IBehandling;
+}
+
+interface BrevmottakereAlertFagsakProps extends Props {
+    erPåBehandling: false;
+    brevmottakere: SkjemaBrevmottaker[];
 }
 
 const StyledAlert = styled(Alert)`
     margin-bottom: 1.5rem;
 `;
 
-export const BrevmottakereAlert: React.FC<BrevmottakereAlertBehandlingProps> = props => {
-    const { className, bruker, åpenBehandling, erLesevisning } = props;
-
+export const BrevmottakereAlert: React.FC<
+    BrevmottakereAlertBehandlingProps | BrevmottakereAlertFagsakProps
+> = props => {
     const location = useLocation();
     const [visManuelleMottakereModal, settVisManuelleMottakereModal] = useState(false);
 
-    const brevmottakere = åpenBehandling.brevmottakere;
+    const brevmottakere = props.brevmottakere;
 
     function hentBrevtypetekst(pathname: string) {
         if (hentSideHref(pathname) === sider.SIMULERING.href) {
@@ -50,11 +61,11 @@ export const BrevmottakereAlert: React.FC<BrevmottakereAlertBehandlingProps> = p
     return (
         <>
             {brevmottakere && brevmottakere.length !== 0 && (
-                <StyledAlert variant="info" className={className}>
+                <StyledAlert variant="info" className={props.className}>
                     {`Brevmottaker(e) er endret, og ${hentBrevtypetekst(
                         location.pathname
                     )} sendes til:`}
-                    <BrevmottakerListe brevmottakere={brevmottakere} bruker={bruker} />
+                    <BrevmottakerListe brevmottakere={brevmottakere} bruker={props.bruker} />
                     <Button
                         variant={'tertiary'}
                         onClick={() => settVisManuelleMottakereModal(true)}
@@ -66,13 +77,18 @@ export const BrevmottakereAlert: React.FC<BrevmottakereAlertBehandlingProps> = p
                 </StyledAlert>
             )}
 
-            {visManuelleMottakereModal && (
-                <LeggTilBrevmottakerModalBehandling
-                    lukkModal={() => settVisManuelleMottakereModal(false)}
-                    behandling={åpenBehandling}
-                    erLesevisning={erLesevisning}
-                />
-            )}
+            {visManuelleMottakereModal &&
+                (props.erPåBehandling ? (
+                    <LeggTilBrevmottakerModalBehandling
+                        lukkModal={() => settVisManuelleMottakereModal(false)}
+                        behandling={props.åpenBehandling}
+                        erLesevisning={props.erLesevisning}
+                    />
+                ) : (
+                    <LeggTilBrevmottakerModalFagsak
+                        lukkModal={() => settVisManuelleMottakereModal(false)}
+                    />
+                ))}
         </>
     );
 };

--- a/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
@@ -52,13 +52,13 @@ export interface IRegistrerBarnSkjema {
 interface IProps {
     barnaMedOpplysninger: Felt<IBarnMedOpplysninger[]>;
     onSuccess?: (barn: IPersonInfo) => void;
-    manuelleBrevmottakere?: SkjemaBrevmottaker[] | IRestBrevmottaker[]; // Todo: endre denne til å være required når vi får inn manuelle brevmottakre på fagsak
+    manuelleBrevmottakere: SkjemaBrevmottaker[] | IRestBrevmottaker[];
 }
 
 const LeggTilBarn: React.FC<IProps> = ({
     barnaMedOpplysninger,
     onSuccess,
-    manuelleBrevmottakere = [],
+    manuelleBrevmottakere,
 }) => {
     const { request } = useHttp();
     const { logg } = useBehandling();

--- a/src/frontend/typer/dokument.ts
+++ b/src/frontend/typer/dokument.ts
@@ -1,5 +1,6 @@
 import type { BehandlingKategori } from './behandlingstema';
 import type { Målform } from './søknad';
+import type { SkjemaBrevmottaker } from '../komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import type {
     Brevmal,
     Informasjonsbrev,
@@ -24,4 +25,5 @@ export interface IManueltBrevRequestPåFagsak {
     brevmal: Brevmal | Informasjonsbrev;
     behandlingKategori?: undefined;
     antallUkerSvarfrist?: undefined;
+    manuelleBrevmottakere: SkjemaBrevmottaker[];
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17930

Denne PR'en legger til featuren å kunne legge til manuelle brevmottakere på fagsaknivå (dokumentutsendings-siden/informasjonsbrev)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Commit for commit skal være greit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
![Screenshot 2024-02-13 at 12 28 38](https://github.com/navikt/familie-ks-sak-frontend/assets/8656966/04ea3918-792e-4b7a-a263-64a1ab2e421c)
![Screenshot 2024-02-13 at 12 29 12](https://github.com/navikt/familie-ks-sak-frontend/assets/8656966/75a6e2e1-df44-4a52-8fa8-d7505029a449)
![Screenshot 2024-02-13 at 13 03 56](https://github.com/navikt/familie-ks-sak-frontend/assets/8656966/c01f9292-cdab-44c9-ba1b-fb56a90a3ab2)

