### PR TITLE
Bugfix: ny funksjon for å parse dato som ikke kaster feil hvis dato er ugyldig

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
@@ -11,7 +11,7 @@ import { Resultat } from '../../../../../../typer/vilkår';
 import {
     datoForLovendringAugust24,
     type IIsoDatoPeriode,
-    isoStringTilDateEllerUndefined,
+    isoStringTilDateEllerUndefinedHvisUgyldigDato,
 } from '../../../../../../utils/dato';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
@@ -20,7 +20,7 @@ import { useVilkårSkjema } from '../../VilkårSkjemaContext';
 type BarnetsAlderProps = IVilkårSkjemaBaseProps;
 
 const hentSpørsmålForPeriode = (periode: IIsoDatoPeriode, erLovendringTogglePå: boolean) => {
-    const fraOgMedDato = isoStringTilDateEllerUndefined(periode.fom);
+    const fraOgMedDato = isoStringTilDateEllerUndefinedHvisUgyldigDato(periode.fom);
     const fraOgMedErFørLovendring =
         fraOgMedDato && isBefore(fraOgMedDato, datoForLovendringAugust24);
     if (fraOgMedErFørLovendring || !erLovendringTogglePå) {

--- a/src/frontend/utils/dato/dato.ts
+++ b/src/frontend/utils/dato/dato.ts
@@ -87,6 +87,15 @@ export const isoStringTilDate = (isoDatoString: IsoDatoString | IsoMånedString)
     return dato;
 };
 
+export const isoStringTilDateEllerUndefinedHvisUgyldigDato = (
+    isoDatoString: IsoDatoString | IsoMånedString | undefined
+): Date | undefined => {
+    if (isoDatoString === undefined) return undefined;
+    const dato = parseISO(isoDatoString);
+
+    return isValid(dato) ? dato : undefined;
+};
+
 interface IsoStringTilDateProps {
     isoString: IsoDatoString | IsoMånedString | undefined;
     fallbackDate: Date;
@@ -103,12 +112,6 @@ export const erIsoStringGyldig = (isoString?: IsoDatoString): boolean => {
 
     const dato = parseISO(isoString);
     return isValid(dato);
-};
-
-export const isoStringTilDateEllerUndefined = (
-    isoDatoString: IsoDatoString | undefined
-): Date | undefined => {
-    return isoDatoString ? isoStringTilDate(isoDatoString) : undefined;
 };
 
 export const parseTilOgMedDato = (tom: IsoDatoString | undefined) =>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Under testing oppdaget vi at det feiler hardt om man prøver å endre fra og med datoen på barnets alder-vilkåret fordi datoen var ugyldig mens man holdt på å skrive. Dette skjer fordi man parser fra og med datoen for å sjekke om den er før eller etter lovendringen i august 24, og inne i parse-funksjonen kaster man feil om datoen er ugyldig. Dette stedet hvor man sjekker fom datoen så trenger man ikke å kaste feil om det er en ugyldig dato, det holder å returnere undefined. Det er et annet sted i koden som faktisk tar seg av valideringen av datoen.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Syns ikke det er nødvendig

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
