### PR TITLE
Endrer på spørsmål og validering av barnets alder vilkåret til å være avhengig av regelsett

### DIFF
--- a/src/frontend/context/Vilkårsvurdering/vilkårsvurdering.ts
+++ b/src/frontend/context/Vilkårsvurdering/vilkårsvurdering.ts
@@ -92,6 +92,7 @@ export const mapFraRestPersonResultatTilPersonResultat = (
                                     antallTimer: vilkårResultat.antallTimer,
                                     søkerHarMeldtFraOmBarnehageplass:
                                         vilkårResultat.søkerHarMeldtFraOmBarnehageplass,
+                                    regelsett: vilkårResultat.regelsett,
                                 };
                             }
                         )

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/BarnehageplassContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/BarnehageplassContext.ts
@@ -73,7 +73,7 @@ export const useBarnehageplass = (vilkår: IVilkårResultat, person: IGrunnlagPe
             søkerHarMeldtFraOmBarnehageplass: søkerHarMeldtFraOmBarnehageplass.verdi,
         },
         valideringsfunksjon: (felt, avhengigheter) =>
-            erPeriodeGyldig(felt, VilkårType.BARNEHAGEPLASS, avhengigheter),
+            erPeriodeGyldig(felt, VilkårType.BARNEHAGEPLASS, vilkår.regelsett, avhengigheter),
     });
 
     const felter = {

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
@@ -10,7 +10,7 @@ import { useVilkårSkjema } from '../../VilkårSkjemaContext';
 
 type BarnetsAlderProps = IVilkårSkjemaBaseProps;
 
-const hentSpørsmålBasertPåREgelsett = (regelsett: VilkårRegelsett) => {
+const hentSpørsmålBasertPåRegelsett = (regelsett: VilkårRegelsett) => {
     switch (regelsett) {
         case VilkårRegelsett.LOV_AUGUST_2021:
             return 'Er barnet mellom 1 og 2 år eller adoptert?';
@@ -28,7 +28,7 @@ export const BarnetsAlder: React.FC<BarnetsAlderProps> = ({
 }: BarnetsAlderProps) => {
     const { felter } = useBarnetsAlder(vilkårResultat, person);
     const vilkårSkjemaContext = useVilkårSkjema(vilkårResultat, felter, person, toggleForm);
-    const spørsmål = hentSpørsmålBasertPåREgelsett(vilkårResultat.regelsett);
+    const spørsmål = hentSpørsmålBasertPåRegelsett(vilkårResultat.regelsett);
 
     return (
         <VilkårSkjema

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
@@ -1,11 +1,23 @@
 import React from 'react';
 
+import { Label, Radio, RadioGroup } from '@navikt/ds-react';
+
 import { muligeUtdypendeVilkårsvurderinger, useBarnetsAlder } from './BarnetsAlderContext';
+import { Resultat, VilkårRegelsett } from '../../../../../../typer/vilkår';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
 
 type BarnetsAlderProps = IVilkårSkjemaBaseProps;
+
+const hentSpørsmålBasertPåREgelsett = (regelsett: VilkårRegelsett) => {
+    switch (regelsett) {
+        case VilkårRegelsett.LOV_AUGUST_2021:
+            return 'Er barnet mellom 1 og 2 år eller adoptert?';
+        case VilkårRegelsett.LOV_AUGUST_2024:
+            return 'Er barnet mellom 13 og 19 måneder eller adoptert?';
+    }
+};
 
 export const BarnetsAlder: React.FC<BarnetsAlderProps> = ({
     vilkårResultat,
@@ -16,17 +28,57 @@ export const BarnetsAlder: React.FC<BarnetsAlderProps> = ({
 }: BarnetsAlderProps) => {
     const { felter } = useBarnetsAlder(vilkårResultat, person);
     const vilkårSkjemaContext = useVilkårSkjema(vilkårResultat, felter, person, toggleForm);
+    const spørsmål = hentSpørsmålBasertPåREgelsett(vilkårResultat.regelsett);
+
     return (
         <VilkårSkjema
             vilkårSkjemaContext={vilkårSkjemaContext}
             visVurderesEtter={false}
-            visSpørsmål={true}
+            visSpørsmål={false}
             muligeUtdypendeVilkårsvurderinger={muligeUtdypendeVilkårsvurderinger}
             vilkårResultat={vilkårResultat}
             vilkårFraConfig={vilkårFraConfig}
             toggleForm={toggleForm}
             person={person}
             lesevisning={lesevisning}
-        />
+        >
+            <RadioGroup
+                readOnly={lesevisning}
+                value={vilkårSkjemaContext.skjema.felter.resultat.verdi}
+                legend={<Label>{spørsmål}</Label>}
+                error={
+                    vilkårSkjemaContext.skjema.visFeilmeldinger
+                        ? vilkårSkjemaContext.skjema.felter.resultat.feilmelding
+                        : ''
+                }
+            >
+                <Radio
+                    name={`${vilkårResultat.vilkårType}_${vilkårResultat.id}`}
+                    value={Resultat.OPPFYLT}
+                    onChange={() => {
+                        vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
+                            Resultat.OPPFYLT
+                        );
+                        vilkårSkjemaContext.skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
+                            false
+                        );
+                        vilkårSkjemaContext.skjema.felter.avslagBegrunnelser.validerOgSettFelt([]);
+                    }}
+                >
+                    Ja
+                </Radio>
+                <Radio
+                    name={`${vilkårResultat.vilkårType}_${vilkårResultat.id}`}
+                    value={Resultat.IKKE_OPPFYLT}
+                    onChange={() =>
+                        vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
+                            Resultat.IKKE_OPPFYLT
+                        )
+                    }
+                >
+                    Nei
+                </Radio>
+            </RadioGroup>
+        </VilkårSkjema>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderContext.ts
@@ -60,7 +60,7 @@ export const useBarnetsAlder = (vilkår: IVilkårResultat, person: IGrunnlagPers
                 utdypendeVilkårsvurdering: utdypendeVilkårsvurdering.verdi,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(felt, VilkårType.BARNETS_ALDER, avhengigheter),
+                erPeriodeGyldig(felt, VilkårType.BARNETS_ALDER, vilkår.regelsett, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BorMedSøker/BorMedSøkerContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BorMedSøker/BorMedSøkerContext.ts
@@ -64,7 +64,7 @@ export const useBorMedSøker = (vilkår: IVilkårResultat, person: IGrunnlagPers
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(felt, VilkårType.BOR_MED_SØKER, avhengigheter),
+                erPeriodeGyldig(felt, VilkårType.BOR_MED_SØKER, vilkår.regelsett, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiketContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiketContext.ts
@@ -66,7 +66,7 @@ export const useBosattIRiket = (vilkår: IVilkårResultat, person: IGrunnlagPers
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(felt, VilkårType.BOSATT_I_RIKET, avhengigheter),
+                erPeriodeGyldig(felt, VilkårType.BOSATT_I_RIKET, vilkår.regelsett, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOppholdContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOppholdContext.ts
@@ -58,7 +58,7 @@ export const useLovligOpphold = (vilkår: IVilkårResultat, person: IGrunnlagPer
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(felt, VilkårType.LOVLIG_OPPHOLD, avhengigheter),
+                erPeriodeGyldig(felt, VilkårType.LOVLIG_OPPHOLD, vilkår.regelsett, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Medlemskap/MedlemskapContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Medlemskap/MedlemskapContext.ts
@@ -58,7 +58,7 @@ export const useMedlemskap = (vilkår: IVilkårResultat, person: IGrunnlagPerson
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(felt, VilkårType.MEDLEMSKAP, avhengigheter),
+                erPeriodeGyldig(felt, VilkårType.MEDLEMSKAP, vilkår.regelsett, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelderContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelderContext.ts
@@ -53,7 +53,8 @@ export const useMedlemskapAnnenForelder = (vilkår: IVilkårResultat, person: IG
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
                 erMedlemskapAnnenForelderVilkår: true,
             },
-            valideringsfunksjon: erPeriodeGyldig,
+            valideringsfunksjon: (felt, avhengigheter) =>
+                erPeriodeGyldig(felt, vilkår.regelsett, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelderValidering.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelderValidering.ts
@@ -1,16 +1,23 @@
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { ok } from '@navikt/familie-skjema';
 
+import type { VilkårRegelsett } from '../../../../../../typer/vilkår';
 import { Resultat, VilkårType } from '../../../../../../typer/vilkår';
 import type { IIsoDatoPeriode } from '../../../../../../utils/dato';
 import { erPeriodeGyldig as erPeriodeGyldigDefault } from '../../../../../../utils/validators';
 
 export const erPeriodeGyldig = (
     felt: FeltState<IIsoDatoPeriode>,
+    regelsett: VilkårRegelsett,
     avhengigheter?: Avhengigheter
 ): FeltState<IIsoDatoPeriode> => {
     if (avhengigheter && avhengigheter.resultat.verdi === Resultat.IKKE_AKTUELT) {
         return ok(felt);
     }
-    return erPeriodeGyldigDefault(felt, VilkårType.MEDLEMSKAP_ANNEN_FORELDER, avhengigheter);
+    return erPeriodeGyldigDefault(
+        felt,
+        VilkårType.MEDLEMSKAP_ANNEN_FORELDER,
+        regelsett,
+        avhengigheter
+    );
 };

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjemaContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjemaContext.ts
@@ -80,6 +80,7 @@ export const useVilkårSkjema = <T extends IVilkårSkjemaContext>(
                     søkerHarMeldtFraOmBarnehageplass: skjema.felter.søkerHarMeldtFraOmBarnehageplass
                         ? skjema.felter.søkerHarMeldtFraOmBarnehageplass.verdi
                         : undefined,
+                    regelsett: vilkår.regelsett,
                 },
             };
             vilkårsvurderingApi.lagreVilkår(

--- a/src/frontend/typer/vilkår.ts
+++ b/src/frontend/typer/vilkår.ts
@@ -37,6 +37,11 @@ export enum Regelverk {
     EØS_FORORDNINGEN = 'EØS_FORORDNINGEN',
 }
 
+export enum VilkårRegelsett {
+    LOV_AUGUST_2021 = 'LOV_AUGUST_2021',
+    LOV_AUGUST_2024 = 'LOV_AUGUST_2024',
+}
+
 // Vilkårsvurdering typer for ui
 export interface IPersonResultat {
     personIdent: string;
@@ -73,6 +78,7 @@ export interface IVilkårResultat {
     utdypendeVilkårsvurderinger: UtdypendeVilkårsvurdering[];
     antallTimer?: number;
     søkerHarMeldtFraOmBarnehageplass?: boolean;
+    regelsett: VilkårRegelsett;
 }
 
 // Vilkårsvurdering typer for api
@@ -111,6 +117,7 @@ export interface IRestVilkårResultat {
     utdypendeVilkårsvurderinger: UtdypendeVilkårsvurdering[];
     antallTimer: number | undefined;
     søkerHarMeldtFraOmBarnehageplass?: boolean;
+    regelsett: VilkårRegelsett;
 }
 
 export interface IRestAnnenVurdering {
@@ -185,10 +192,10 @@ export const vilkårConfig: Record<VilkårType, IVilkårConfig> = {
         parterDetteGjelderFor: [PersonType.SØKER],
     },
     BARNETS_ALDER: {
-        beskrivelse: 'Barn mellom 1 og 2 år eller adoptert',
+        beskrivelse: 'Barnets alder',
         key: 'BARNETS_ALDER',
         tittel: 'Barnets alder',
-        spørsmål: () => 'Er barnet mellom 1 og 2 år eller adoptert?',
+        spørsmål: (spørsmål?: string) => `${spørsmål}`,
         parterDetteGjelderFor: [PersonType.BARN],
     },
 };

--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -8,7 +8,7 @@ import generator from '../../testverktøy/fnr/fnr-generator';
 import type { IGrunnlagPerson } from '../../typer/person';
 import { PersonType } from '../../typer/person';
 import { Målform } from '../../typer/søknad';
-import { Resultat, VilkårType } from '../../typer/vilkår';
+import { Resultat, VilkårRegelsett, VilkårType } from '../../typer/vilkår';
 import type { IIsoDatoPeriode } from '../dato';
 import { nyIsoDatoPeriode } from '../dato';
 import { erPeriodeGyldig, erResultatGyldig, identValidator } from '../validators';
@@ -38,10 +38,15 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('400220', undefined)
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: false,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual('Ugyldig f.o.m.');
     });
@@ -50,10 +55,15 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2020-06-17', '400220')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: false,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual('Ugyldig t.o.m.');
     });
@@ -62,10 +72,15 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode(undefined, undefined)
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: false,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual('F.o.m. må settes før du kan gå videre');
     });
@@ -74,10 +89,15 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode(undefined, '2010-05-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: true,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: true,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual(
             'F.o.m. må settes eller t.o.m. må fjernes før du kan gå videre'
@@ -88,10 +108,15 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode(undefined, undefined)
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: true,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: true,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
     });
 
@@ -99,10 +124,15 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2010-06-17', '2010-01-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: true,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: true,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual('F.o.m må settes tidligere enn t.o.m');
     });
@@ -111,10 +141,15 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('1999-05-17', '2018-05-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: false,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual(
             'Du kan ikke legge til periode før barnets fødselsdato'
@@ -125,10 +160,15 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2000-05-17', '2021-05-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture({ dødsfallDato: '2020-12-12' }),
-            erEksplisittAvslagPåSøknad: true,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture({ dødsfallDato: '2020-12-12' }),
+                erEksplisittAvslagPåSøknad: true,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual(
             'Du kan ikke sette til og med dato etter dødsfalldato'
@@ -139,10 +179,15 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2020-12-12', '2020-12-12')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: false,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual('F.o.m må settes tidligere enn t.o.m');
     });
@@ -151,24 +196,53 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2020-12-12', '2020-12-12')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture({ dødsfallDato: '2020-12-12' }),
-            erEksplisittAvslagPåSøknad: false,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture({ dødsfallDato: '2020-12-12' }),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
     });
 
-    test('Periode med etter barnets fødselsdato pluss 2 år gir feil på BarnetsAlder-vilkåret', () => {
+    test('Periode med etter barnets fødselsdato pluss 2 år gir feil på BarnetsAlder-vilkåret dersom regelsett er LOV_AUGUST_2021', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2001-05-17', '2018-05-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: false,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.BARNETS_ALDER,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual(
             'T.o.m datoen må være lik barnets 2 års dag'
+        );
+    });
+
+    test('Periode med etter barnets fødselsdato pluss 19 måneder gir feil på BarnetsAlder-vilkåret dersom regelsett er LOV_AUGUST_2024', () => {
+        const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
+            nyIsoDatoPeriode('2001-06-17', '2018-05-17')
+        );
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.BARNETS_ALDER,
+            VilkårRegelsett.LOV_AUGUST_2024,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
+        expect(valideringsresultat.feilmelding).toEqual(
+            'T.o.m datoen må være lik datoen barnet fyller 19 måneder'
         );
     });
 
@@ -176,21 +250,47 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2001-05-17', '2018-05-18')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: false,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.LOVLIG_OPPHOLD,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
     });
 
-    test('Periode med innenfor 1-2 år gir ok på BarnetsAlder-vilkåret', () => {
+    test('Periode med innenfor 1-2 år gir ok på BarnetsAlder-vilkåret dersom regelsett er LOV_AUGUST_2021', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2001-05-17', '2002-05-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, {
-            person: grunnlagPersonFixture(),
-            erEksplisittAvslagPåSøknad: false,
-        });
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.BARNETS_ALDER,
+            VilkårRegelsett.LOV_AUGUST_2021,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
+    });
+
+    test('Periode med innenfor 13-19 måneder gir ok på BarnetsAlder-vilkåret dersom regelsett er LOV_AUGUST_2024', () => {
+        const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
+            nyIsoDatoPeriode('2001-06-17', '2001-12-17')
+        );
+        const valideringsresultat = erPeriodeGyldig(
+            periode,
+            VilkårType.BARNETS_ALDER,
+            VilkårRegelsett.LOV_AUGUST_2024,
+            {
+                person: grunnlagPersonFixture(),
+                erEksplisittAvslagPåSøknad: false,
+            }
+        );
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
     });
 

--- a/src/frontend/utils/test/vilkårsvurdering/vilkår.mock.ts
+++ b/src/frontend/utils/test/vilkårsvurdering/vilkår.mock.ts
@@ -3,7 +3,7 @@ import type {
     IRestPersonResultat,
     IRestVilkårResultat,
 } from '../../../typer/vilkår';
-import { Regelverk, Resultat, VilkårType } from '../../../typer/vilkår';
+import { Regelverk, Resultat, VilkårRegelsett, VilkårType } from "../../../typer/vilkår";
 import { erIkkeGenereltVilkår } from '../../vilkår';
 
 interface IMockRestPersonResultat {
@@ -20,6 +20,7 @@ interface IRestResultaterMock {
     periodeFom?: string;
     periodeTom?: string;
     vurderesEtter?: Regelverk;
+    regelsett?: VilkårRegelsett;
 }
 
 const mockRestVilkårResultat = ({
@@ -30,6 +31,7 @@ const mockRestVilkårResultat = ({
     periodeFom = '2000-01-01',
     periodeTom = undefined,
     vurderesEtter = Regelverk.NASJONALE_REGLER,
+    regelsett = VilkårRegelsett.LOV_AUGUST_2021,
 }: IRestResultaterMock = {}): IRestVilkårResultat => ({
     id,
     vilkårType,
@@ -47,6 +49,7 @@ const mockRestVilkårResultat = ({
     utdypendeVilkårsvurderinger: [],
     antallTimer: undefined,
     søkerHarMeldtFraOmBarnehageplass: undefined,
+    regelsett: regelsett,
 });
 
 export const mockRestPersonResultat = ({

--- a/src/frontend/utils/test/vilkårsvurdering/vilkår.mock.ts
+++ b/src/frontend/utils/test/vilkårsvurdering/vilkår.mock.ts
@@ -3,7 +3,7 @@ import type {
     IRestPersonResultat,
     IRestVilkårResultat,
 } from '../../../typer/vilkår';
-import { Regelverk, Resultat, VilkårRegelsett, VilkårType } from "../../../typer/vilkår";
+import { Regelverk, Resultat, VilkårRegelsett, VilkårType } from '../../../typer/vilkår';
 import { erIkkeGenereltVilkår } from '../../vilkår';
 
 interface IMockRestPersonResultat {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18468

Avhengig av hva slags regelsett som er satt på vilkåret, så skal barnets alder ha forskjellig validering og forskjellig spørsmål.


![nytt regelverk 2024](https://github.com/navikt/familie-ks-sak-frontend/assets/110383605/5bb13e5e-6755-4ca3-a9b2-b67e0294829a)
![gammelt regelverk 2021](https://github.com/navikt/familie-ks-sak-frontend/assets/110383605/4cd72c4e-4101-48eb-bba0-2f24a334d3d6)
