### PR TITLE
Låser opp fritekst-funksjonalitet dersom det finnes fritekster for vedtaksperioden

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -68,6 +68,7 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
             ...vedtaksperiodeMedBegrunnelser.eøsBegrunnelser,
         ];
         return (
+            vedtaksperiodeMedBegrunnelser.fritekster.length > 0 ||
             (vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.UTBETALING &&
                 vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.ENDRET_UTBETALING) ||
             vedtaksperiodeInneholderEtterbetaling3MånedBegrunnelse() ||


### PR DESCRIPTION
Favro: [NAV-20163](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20163)

### 💰 Hva forsøker du å løse i denne PR'en
Dersom man legger til et kulepunkt med fritekst til en begrunnelse på en vedtaksperiode, og man fjerner begrunnelsen, blir friteksten liggene og saksbehandler har ingen mulighet til å endre/fjerne teksten som er lagt inn.

For å hindre at det kun ligger fritekster på en vedtaksperiode, ligger det validering i backend som stanser videre saksbehandling i disse tilfellene. Vi har nå flere saker som blir hindret fra videre saksbehandling på grunn av dette.

Som et første steg mot å få løst opp i problemet, legger jeg her til funksjonalitet som sørger for at fritekster alltid kan redigeres/fjernes dersom vedtaksperioden har tilknyttede fritekster. Da kan saksbehandler få rettet opp i feilmeldingen som vises ved godkjenning/underkjenning av vedtak.

Steg 2 blir å justere logikk i backend for oppdatering av fritekster ved fjerning av begrunnelser. Dersom ingen av de valgte begrunnelsene støtter fritekst burde alle fritekster slettes fra vedtaksperioden. Tilsvarende dersom ingen begrunnelser er valgt.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
