### PR TITLE
Legg til LOVENDRING_2024 som behandlingsårsak

### DIFF
--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -56,6 +56,7 @@ export enum BehandlingÅrsak {
     SATSENDRING = 'SATSENDRING',
     BARNEHAGELISTE = 'BARNEHAGELISTE',
     TEKNISK_ENDRING = 'TEKNISK_ENDRING',
+    LOVENDRING_2024 = 'LOVENDRING_2024',
 }
 
 export const behandlingÅrsak: Record<
@@ -71,6 +72,7 @@ export const behandlingÅrsak: Record<
     SATSENDRING: 'Satsendring',
     BARNEHAGELISTE: 'Barnehageliste',
     TEKNISK_ENDRING: 'Teknisk Endring',
+    LOVENDRING_2024: 'Lovendring 2024',
 
     /** De neste er revurderingsårsaker for tilbakekrevingsbehandlinger **/
     REVURDERING_KLAGE_NFP: 'Klage tilbakekreving',


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-21214

Vi ønsker å vise 'Lovendring 2024' som en behandlingsårsak.
Denne kan ikke velges av saksbehandlere.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
![image](https://github.com/user-attachments/assets/787796a2-9749-4d9d-9cf9-3171017c8d07)
