### PR TITLE
Fix: holder endret utbetaling andel sin skjematilstand oppdatert ved endringer

### DIFF
--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -22,7 +22,7 @@ interface IProps {
 const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseContext(
     ({ endretUtbetalingAndel }: IProps) => {
         const årsakFelt = useFelt<IEndretUtbetalingAndelÅrsak | undefined>({
-            verdi: endretUtbetalingAndel.årsak ? endretUtbetalingAndel.årsak : undefined,
+            verdi: undefined,
             valideringsfunksjon: felt =>
                 felt.verdi && Object.values(IEndretUtbetalingAndelÅrsak).includes(felt.verdi)
                     ? ok(felt)
@@ -30,7 +30,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
         });
 
         const periodeSkalUtbetalesTilSøkerFelt = useFelt<boolean | undefined>({
-            verdi: endretUtbetalingAndel.prosent !== undefined && endretUtbetalingAndel.prosent > 0,
+            verdi: undefined,
         });
 
         const { skjema, kanSendeSkjema, onSubmit } = useSkjema<
@@ -50,19 +50,19 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
         >({
             felter: {
                 person: useFelt<string | undefined>({
-                    verdi: endretUtbetalingAndel.personIdent,
+                    verdi: undefined,
                     valideringsfunksjon: felt =>
                         felt.verdi ? ok(felt) : feil(felt, 'Du må velge en person'),
                 }),
                 fom: useFelt<IsoMånedString | undefined>({
-                    verdi: endretUtbetalingAndel.fom,
+                    verdi: undefined,
                     valideringsfunksjon: felt =>
                         erIsoStringGyldig(felt.verdi)
                             ? ok(felt)
                             : feil(felt, 'Du må velge f.o.m-dato'),
                 }),
                 tom: useFelt<IsoMånedString | undefined>({
-                    verdi: endretUtbetalingAndel.tom,
+                    verdi: undefined,
                 }),
                 periodeSkalUtbetalesTilSøker: periodeSkalUtbetalesTilSøkerFelt,
                 årsak: årsakFelt,
@@ -81,11 +81,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                     valideringsfunksjon: validerGyldigDato,
                 }),
                 fullSats: useFelt<boolean | undefined>({
-                    verdi:
-                        endretUtbetalingAndel.prosent !== null &&
-                        endretUtbetalingAndel.prosent !== undefined
-                            ? endretUtbetalingAndel.prosent === 100
-                            : undefined,
+                    verdi: undefined,
                     avhengigheter: {
                         årsak: årsakFelt,
                         periodeSkalUtbetalesTilSøker: periodeSkalUtbetalesTilSøkerFelt,
@@ -104,12 +100,12 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                     },
                 }),
                 begrunnelse: useFelt<string | undefined>({
-                    verdi: endretUtbetalingAndel.begrunnelse,
+                    verdi: undefined,
                     valideringsfunksjon: felt =>
                         felt.verdi ? ok(felt) : feil(felt, 'Du må oppgi en begrunnelse.'),
                 }),
                 erEksplisittAvslagPåSøknad: useFelt<boolean | undefined>({
-                    verdi: endretUtbetalingAndel.erEksplisittAvslagPåSøknad,
+                    verdi: undefined,
                 }),
             },
             skjemanavn: 'Endre utbetalingsperiode',
@@ -128,25 +124,35 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             );
         };
 
+        const tilbakestillFelterTilDefault = () => {
+            skjema.felter.person.validerOgSettFelt(endretUtbetalingAndel.personIdent);
+            skjema.felter.fom.validerOgSettFelt(endretUtbetalingAndel.fom);
+            skjema.felter.tom.validerOgSettFelt(endretUtbetalingAndel.tom);
+            skjema.felter.periodeSkalUtbetalesTilSøker.validerOgSettFelt(
+                endretUtbetalingAndel.prosent !== undefined && endretUtbetalingAndel.prosent > 0
+            );
+            skjema.felter.årsak.validerOgSettFelt(endretUtbetalingAndel.årsak);
+            skjema.felter.fullSats.validerOgSettFelt(
+                endretUtbetalingAndel.prosent !== null &&
+                    endretUtbetalingAndel.prosent !== undefined &&
+                    endretUtbetalingAndel.prosent === 100
+            );
+            skjema.felter.begrunnelse.validerOgSettFelt(endretUtbetalingAndel.begrunnelse);
+            skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
+                endretUtbetalingAndel.erEksplisittAvslagPåSøknad
+            );
+
+            settDatofelterTilDefaultverdier();
+        };
+
         const [forrigeEndretUtbetalingAndel, settForrigeEndretUtbetalingAndel] =
             useState<IRestEndretUtbetalingAndel>();
 
         if (endretUtbetalingAndel !== forrigeEndretUtbetalingAndel) {
             settForrigeEndretUtbetalingAndel(endretUtbetalingAndel);
-            settDatofelterTilDefaultverdier();
+            tilbakestillFelterTilDefault();
         }
 
