### PR TITLE
Fikser visuell bug av endret utbetaling andel i lesevisning

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -286,32 +286,26 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     )}
                 </Feltmargin>
                 <Feltmargin>
-                    {erLesevisning ? (
-                        <>
-                            {skjema.felter.erEksplisittAvslagPåSøknad.verdi && (
-                                <BodyShort
-                                    className={classNames('skjemaelement', 'lese-felt')}
-                                    children={'Vurderingen er et avslag'}
-                                />
-                            )}
-                        </>
-                    ) : (
-                        <>
-                            {!skjema.felter.periodeSkalUtbetalesTilSøker.verdi && (
-                                <Checkbox
-                                    value={'Vurderingen er et avslag'}
-                                    checked={skjema.felter.erEksplisittAvslagPåSøknad.verdi}
-                                    onChange={event =>
-                                        skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
-                                            event.target.checked
-                                        )
-                                    }
-                                >
-                                    {'Vurderingen er et avslag'}
-                                </Checkbox>
-                            )}
-                        </>
-                    )}
+                    {erLesevisning
+                        ? skjema.felter.erEksplisittAvslagPåSøknad.verdi && (
+                              <BodyShort
+                                  className={classNames('skjemaelement', 'lese-felt')}
+                                  children={'Vurderingen er et avslag'}
+                              />
+                          )
+                        : !skjema.felter.periodeSkalUtbetalesTilSøker.verdi && (
+                              <Checkbox
+                                  value={'Vurderingen er et avslag'}
+                                  checked={skjema.felter.erEksplisittAvslagPåSøknad.verdi}
+                                  onChange={event =>
+                                      skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
+                                          event.target.checked
+                                      )
+                                  }
+                              >
+                                  {'Vurderingen er et avslag'}
+                              </Checkbox>
+                          )}
                 </Feltmargin>
 
                 <Feltmargin>

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -258,12 +258,6 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                             <BodyShort>
                                 {skjema.felter.periodeSkalUtbetalesTilSøker.verdi ? 'Ja' : 'Nei'}
                             </BodyShort>
-                            skjema.felter.erEksplisittAvslagPåSøknad.verdi && (
-                            <BodyShort
-                                className={classNames('skjemaelement', 'lese-felt')}
-                                children={'Vurderingen er et avslag'}
-                            />
-                            )
                         </>
                     ) : (
                         <RadioGroup
@@ -292,18 +286,31 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     )}
                 </Feltmargin>
                 <Feltmargin>
-                    {!skjema.felter.periodeSkalUtbetalesTilSøker.verdi && (
-                        <Checkbox
-                            value={'Vurderingen er et avslag'}
-                            checked={skjema.felter.erEksplisittAvslagPåSøknad.verdi}
-                            onChange={event =>
-                                skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
-                                    event.target.checked
-                                )
-                            }
-                        >
-                            {'Vurderingen er et avslag'}
-                        </Checkbox>
+                    {erLesevisning ? (
+                        <>
+                            {skjema.felter.erEksplisittAvslagPåSøknad.verdi && (
+                                <BodyShort
+                                    className={classNames('skjemaelement', 'lese-felt')}
+                                    children={'Vurderingen er et avslag'}
+                                />
+                            )}
+                        </>
+                    ) : (
+                        <>
+                            {!skjema.felter.periodeSkalUtbetalesTilSøker.verdi && (
+                                <Checkbox
+                                    value={'Vurderingen er et avslag'}
+                                    checked={skjema.felter.erEksplisittAvslagPåSøknad.verdi}
+                                    onChange={event =>
+                                        skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
+                                            event.target.checked
+                                        )
+                                    }
+                                >
+                                    {'Vurderingen er et avslag'}
+                                </Checkbox>
+                            )}
+                        </>
                     )}
                 </Feltmargin>
 


### PR DESCRIPTION
Favrokort:

Før:
<img width="631" alt="bug" src="https://github.com/user-attachments/assets/f0109b1d-cd57-408c-b611-6fdb3a8690c8">


Etter med avslag:
<img width="730" alt="Screenshot 2024-08-29 at 00 16 48" src="https://github.com/user-attachments/assets/2860da4d-2c07-4b0b-8525-31f69978dc48">


Etter uten avslag:
<img width="567" alt="Screenshot 2024-08-29 at 00 17 55" src="https://github.com/user-attachments/assets/04dfb3fd-df8e-431c-bd0d-7a11a1c65bef">
