### PR TITLE
Chore: fjern sentry/tracing fra dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,6 @@ updates:
       - dependency-name: "*"
         update-types: [ "version-update:semver-patch" ]
     groups:
-      sentry:
-        patterns:
-          - "@sentry/browser"
       typescript-eslint:
         patterns:
           - "@typescript-eslint/eslint-plugin"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,6 @@ updates:
     groups:
       sentry:
         patterns:
-          - "@sentry/tracing"
           - "@sentry/browser"
       typescript-eslint:
         patterns:


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Oppgraderte nettopp sentry til v8 hvor @sentry/tracing slettes som pakke. Glemte å fjerne pakken fra dependabot-config, så rydder det opp her.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
