### PR TITLE
Fjerner skjemavalidering og gjør feltene postnummer og poststed disablede når utenlandsk mottaker

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Fieldset, HStack, Select, Spacer, TextField, VStack } from '@navikt/ds-react';
+import { Alert, Fieldset, HStack, Select, Spacer, TextField, VStack } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
@@ -64,52 +64,6 @@ const BrevmottakerSkjema = ({ erLesevisning, skjema, navnErPreutfylt }: Props) =
                             skjema.felter.navn.validerOgSettFelt(event.target.value);
                         }}
                     />
-                    <TextField
-                        {...skjema.felter.adresselinje1.hentNavBaseSkjemaProps(
-                            skjema.visFeilmeldinger
-                        )}
-                        readOnly={erLesevisning}
-                        label={'Adresselinje 1'}
-                        onChange={(event): void => {
-                            skjema.felter.adresselinje1.validerOgSettFelt(event.target.value);
-                        }}
-                    />
-                    <TextField
-                        {...skjema.felter.adresselinje2.hentNavBaseSkjemaProps(
-                            skjema.visFeilmeldinger
-                        )}
-                        readOnly={erLesevisning}
-                        label={'Adresselinje 2 (valgfri)'}
-                        onChange={(event): void => {
-                            skjema.felter.adresselinje2.validerOgSettFelt(event.target.value);
-                        }}
-                    />
-                    <HStack>
-                        <StyledTextField
-                            {...skjema.felter.postnummer.hentNavBaseSkjemaProps(
-                                skjema.visFeilmeldinger
-                            )}
-                            readOnly={erLesevisning}
-                            label={'Postnummer'}
-                            onChange={(event): void => {
-                                skjema.felter.postnummer.validerOgSettFelt(event.target.value);
-                            }}
-                            $width={'10rem'}
-                        />
-                        <Spacer />
-                        <StyledTextField
-                            {...skjema.felter.poststed.hentNavBaseSkjemaProps(
-                                skjema.visFeilmeldinger
-                            )}
-                            readOnly={erLesevisning}
-                            label={'Poststed'}
-                            onChange={(event): void => {
-                                skjema.felter.poststed.validerOgSettFelt(event.target.value);
-                            }}
-                            $width={'19.5rem'}
-                        />
-                    </HStack>
-
                     <FamilieLandvelger
                         id={'land'}
                         value={
@@ -134,6 +88,71 @@ const BrevmottakerSkjema = ({ erLesevisning, skjema, navnErPreutfylt }: Props) =
                             skjema.felter.land.validerOgSettFelt(land.value);
                         }}
                     />
+                    {skjema.felter.land.verdi && (
+                        <>
+                            <TextField
+                                {...skjema.felter.adresselinje1.hentNavBaseSkjemaProps(
+                                    skjema.visFeilmeldinger
+                                )}
+                                readOnly={erLesevisning}
+                                label={'Adresselinje 1'}
+                                onChange={(event): void => {
+                                    skjema.felter.adresselinje1.validerOgSettFelt(
+                                        event.target.value
+                                    );
+                                }}
+                            />
+                            <TextField
+                                {...skjema.felter.adresselinje2.hentNavBaseSkjemaProps(
+                                    skjema.visFeilmeldinger
+                                )}
+                                readOnly={erLesevisning}
+                                label={'Adresselinje 2 (valgfri)'}
+                                onChange={(event): void => {
+                                    skjema.felter.adresselinje2.validerOgSettFelt(
+                                        event.target.value
+                                    );
+                                }}
+                            />
+                            {skjema.felter.land.verdi !== 'NO' && (
+                                <Alert variant="info">
+                                    Ved utenlandsk adresse skal postnummer og poststed legges i
+                                    adresselinjene.
+                                </Alert>
+                            )}
+                            <HStack>
+                                <StyledTextField
+                                    {...skjema.felter.postnummer.hentNavBaseSkjemaProps(
+                                        skjema.visFeilmeldinger
+                                    )}
+                                    readOnly={erLesevisning}
+                                    disabled={skjema.felter.land.verdi !== 'NO'}
+                                    label={'Postnummer'}
+                                    onChange={(event): void => {
+                                        skjema.felter.postnummer.validerOgSettFelt(
+                                            event.target.value
+                                        );
+                                    }}
+                                    $width={'10rem'}
+                                />
+                                <Spacer />
+                                <StyledTextField
+                                    {...skjema.felter.poststed.hentNavBaseSkjemaProps(
+                                        skjema.visFeilmeldinger
+                                    )}
+                                    readOnly={erLesevisning}
+                                    disabled={skjema.felter.land.verdi !== 'NO'}
+                                    label={'Poststed'}
+                                    onChange={(event): void => {
+                                        skjema.felter.poststed.validerOgSettFelt(
+                                            event.target.value
+                                        );
+                                    }}
+                                    $width={'19.5rem'}
+                                />
+                            </HStack>
+                        </>
+                    )}
                 </VStack>
             </Fieldset>
         </>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