-        const tilbakestillFelterTilDefault = () => {
-            skjema.felter.person.nullstill();
-            skjema.felter.fom.nullstill();
-            skjema.felter.tom.nullstill();
-            skjema.felter.periodeSkalUtbetalesTilSøker.nullstill();
-            skjema.felter.årsak.nullstill();
-            skjema.felter.fullSats.nullstill();
-            skjema.felter.begrunnelse.nullstill();
-            skjema.felter.erEksplisittAvslagPåSøknad.nullstill();
-            settDatofelterTilDefaultverdier();
-        };
         const hentProsentForEndretUtbetaling = () => {
             return (
                 (skjema.felter.periodeSkalUtbetalesTilSøker.verdi ? 100 : 0) /

--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -190,7 +190,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             kanSendeSkjema,
             onSubmit,
             hentSkjemaData,
-            tilbakestillFelterTilDefault: settFelterTilDefault,
+            settFelterTilDefault,
         };
     }
 );

--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -111,7 +111,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             skjemanavn: 'Endre utbetalingsperiode',
         });
 
-        const tilbakestillFelterTilDefault = () => {
+        const settFelterTilDefault = () => {
             skjema.felter.person.validerOgSettFelt(endretUtbetalingAndel.personIdent);
             skjema.felter.fom.validerOgSettFelt(endretUtbetalingAndel.fom);
             skjema.felter.tom.validerOgSettFelt(endretUtbetalingAndel.tom);
@@ -146,7 +146,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
 
         if (endretUtbetalingAndel !== forrigeEndretUtbetalingAndel) {
             settForrigeEndretUtbetalingAndel(endretUtbetalingAndel);
-            tilbakestillFelterTilDefault();
+            settFelterTilDefault();
         }
 
         const hentProsentForEndretUtbetaling = () => {
@@ -190,7 +190,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             kanSendeSkjema,
             onSubmit,
             hentSkjemaData,
-            tilbakestillFelterTilDefault,
+            tilbakestillFelterTilDefault: settFelterTilDefault,
         };
     }
 );

--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -111,19 +111,6 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             skjemanavn: 'Endre utbetalingsperiode',
         });
 
-        const settDatofelterTilDefaultverdier = () => {
-            skjema.felter.søknadstidspunkt.validerOgSettFelt(
-                endretUtbetalingAndel.søknadstidspunkt
-                    ? new Date(endretUtbetalingAndel.søknadstidspunkt)
-                    : undefined
-            );
-            skjema.felter.avtaletidspunktDeltBosted.validerOgSettFelt(
-                endretUtbetalingAndel.avtaletidspunktDeltBosted
-                    ? new Date(endretUtbetalingAndel.avtaletidspunktDeltBosted)
-                    : undefined
-            );
-        };
-
         const tilbakestillFelterTilDefault = () => {
             skjema.felter.person.validerOgSettFelt(endretUtbetalingAndel.personIdent);
             skjema.felter.fom.validerOgSettFelt(endretUtbetalingAndel.fom);
@@ -142,7 +129,16 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 endretUtbetalingAndel.erEksplisittAvslagPåSøknad
             );
 
-            settDatofelterTilDefaultverdier();
+            skjema.felter.søknadstidspunkt.validerOgSettFelt(
+                endretUtbetalingAndel.søknadstidspunkt
+                    ? new Date(endretUtbetalingAndel.søknadstidspunkt)
+                    : undefined
+            );
+            skjema.felter.avtaletidspunktDeltBosted.validerOgSettFelt(
+                endretUtbetalingAndel.avtaletidspunktDeltBosted
+                    ? new Date(endretUtbetalingAndel.avtaletidspunktDeltBosted)
+                    : undefined
+            );
         };
 
         const [forrigeEndretUtbetalingAndel, settForrigeEndretUtbetalingAndel] =

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -96,7 +96,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
         kanSendeSkjema,
         onSubmit,
         hentSkjemaData,
-        tilbakestillFelterTilDefault,
+        settFelterTilDefault,
     } = useEndretUtbetalingAndel();
 
     const oppdaterEndretUtbetaling = (avbrytEndringAvUtbetalingsperiode: () => void) => {
@@ -394,7 +394,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 variant="tertiary"
                                 size="small"
                                 onClick={() => {
-                                    tilbakestillFelterTilDefault();
+                                    settFelterTilDefault();
                                     lukkSkjema();
                                 }}
                             >


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22991

Skjemaet er satt opp til å initielt være verdiene til endret utbetaling andel som kommer fra backend. Problemet er når denne verdien endrer seg, så blir ikke dette propagert til skjemaet på riktig måte. Løser dette på samme måte som er løst for dato-felter tidligere, ved å sette feltene til å initielt være undefined, også heller oppdatere feltene hver gang endret utbetaling andelen endrer seg. Se punktet under for noen tanker 👇 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
To ting:
1. 
Jeg syns vi skal vurdere å skrive om hele måten Endret utbetaling er satt opp på. Det er ganske krøllete når contexten er satt opp på den måten den er. Den tar inn en endretUtbetalingAndel som parameter og måten hele skjemaet er satt opp på baserer seg på denne andelen. Men, når det skjer endringer i andeler (ved lagring feks) så blir ikke det propagert til skjemaet på riktig måte. Tror det er mye forbedringspotensiale på hele strukturen her

2. 
Når vi setter feltene til undefined initielt og heller oppdaterer ved endringer på endret utbetaling andel, så vil extention-funksjonen `.nullstill()` på feltet sette feltet til undefined og ikke til den "initielle/default"-verdien til endret utbetaling andel. Dette ble brukt tre steder på fom og tom-feltene i dag, men jeg mener at det fungerer like godt å sette feltet til undefined som initiell verdi i alle de tilfellene. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Jeg syns ikke det er vits å bruke tid på når jeg har testet manuelt

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Commit for commit er sikkert fint

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
