### PR TITLE
Bug: tillatt å vise vedtaksperioder som er 2 mnd frem i tid

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
@@ -54,13 +54,13 @@ describe('VedtakBegrunnelserContext', () => {
 
         describe('Test filtrering av perioder frem i tid', () => {
             test(`Test at perioder med fom-dato før 2 mnd frem i tid returneres`, () => {
-                const enMndFremITidFom = addMonths(startOfMonth(dagensDato), 1);
-                const enMndFremITidTom = addMonths(endOfMonth(dagensDato), 1);
+                const toMndFremITidFom = addMonths(startOfMonth(dagensDato), 2);
+                const toMndFremITidTom = addMonths(endOfMonth(dagensDato), 2);
                 const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                     [
                         mockUtbetalingsperiode({
-                            fom: dateTilIsoDatoString(enMndFremITidFom),
-                            tom: dateTilIsoDatoString(enMndFremITidTom),
+                            fom: dateTilIsoDatoString(toMndFremITidFom),
+                            tom: dateTilIsoDatoString(toMndFremITidTom),
                         }),
                     ],
                     BehandlingResultat.INNVILGET,
@@ -69,15 +69,15 @@ describe('VedtakBegrunnelserContext', () => {
                 );
                 expect(perioder.length).toBe(1);
             });
-            test(`Test at perioder med fom-dato fra og med 2 mnd frem i tid ikke returneres`, () => {
-                const toMndFremITidFom = addMonths(startOfMonth(dagensDato), 2);
-                const toMndFremITidTom = addMonths(endOfMonth(dagensDato), 2);
+            test(`Test at perioder med fom-dato etter 2 mnd frem i tid ikke returneres`, () => {
+                const treMndFremITidFom = addMonths(startOfMonth(dagensDato), 3);
+                const treMndFremITidTom = addMonths(endOfMonth(dagensDato), 3);
 
                 const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                     [
                         mockUtbetalingsperiode({
-                            fom: dateTilIsoDatoString(toMndFremITidFom),
-                            tom: dateTilIsoDatoString(toMndFremITidTom),
+                            fom: dateTilIsoDatoString(treMndFremITidFom),
+                            tom: dateTilIsoDatoString(treMndFremITidTom),
                         }),
                     ],
                     BehandlingResultat.INNVILGET,

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
@@ -53,7 +53,7 @@ describe('VedtakBegrunnelserContext', () => {
         });
 
         describe('Test filtrering av perioder frem i tid', () => {
-            test(`Test at perioder med fom-dato før 2 mnd frem i tid returneres`, () => {
+            test(`Test at perioder med fom-dato før eller lik 2 mnd frem i tid returneres`, () => {
                 const toMndFremITidFom = addMonths(startOfMonth(dagensDato), 2);
                 const toMndFremITidTom = addMonths(endOfMonth(dagensDato), 2);
                 const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(

--- a/src/frontend/utils/vedtakUtils.ts
+++ b/src/frontend/utils/vedtakUtils.ts
@@ -1,4 +1,11 @@
-import { addMonths, differenceInMilliseconds, isAfter, isBefore, startOfMonth } from 'date-fns';
+import {
+    addMonths,
+    differenceInMilliseconds,
+    isAfter,
+    isBefore,
+    isSameMonth,
+    startOfMonth,
+} from 'date-fns';
 
 import {
     ABorderDanger,
@@ -48,7 +55,7 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
                             sisteVedtaksperiodeVisningDato,
                             vedtaksperiode.fom
                         )) ||
-                    erPeriodeMindreEnn2MndFramITid(vedtaksperiode.fom)
+                    erPeriode2MndFramITidEllerMindre(vedtaksperiode.fom)
                 );
             }
         });
@@ -73,11 +80,11 @@ const erPeriodeMindreEllerLikEnnSisteVedtaksperiodeVisningDato = (
     );
 };
 
-const erPeriodeMindreEnn2MndFramITid = (periodeFom: string | undefined) => {
+const erPeriode2MndFramITidEllerMindre = (periodeFom: string | undefined) => {
     const fom = isoStringTilDateMedFallback({ isoString: periodeFom, fallbackDate: tidenesMorgen });
     const toMånederFremITid = addMonths(startOfMonth(dagensDato), 2);
 
-    return isBefore(fom, toMånederFremITid);
+    return isBefore(fom, toMånederFremITid) || isSameMonth(fom, toMånederFremITid);
 };
 
 const harPeriodeBegrunnelse = (vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21790

Etter lovendringene forskyver vi annerledes og har da behov for å vise opphør og endringsperioder som er 2 mnd frem i tid. Feks for september 24 nå i juli 24.

Endrer nå til at vi nå ikke bare tillatter perioder _før_ 2 mnd, men også perioder som starter om 2 mnd.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Har avklart med Birgitte

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