-import { Button, Heading, HStack, Spacer } from '@navikt/ds-react';
+import { Alert, Button, Heading, HStack, Spacer } from '@navikt/ds-react';
 import { AFontWeightBold } from '@navikt/ds-tokens/dist/tokens';
 import CountryData from '@navikt/land-verktoy';
 
@@ -65,17 +65,23 @@ const BrevmottakerTabell = <T extends SkjemaBrevmottaker | IRestBrevmottaker>({
             <DefinitionList>
                 <dt>Navn</dt>
                 <dd>{mottaker.navn}</dd>
+                <dt>Land</dt>
+                <dd>{land.label}</dd>
                 <dt>Adresselinje 1</dt>
                 <dd>{mottaker.adresselinje1}</dd>
                 <dt>Adresselinje 2</dt>
                 <dd>{mottaker.adresselinje2 || '-'}</dd>
                 <dt>Postnummer</dt>
-                <dd>{mottaker.postnummer}</dd>
+                <dd>{mottaker.postnummer || '-'}</dd>
                 <dt>Poststed</dt>
-                <dd>{mottaker.poststed}</dd>
-                <dt>Land</dt>
-                <dd>{land.label}</dd>
+                <dd>{mottaker.poststed || '-'}</dd>
             </DefinitionList>
+
+            {mottaker.landkode !== 'NO' && (
+                <Alert variant="info" inline>
+                    Ved utenlandsk adresse skal postnummer og poststed legges i adresselinjene.
+                </Alert>
+            )}
         </MarginTop>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import type { FieldDictionary } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import type { UseSkjemaVerdi } from '@navikt/familie-skjema/dist/typer';
+import type { Avhengigheter, UseSkjemaVerdi } from '@navikt/familie-skjema/dist/typer';
 import { hentDataFraRessurs } from '@navikt/familie-typer';
 
 import { useFagsakContext } from '../../../../../context/fagsak/FagsakContext';
@@ -46,8 +46,8 @@ export interface SkjemaBrevmottaker {
     navn: string;
     adresselinje1: string;
     adresselinje2?: string;
-    postnummer: string;
-    poststed: string;
+    postnummer?: string;
+    poststed?: string;
     landkode: string;
 }
 
@@ -112,6 +112,21 @@ export const useBrevmottakerSkjema = ({ eksisterendeMottakere }: Props) => {
                 : feil(felt, 'Feltet kan ikke inneholde mer enn 80 tegn');
         },
     });
