### PR TITLE
Fix forhåndsvisning av vedtak brev lokalt

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -123,11 +123,6 @@ const OppsummeringVedtakInnhold: React.FunctionComponent<IOppsummeringVedtakInnh
             />
             {visDokumentModal && (
                 <PdfVisningModal
-                    onRequestOpen={() => {
-                        if (hentetDokument.status !== RessursStatus.HENTER) {
-                            hentVedtaksbrev();
-                        }
-                    }}
                     onRequestClose={() => {
                         settVisDokumentModal(false);
                         nullstillDokument();
@@ -193,7 +188,10 @@ const OppsummeringVedtakInnhold: React.FunctionComponent<IOppsummeringVedtakInnh
                     id={'forhandsvis-vedtaksbrev'}
                     variant={'secondary'}
                     size={'medium'}
-                    onClick={() => settVisDokumentModal(!visDokumentModal)}
+                    onClick={() => {
+                        settVisDokumentModal(true);
+                        hentVedtaksbrev();
+                    }}
                     loading={hentetDokument.status === RessursStatus.HENTER}
                     icon={<FileContent aria-hidden />}
                 >


### PR DESCRIPTION
Når vi kjører appen lokalt fører <React.StrictMode> til at alle komponenter rendres 2 ganger. I mange tilfeller fører dette til at backend-kall kjøres 2 ganger. I mange tilfeller går det bra at vi kjører kallende 2 ganger, men for forhåndsvisning av brev feiler det andre kallet og vi får ikke sett forhåndsvisningen.

Endrer her til at vi henter forhåndsvisning ved klikk på knapp fremfor som en side-effect av at vi oppdaterer staten til komponenten. Da kjøres hent-forhåndsvisning 1 gang og forhåndsvisning vises som forventet.

Gjort i BA-sak her: https://github.com/navikt/familie-ba-sak-frontend/pull/3128