### PR TITLE
Tar i bruk node 20 i workflows og dockerfile

### DIFF
--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: yarn
           registry-url: "https://npm.pkg.github.com"
       - name: Yarn install

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: yarn
           registry-url: "https://npm.pkg.github.com"
       - name: Yarn install

--- a/.github/workflows/build_n_deploy_rett_i_prod.yaml
+++ b/.github/workflows/build_n_deploy_rett_i_prod.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: yarn
           registry-url: "https://npm.pkg.github.com"
       - name: Yarn install

--- a/.github/workflows/build_pr.yaml
+++ b/.github/workflows/build_pr.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: yarn
           registry-url: "https://npm.pkg.github.com"
       - name: Yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM gcr.io/distroless/nodejs20-debian12:nonroot
 
-WORKDIR /var/server
+#WORKDIR /var/server
 
-COPY assets ./assets
-COPY backend ./backend
-COPY frontend_production ./frontend_production
+COPY --chown=nonroot:nonroot assets ./assets
+COPY --chown=nonroot:nonroot backend ./backend
+COPY --chown=nonroot:nonroot frontend_production ./frontend_production
 
 # Må kopiere package.json og node_modules for at backend skal fungere. Backend henter avhengigheter runtime fra node_modules, og package.json trengs for at 'import' statements skal fungere.
