### PR TITLE
Chore: skriv om redirect proxy så vi alltid har kontroll på basePath

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -17,7 +17,7 @@ const Environment = () => {
             buildPath: 'frontend_development',
             namespace: 'local',
             proxyUrl: 'https://familie-kontantstotte-sak.intern.dev.nav.no/api',
-            familieTilbakeUrl: 'https://familie-tilbake.intern.dev.nav.no',
+            familieTilbakeUrl: 'https://familie-tilbake-frontend.intern.dev.nav.no',
             familieKlageUrl: 'https://familie-klage.intern.dev.nav.no',
         };
     } else if (process.env.ENV === 'e2e') {

--- a/src/backend/proxy.ts
+++ b/src/backend/proxy.ts
@@ -32,11 +32,11 @@ export const doProxy: any = () => {
 export const doRedirectProxy = () => {
     return (req: Request, res: Response) => {
         const urlKey = Object.keys(redirectRecords).find(k => req.originalUrl.includes(k));
-        let newUrl;
         if (urlKey) {
-            newUrl = req.originalUrl.replace(urlKey, redirectRecords[urlKey]);
+            const basePath = redirectRecords[urlKey];
+            const path = req.originalUrl.replace(urlKey, '');
             stdoutLogger.info(`Redirect ${urlKey} -> ${redirectRecords[urlKey]}`);
-            res.redirect(newUrl);
+            res.redirect(basePath + path);
         } else {
             console.log(`Ustøttet redirect: ${req.originalUrl}`);
             res.sendStatus(404);


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20227

Fikser opp denne CodeQL-feilen: https://github.com/navikt/familie-ks-sak-frontend/security/code-scanning/1

For å sørge for at vi alltid har kontroll på hvilket domene vi redirecter til skriver jeg om redirect-proxy. Sånn koden var tidligere kunne man i teorien ha klart å redirecte til et annet domene, men med den nye måten å skrive det på så vil basePath alltid være noe vi selv har definert opp i koden.

Tilsvarende PR i ba-sak-frontend: https://github.com/navikt/familie-ba-sak-frontend/pull/3100

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Testet manuelt

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei