### PR TITLE
Chore: sikre kun 1 versjon av familie-http 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@navikt/familie-backend": "^10.0.14",
     "@navikt/familie-form-elements": "^15.0.0",
     "@navikt/familie-header": "^14.0.0",
-    "@navikt/familie-http": "^7.0.3",
     "@navikt/familie-ikoner": "^9.0.0",
     "@navikt/familie-logging": "^7.0.0",
     "@navikt/familie-skjema": "^8.0.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     ]
   },
   "dependencies": {
-    "@axe-core/react": "^4.8.1",
     "@navikt/aksel-icons": "6.1.0",
     "@navikt/ds-css": "^6.1.0",
     "@navikt/ds-icons": "^2.2.0",
@@ -78,6 +77,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@axe-core/react": "^4.8.5",
     "@babel/core": "^7.24.0",
     "@babel/preset-env": "^7.24.0",
     "@babel/preset-react": "^7.23.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,12 +40,12 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@axe-core/react@^4.8.1":
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/@axe-core/react/-/react-4.8.1.tgz#d3823389a01bffe7b0d0d30c05e386b161789e86"
-  integrity sha512-55eSebGFYQaBRJsACCr+SxX9QV7buSmQUnUMH37y0k2CvlyPAuPLNcG6IcSaU+U6IhDJ5EWSHBIoM4HSVU3f3w==
+"@axe-core/react@^4.8.5":
+  version "4.8.5"
+  resolved "https://registry.yarnpkg.com/@axe-core/react/-/react-4.8.5.tgz#49828fecb604a89027a7aac140cd483e6a7a848f"
+  integrity sha512-GKXFAc/VPa3sDPv8lqPZlDvBt0UNwOwN0B/EnUOaHTRe5IcLl+RfcD+LHVEE75Quc1LOgSyw4T0O9kvJuPzIxg==
   dependencies:
-    axe-core "~4.8.2"
+    axe-core "~4.8.4"
     requestidlecallback "^0.3.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.23.5":
@@ -3441,10 +3441,10 @@ axe-core@=4.7.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.0.tgz#34ba5a48a8b564f67e103f0aa5768d76e15bbbbf"
   integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
 
-axe-core@~4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.8.2.tgz#2f6f3cde40935825cf4465e3c1c9e77b240ff6ae"
-  integrity sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==
+axe-core@~4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.8.4.tgz#90db39a2b316f963f00196434d964e6e23648643"
+  integrity sha512-CZLSKisu/bhJ2awW4kJndluz2HLZYIHh5Uy1+ZwDRkJi69811xgIXXfdU9HSLX0Th+ILrHj8qfL/5wzamsFtQg==
 
 axios@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Vi har hatt en del bugs når vi oppgraderer familie-skjema knyttet til at man ender opp med ulike versjoner av familie-http. Fjerner familie-http fra package.json slik at man alltid bruker samme http-versjon som familie-skjema (som drar med seg denne pakken som en dependency).

I tillegg så jeg at vi har axe-core/react som en dependency, men den trenger bare være en dev dependency.

Samme PR i ba: https://github.com/navikt/familie-ba-sak-frontend/pull/3049

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Nei