### PR TITLE
Filtrer bort sider for behandling lovendring

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
@@ -23,8 +23,7 @@ import { useTidslinje } from '../../../context/TidslinjeContext';
 import { utenlandskPeriodeBeløpFeilmeldingId } from '../../../context/UtenlandskPeriodeBeløp/UtenlandskPeriodeBeløpSkjemaContext';
 import { valutakursFeilmeldingId } from '../../../context/Valutakurs/ValutakursSkjemaContext';
 import useSakOgBehandlingParams from '../../../hooks/useSakOgBehandlingParams';
-import type { IBehandling } from '../../../typer/behandling';
-import { BehandlingSteg } from '../../../typer/behandling';
+import { BehandlingSteg, BehandlingÅrsak, type IBehandling } from '../../../typer/behandling';
 import type {
     IRestKompetanse,
     IRestUtenlandskPeriodeBeløp,
@@ -163,6 +162,10 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
 
     const harEøs = harKompetanser || harUtenlandskeBeløper || harValutakurser;
 
+    const skalViseNesteKnapp =
+        åpenBehandling.årsak !== BehandlingÅrsak.LOVENDRING_2024 ||
+        åpenBehandling.stegTilstand.some(steg => steg.behandlingSteg === BehandlingSteg.SIMULERING);
+
     return (
         <Skjemasteg
             senderInn={behandlingsstegSubmitressurs.status === RessursStatus.HENTER}
@@ -181,6 +184,7 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
             maxWidthStyle={'80rem'}
             feilmelding={hentFrontendFeilmelding(behandlingsstegSubmitressurs)}
             steg={BehandlingSteg.BEHANDLINGSRESULTAT}
+            skalViseNesteKnapp={skalViseNesteKnapp}
         >
             {personerMedUgyldigEtterbetalingsperiode.length > 0 && (
                 <StyledAlert variant={'warning'}>

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -1,6 +1,10 @@
 import { mapFraRestPersonResultatTilPersonResultat } from '../../../context/Vilkårsvurdering/vilkårsvurdering';
-import type { IBehandling } from '../../../typer/behandling';
-import { BehandlingSteg, BehandlingÅrsak, hentStegNummer } from '../../../typer/behandling';
+import {
+    BehandlingSteg,
+    BehandlingÅrsak,
+    hentStegNummer,
+    type IBehandling,
+} from '../../../typer/behandling';
 import type { IPersonResultat, IVilkårResultat } from '../../../typer/vilkår';
 import { Resultat } from '../../../typer/vilkår';
 import { formaterIdent } from '../../../utils/formatter';
@@ -83,13 +87,28 @@ export const sider: Record<SideId, ISide> = {
         href: 'simulering',
         navn: 'Simulering',
         steg: BehandlingSteg.SIMULERING,
+        visSide: (åpenBehandling: IBehandling) => {
+            const erLovendringUtenSimuleringsteg =
+                åpenBehandling.årsak === BehandlingÅrsak.LOVENDRING_2024 &&
+                åpenBehandling.stegTilstand.every(
+                    steg => steg.behandlingSteg !== BehandlingSteg.SIMULERING
+                );
+            return !erLovendringUtenSimuleringsteg;
+        },
     },
     VEDTAK: {
         href: 'vedtak',
         navn: 'Vedtak',
         steg: BehandlingSteg.VEDTAK,
         visSide: (åpenBehandling: IBehandling) => {
-            return åpenBehandling.årsak !== BehandlingÅrsak.SATSENDRING;
+            const erLovendringUtenVedtaksteg =
+                åpenBehandling.årsak === BehandlingÅrsak.LOVENDRING_2024 &&
+                åpenBehandling.stegTilstand.every(
+                    steg => steg.behandlingSteg !== BehandlingSteg.VEDTAK
+                );
+            return (
+                åpenBehandling.årsak !== BehandlingÅrsak.SATSENDRING && !erLovendringUtenVedtaksteg
+            );
         },
     },
 };

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -131,9 +131,15 @@ export const finnSideForBehandlingssteg = (behandling: IBehandling): ISide | und
     const steg = behandling.steg;
 
     if (hentStegNummer(steg) >= hentStegNummer(BehandlingSteg.VEDTAK)) {
-        return sider.VEDTAK.visSide && sider.VEDTAK.visSide(behandling)
-            ? sider.VEDTAK
-            : sider.SIMULERING;
+        if (sider.VEDTAK.visSide && sider.VEDTAK.visSide(behandling)) {
+            return sider.VEDTAK;
+        }
+
+        if (sider.SIMULERING.visSide && sider.SIMULERING.visSide(behandling)) {
+            return sider.SIMULERING;
+        }
+
+        return sider.BEHANDLINGRESULTAT;
     }
 
     const sideForSteg = Object.entries(sider).find(([_, side]) => side.steg === steg);


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: NAV-21214

For automatisk revurderinger med årsak lovendring 2024 gjennomføres ikke simulering- og vedtaksteget, dersom brev ikke skal sendes, og de sidene skal da heller ikke vises i behandlingen i frontenden.

- Sidene er fjernet i venstremenyen
- Neste-knapp vises ikke på behandlingsresultatsiden
- Automatisk navigering går til behandlingsresultatsiden dersom simuleringssteget ikke er gjennomført

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
![image](https://github.com/user-attachments/assets/a1279149-21a8-4420-b472-f308732e684f)
![image](https://github.com/user-attachments/assets/90ec8998-b46a-43cb-9613-d96e09512968)
 