### PR TITLE
Fiks validering for adopsjon sin totale oppfylte periode - barnets alder

### DIFF
--- a/src/frontend/context/Vilkårsvurdering/hentFeilIVilkårsvurdering.ts
+++ b/src/frontend/context/Vilkårsvurdering/hentFeilIVilkårsvurdering.ts
@@ -1,4 +1,4 @@
-import { addDays, isAfter, isBefore, isSameDay } from 'date-fns';
+import { addDays, isAfter, isSameDay } from 'date-fns';
 
 import type { FeiloppsummeringFeil } from '@navikt/familie-skjema';
 
@@ -13,6 +13,8 @@ import {
     parseFraOgMedDato,
     tidenesEnde,
     tidenesMorgen,
+    erFørEllerSammeDato,
+    erEtterEllerSammeDato,
 } from '../../utils/dato';
 
 export const hentFeilIVilkårsvurdering = (
@@ -126,18 +128,6 @@ const hentBarnetsalderVilkårManglerBarnehagePeriodeFeil = (
           ]
         : [];
 };
-
-/**
- * @returns true hvis dato1 er før eller samme dato som dato2
- */
-const erFørEllerSammeDato = (dato1: Date, dato2: Date) =>
-    isBefore(dato1, dato2) || isSameDay(dato1, dato2);
-
-/**
- * @returns true hvis dato1 er etter eller samme dato som dato2
- */
-const erEtterEllerSammeDato = (dato1: Date, dato2: Date) =>
-    isAfter(dato1, dato2) || isSameDay(dato1, dato2);
 
 const barnetsAlderPeriodeManglerBarnehagePeriode = (
     barnetsAlderPeriode: IIsoDatoPeriode,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderContext.ts
@@ -2,6 +2,7 @@ import { useFelt } from '@navikt/familie-skjema';
 
 import { erBegrunnelseGyldig, erUtdypendeVilkårsvurderingerGyldig } from './BarnetsAlderValidering';
 import { useApp } from '../../../../../../context/AppContext';
+import { useVilkårsvurdering } from '../../../../../../context/Vilkårsvurdering/VilkårsvurderingContext';
 import type { IGrunnlagPerson } from '../../../../../../typer/person';
 import { ToggleNavn } from '../../../../../../typer/toggles';
 import type { Begrunnelse } from '../../../../../../typer/vedtak';
@@ -9,7 +10,7 @@ import { UtdypendeVilkårsvurderingGenerell, VilkårType } from '../../../../../
 import type { UtdypendeVilkårsvurdering } from '../../../../../../typer/vilkår';
 import type { IVilkårResultat } from '../../../../../../typer/vilkår';
 import type { Regelverk as RegelverkType, Resultat } from '../../../../../../typer/vilkår';
-import type { IIsoDatoPeriode } from '../../../../../../utils/dato';
+import { type IIsoDatoPeriode } from '../../../../../../utils/dato';
 import {
     erAvslagBegrunnelserGyldig,
     erPeriodeGyldig,
@@ -31,6 +32,17 @@ export const useBarnetsAlder = (vilkår: IVilkårResultat, person: IGrunnlagPers
         erEksplisittAvslagPåSøknad: vilkår.erEksplisittAvslagPåSøknad ?? false,
         avslagBegrunnelser: vilkår.avslagBegrunnelser,
     };
+
+    const { personResultater } = useVilkårsvurdering();
+
+    const alleBarnetsAlderVilkårsResultater =
+        personResultater
+            .find(personResultat => person.personIdent === personResultat.personIdent)
+            ?.vilkårResultater.filter(
+                vilkårResultat => vilkårResultat.vilkårType === VilkårType.BARNETS_ALDER
+            ) || [];
+
+    const førsteLagredeFom = alleBarnetsAlderVilkårsResultater[0]?.periodeFom;
 
     const { toggles } = useApp();
     const erLovendringTogglePå = toggles[ToggleNavn.lovendring7MndNyeBehandlinger];
@@ -63,6 +75,7 @@ export const useBarnetsAlder = (vilkår: IVilkårResultat, person: IGrunnlagPers
                 person,
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
                 utdypendeVilkårsvurdering: utdypendeVilkårsvurdering.verdi,
+                førsteLagredeFom,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
                 erPeriodeGyldig(

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderContext.ts
@@ -11,6 +11,7 @@ import type { UtdypendeVilkårsvurdering } from '../../../../../../typer/vilkår
 import type { IVilkårResultat } from '../../../../../../typer/vilkår';
 import type { Regelverk as RegelverkType, Resultat } from '../../../../../../typer/vilkår';
 import { type IIsoDatoPeriode } from '../../../../../../utils/dato';
+import { sorterPåDato } from '../../../../../../utils/formatter';
 import {
     erAvslagBegrunnelserGyldig,
     erPeriodeGyldig,
@@ -35,14 +36,21 @@ export const useBarnetsAlder = (vilkår: IVilkårResultat, person: IGrunnlagPers
 
     const { personResultater } = useVilkårsvurdering();
 
-    const alleBarnetsAlderVilkårsResultater =
+    const alleBarnetsAlderVilkårsResultaterSortert =
         personResultater
             .find(personResultat => person.personIdent === personResultat.personIdent)
             ?.vilkårResultater.filter(
                 vilkårResultat => vilkårResultat.vilkårType === VilkårType.BARNETS_ALDER
-            ) || [];
+            )
+            .sort((a, b) => {
+                if (!a.periodeFom || !b.periodeFom) {
+                    return 1; //Perioder som ikke har fom skal sorteres sist i lista
+                } else {
+                    return sorterPåDato(b.periodeFom, a.periodeFom);
+                }
+            }) || [];
 
-    const førsteLagredeFom = alleBarnetsAlderVilkårsResultater[0]?.periodeFom;
+    const førsteLagredeFom = alleBarnetsAlderVilkårsResultaterSortert[0].periodeFom;
 
     const { toggles } = useApp();
     const erLovendringTogglePå = toggles[ToggleNavn.lovendring7MndNyeBehandlinger];

--- a/src/frontend/utils/dato/dato.ts
+++ b/src/frontend/utils/dato/dato.ts
@@ -1,4 +1,13 @@
-import { format, isValid, parseISO, startOfDay, startOfToday } from 'date-fns';
+import {
+    format,
+    isValid,
+    parseISO,
+    startOfDay,
+    startOfToday,
+    isBefore,
+    isAfter,
+    isSameDay,
+} from 'date-fns';
 
 import type { FeltState } from '@navikt/familie-skjema';
 import { feil, ok } from '@navikt/familie-skjema';
@@ -107,3 +116,15 @@ export const parseFraOgMedDato = (fom: IsoDatoString | undefined) =>
         isoString: fom,
         fallbackDate: tidenesMorgen,
     });
+
+/**
+ * @returns true hvis dato1 er før eller samme dato som dato2
+ */
+export const erFørEllerSammeDato = (dato1: Date, dato2: Date) =>
+    isBefore(dato1, dato2) || isSameDay(dato1, dato2);
+
+/**
+ * @returns true hvis dato1 er etter eller samme dato som dato2
+ */
+export const erEtterEllerSammeDato = (dato1: Date, dato2: Date) =>
+    isAfter(dato1, dato2) || isSameDay(dato1, dato2);

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -136,6 +136,8 @@ export const erPeriodeGyldig = (
                     return feil(felt, 'Du kan ikke legge til periode før barnets fødselsdato');
                 }
                 if (erBarnetsAlderVilkår) {
+                    const førsteLagredeFom = avhengigheter?.førsteLagredeFom;
+
                     const erAdopsjon = utdypendeVilkårsvurdering?.includes(
                         UtdypendeVilkårsvurderingGenerell.ADOPSJON
                     );
@@ -159,10 +161,13 @@ export const erPeriodeGyldig = (
                                 );
                             }
                         } else {
-                            if (tom && datoDifferanseMerEnnXAntallMåneder(fom, tom, 7)) {
+                            if (
+                                tom &&
+                                datoDifferanseMerEnnXAntallMåneder(førsteLagredeFom, tom, 7)
+                            ) {
                                 return feil(
                                     felt,
-                                    'Differansen mellom f.o.m datoen og t.o.m datoen kan ikke være mer enn 7 måneder'
+                                    'Differansen mellom tidligste f.o.m.-dato og t.o.m.-datoen kan ikke være mer enn 7 måneder'
                                 );
                             }
                         }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Når vi splitter opp barnets alder i flere perioder har vi i dag mulighet til å legge inn perioder som utgjør flere måneder med kontantstøtte for adopsjon enn det som er lovlig.

Gitt disse aldersperiodene:
<img width="1174" alt="image" src="https://github.com/navikt/familie-ks-sak-frontend/assets/3233286/ea102895-4b89-4361-bc57-594e29c178fe">

Får vi ut disse månedene med utbetaling:
<img width="1219" alt="image" src="https://github.com/navikt/familie-ks-sak-frontend/assets/3233286/b536881c-1ec7-4ec7-ba9f-c9bf3ce8d031">

<img width="1233" alt="image" src="https://github.com/navikt/familie-ks-sak-frontend/assets/3233286/746d95b9-c151-4f00-981d-0c00e43dbdd9">

Som jo er feil, vedkommende skulle jo maks få 7 måneder med utbetalinger, ikke 12.

Derfor legger vi på validering i frontend som gjør at man ikke kan velge mer enn 7 måneder fra første f.o.m.-dato på tvers av alle periodene.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ikke noe spesielt :)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Det finnes ikke tester for adopsjonsregelverket fra før av. Jeg skal se om jeg kan lage noen vettuge tester der. 

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei

### 👀 Screen shots
Bilde av valideringen:
<img width="1207" alt="image" src="https://github.com/navikt/familie-ks-sak-frontend/assets/3233286/8ce5d084-7a35-492a-a101-796f918f0a1c">