+    const land = useFelt<string>({
+        verdi: '',
+        valideringsfunksjon: (felt, avhengigheter) => {
+            const norgeErUlovligValgt =
+                avhengigheter?.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE &&
+                felt.verdi === 'NO';
+            if (norgeErUlovligValgt) {
+                return feil(felt, 'Norge kan ikke være satt for bruker med utenlandsk adresse');
+            }
+            return felt.verdi !== ''
+                ? ok(felt)
+                : feil(felt, 'Feltet er påkrevd. Velg Norge dersom brevet skal sendes innenlands.');
+        },
+        avhengigheter: { mottaker },
+    });
     const adresselinje1 = useFelt<string>({
         verdi: '',
         valideringsfunksjon: felt => {
@@ -132,40 +147,37 @@ export const useBrevmottakerSkjema = ({ eksisterendeMottakere }: Props) => {
     });
     const postnummer = useFelt<string>({
         verdi: '',
-        valideringsfunksjon: felt => {
-            if (felt.verdi === '') {
+        valideringsfunksjon: (felt, avhengigheter) => {
+            if (avhengigheter?.land.verdi !== 'NO' && felt.verdi === '') {
+                return ok(felt);
+            } else if (felt.verdi === '') {
                 return feil(felt, 'Feltet er påkrevd');
             }
             return felt.verdi.length <= 10
                 ? ok(felt)
                 : feil(felt, 'Feltet kan ikke inneholde mer enn 10 tegn');
         },
+        skalFeltetVises: (avhengigheter: Avhengigheter) => {
+            return avhengigheter?.land.verdi === 'NO';
+        },
+        avhengigheter: { land },
     });
     const poststed = useFelt<string>({
         verdi: '',
-        valideringsfunksjon: felt => {
-            if (felt.verdi === '') {
+        valideringsfunksjon: (felt, avhengigheter) => {
+            if (avhengigheter?.land.verdi !== 'NO' && felt.verdi === '') {
+                return ok(felt);
+            } else if (felt.verdi === '') {
                 return feil(felt, 'Feltet er påkrevd');
             }
             return felt.verdi.length <= 50
                 ? ok(felt)
                 : feil(felt, 'Feltet kan ikke inneholde mer enn 50 tegn');
         },
-    });
-    const land = useFelt<string>({
-        verdi: '',
-        valideringsfunksjon: (felt, avhengigheter) => {
-            const norgeErUlovligValgt =
-                avhengigheter?.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE &&
-                felt.verdi === 'NO';
-            if (norgeErUlovligValgt) {
-                return feil(felt, 'Norge kan ikke være satt for bruker med utenlandsk adresse');
-            }
-            return felt.verdi !== ''
-                ? ok(felt)
-                : feil(felt, 'Feltet er påkrevd. Velg Norge dersom brevet skal sendes innenlands.');
+        skalFeltetVises: (avhengigheter: Avhengigheter) => {
+            return avhengigheter?.land.verdi === 'NO';
         },
-        avhengigheter: { mottaker },
+        avhengigheter: { land },
     });
 
     const [navnErPreutfylt, settNavnErPreutfylt] = useState(false);
@@ -184,6 +196,15 @@ export const useBrevmottakerSkjema = ({ eksisterendeMottakere }: Props) => {
         }
         settNavnErPreutfylt(skalNavnVærePreutfylt);
     }, [mottaker.verdi, land.verdi]);
+
+    // Postnummer og poststed disables og skal sendes med som tom streng når landet ikke er Norge
+    if (land.verdi !== 'NO' && postnummer.verdi !== '') {
+        postnummer.nullstill();
+    }
+
+    if (land.verdi !== 'NO' && poststed.verdi !== '') {
+        poststed.nullstill();
+    }
 
     const verdierFraUseSkjema: BrevmottakerUseSkjema = useSkjema<
         ILeggTilFjernBrevmottakerSkjemaFelter,


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22908

### 💰 Hva forsøker du å løse i denne PR'en
Legger på ekstra logikk slik at postnummer og poststed kan forbli tomme felter når landet til mottaker av brevet er i utlandet.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Vi har eksplisitt valgt å ikke fjerne disse feltene fra requesten videre til backend, siden det vil medføre _mye_ ekstra jobb i både ba-sak og familie-tilbake. Disse bruker begge de samme kontraktene, der vi har satt postnummer og poststed som obligatoriske felter. Dette er avklart med @bragejahren.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Det finnes ingen tester fra før.
Oppgaven haster, så vi bruker ikke tid på å skrive tester nå.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei

### 👀 Screen shots
Når vi velger et annet land enn Norge blir postnummer og poststed disablet, og en melding kommer opp om at disse to feltene må inkluderes i adresselinjene:
<img width="551" alt="image" src="https://github.com/user-attachments/assets/4ee5804e-d9f8-43c6-8ef4-a308b38072fe">

Når vi har lagret mottaker med utenlandsk land ser det slik ut:
<img width="547" alt="image" src="https://github.com/user-attachments/assets/38b5cebf-d221-4fe9-8c84-6eca39aa5c54">

Når Norge er valgt, ser det slik ut
<img width="554" alt="image" src="https://github.com/user-attachments/assets/ec8a328a-b4ff-46d2-bed0-0bf6c4ad0779">



