### PR TITLE
Oppdatert feilmelding dersom saksbehandler ikke har tilgang til journalpost

### DIFF
--- a/src/frontend/komponenter/ManuellJournalfør/ManuellJournalfør.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/ManuellJournalfør.tsx
@@ -58,9 +58,17 @@ const ManuellJournalførContent: React.FC = () => {
             );
         case RessursStatus.FEILET:
         case RessursStatus.FUNKSJONELL_FEIL:
-        case RessursStatus.IKKE_TILGANG:
             return (
                 <Alert variant="error" children={dataForManuellJournalføring.frontendFeilmelding} />
+            );
+        case RessursStatus.IKKE_TILGANG:
+            return (
+                <Alert
+                    variant="error"
+                    children={
+                        'Kan ikke vise journalføringsoppgave. Personer relatert til journalpost har adressebeskyttelse. Krever ekstra tilganger.'
+                    }
+                />
             );
         default:
             return <div />;


### PR DESCRIPTION
Favro: [NAV-22361](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22361)

### 💰 Hva forsøker du å løse i denne PR'en
Sørger for at saksbehandler får en mer beskrivende feilmelding dersom de ikke har tilgang til journalpost.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

Jeg har ikke skrevet tester fordi:
Ingen funksjonell endring annet enn at `RessursStatus.INGEN_TILGANG` fører til spesifikk feilmelding.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://github.com/user-attachments/assets/a75b27bd-ed90-4d9e-809c-72bea54c9eac)