-COPY node_modules ./node_modules
-COPY package.json .
+COPY --chown=nonroot:nonroot node_modules ./node_modules
+COPY --chown=nonroot:nonroot package.json .
 
 CMD ["--import=./backend/backend/register.js", "--es-module-specifier-resolution=node", "backend/backend/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs:18
+FROM gcr.io/distroless/nodejs20-debian12
 USER root
 USER apprunner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY frontend_production ./frontend_production
 COPY node_modules ./node_modules
 COPY package.json .
 
-CMD ["--import=./backend/backend/register.js --es-module-specifier-resolution=node", "backend/backend/server.js"]
+CMD ["--import=./backend/backend/register.js", "--es-module-specifier-resolution=node", "backend/backend/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12
+FROM gcr.io/distroless/nodejs20-debian12:nonroot
 
 COPY assets ./assets
 COPY backend ./backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12
-USER root
-USER apprunner
+FROM gcr.io/distroless/nodejs20-debian12:nonroot
 
 COPY assets ./assets
 COPY backend ./backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM gcr.io/distroless/nodejs20-debian12:nonroot
 
-#WORKDIR /var/server
+WORKDIR /app
 
-COPY --chown=nonroot:nonroot assets ./assets
-COPY --chown=nonroot:nonroot backend ./backend
-COPY --chown=nonroot:nonroot frontend_production ./frontend_production
+COPY assets ./assets
+COPY backend ./backend
+COPY frontend_production ./frontend_production
 
 # Må kopiere package.json og node_modules for at backend skal fungere. Backend henter avhengigheter runtime fra node_modules, og package.json trengs for at 'import' statements skal fungere.
-COPY --chown=nonroot:nonroot node_modules ./node_modules
-COPY --chown=nonroot:nonroot package.json .
+COPY node_modules ./node_modules
+COPY package.json .
 
 CMD ["--import=./backend/backend/register.js", "--es-module-specifier-resolution=node", "backend/backend/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY frontend_production ./frontend_production
 COPY node_modules ./node_modules
 COPY package.json .
 
-CMD ["--es-module-specifier-resolution=node", "backend/backend/server.js"]
+CMD ["--import=./backend/backend/register.ts --es-module-specifier-resolution=node", "backend/backend/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12:nonroot
+FROM gcr.io/distroless/nodejs20-debian12
 
 COPY assets ./assets
 COPY backend ./backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM gcr.io/distroless/nodejs20-debian12:nonroot
 
+WORKDIR /var/server
+
 COPY assets ./assets
 COPY backend ./backend
 COPY frontend_production ./frontend_production

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY frontend_production ./frontend_production
 COPY node_modules ./node_modules
 COPY package.json .
 
-CMD ["--import=./backend/backend/register.ts --es-module-specifier-resolution=node", "backend/backend/server.js"]
+CMD ["--import=./backend/backend/register.js --es-module-specifier-resolution=node", "backend/backend/server.js"]

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "author": "Team BAKS",
   "license": "MIT",
   "scripts": {
-    "start": "NODE_ENV=production node --loader ts-node/esm --es-module-specifier-resolution=node backend/backend/server.js",
-    "start:dev": "tsc -p tsconfig.backend.json && NODE_ENV=development node --loader ts-node/esm --es-module-specifier-resolution=node backend/backend/server.js",
+    "start": "NODE_ENV=production node --import=./backend/backend/register.js --es-module-specifier-resolution=node backend/backend/server.js",
+    "start:dev": "tsc -p tsconfig.backend.json && NODE_ENV=development node --import=./backend/backend/register.js --es-module-specifier-resolution=node backend/backend/server.js",
     "build": "yarn build:prod",
     "build:prod": "tsc -p tsconfig.backend.json && NODE_ENV=production webpack --config ./src/webpack/webpack.prod.js",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@types/deep-equal": "^1.0.1",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.8",
-    "@types/node": "^20.11.6",
+    "@types/node": "^20.12.4",
     "@types/react": "^18.2.48",
     "@types/react-collapse": "^5.0.1",
     "@types/react-dom": "^18.2.18",

--- a/src/backend/register.ts
+++ b/src/backend/register.ts
@@ -1,0 +1,6 @@
+// Fjerner warningen: 'ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`'
+
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register('ts-node/esm', pathToFileURL('./'));

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -15,10 +15,10 @@ import type { IApp } from '@navikt/familie-backend';
 import { default as backend, ensureAuthenticated, envVar } from '@navikt/familie-backend';
 import { logInfo } from '@navikt/familie-logging';
 
-import { sessionConfig } from './config';
-import { prometheusTellere } from './metrikker';
-import { attachToken, doProxy, doRedirectProxy } from './proxy';
-import setupRouter from './router';
+import { sessionConfig } from './config.js';
+import { prometheusTellere } from './metrikker.js';
+import { attachToken, doProxy, doRedirectProxy } from './proxy.js';
+import setupRouter from './router.js';
 import webpackDevConfig from '../webpack/webpack.dev';
 
 const port = 8000;

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -19,7 +19,7 @@ import { sessionConfig } from './config.js';
 import { prometheusTellere } from './metrikker.js';
 import { attachToken, doProxy, doRedirectProxy } from './proxy.js';
 import setupRouter from './router.js';
-import webpackDevConfig from '../webpack/webpack.dev';
+import webpackDevConfig from '../webpack/webpack.dev.js';
 
 const port = 8000;
 

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -15,11 +15,11 @@ import type { IApp } from '@navikt/familie-backend';
 import { default as backend, ensureAuthenticated, envVar } from '@navikt/familie-backend';
 import { logInfo } from '@navikt/familie-logging';
 
-import { sessionConfig } from './config.js';
-import { prometheusTellere } from './metrikker.js';
-import { attachToken, doProxy, doRedirectProxy } from './proxy.js';
-import setupRouter from './router.js';
-import webpackDevConfig from '../webpack/webpack.dev.js';
+import { sessionConfig } from './config';
+import { prometheusTellere } from './metrikker';
+import { attachToken, doProxy, doRedirectProxy } from './proxy';
+import setupRouter from './router';
+import webpackDevConfig from '../webpack/webpack.dev';
 
 const port = 8000;
 

--- a/tsconfig.backend.json
+++ b/tsconfig.backend.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "allowJs": true,
         "skipLibCheck": true,
+        "module": "esnext",
         "outDir": "backend",
         "rootDir": "./src",
         "resolveJsonModule": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,10 +2718,10 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^20.11.6":
-  version "20.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.7.tgz#cb49aedd758c978c30806d0c38b520ed2a3df6e0"
-  integrity sha512-GPmeN1C3XAyV5uybAf4cMLWT9fDWcmQhZVtMFu7OR32WjrqGG+Wnk2V1d0bmtUyE/Zy1QJ9BxyiTih9z8Oks8A==
+"@types/node@^20.12.4":
+  version "20.12.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.4.tgz#af5921bd75ccdf3a3d8b3fa75bf3d3359268cd11"
+  integrity sha512-E+Fa9z3wSQpzgYQdYmme5X3OTuejnnTx88A6p6vkkJosR3KBz+HpE3kqNm98VE6cfLFcISx7zW7MsJkH6KwbTw==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi benytter node 18 i bygg og i `Dockerfile` og det er på tide å oppgradere til node 20 LTS. Oppgraderer derfor til node 20 i alle workflows, bumper @types/node til siste versjon og bruker `gcr.io/distroless/nodejs20-debian12:nonroot` i `Dockerfile`.

Har i tillegg byttet ut
```
--loader ts-node/esm
```

med fila `register.ts` og kommandoen:
```
--import=./backend/backend/register.js
```
 som gir samme resultat, men som ikke gir oss warnings ved oppstart.

Nå når vi kjører med `nonroot` må vi bruke `WORKDIR /app` for å få riktige tilganger til å kjøre opp appen. Ref: https://github.com/navikt/security-playbook/blob/main/docs/07-sikker-utvikling/containere.md

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Testet OK i preprod.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
