### PR TITLE
Legg til kolonne om ytelsestype for overgangsordningbehandlinger i Oppsummeringsboks

### DIFF
--- a/src/frontend/context/test/SøknadContext.test.ts
+++ b/src/frontend/context/test/SøknadContext.test.ts
@@ -2,6 +2,7 @@ import { addYears } from 'date-fns';
 
 import { kjønnType } from '@navikt/familie-typer';
 
+import { YtelseType } from '../../typer/beregning';
 import { PersonType } from '../../typer/person';
 import { Målform } from '../../typer/søknad';
 import { Vedtaksperiodetype } from '../../typer/vedtaksperiode';
@@ -36,6 +37,7 @@ describe('SøknadContext', () => {
                             utbetaltPerMnd: 1054,
                             erPåvirketAvEndring: false,
                             prosent: 80,
+                            ytelseType: YtelseType.ORDINÆR_KONTANTSTØTTE,
                         },
                     ],
                     antallBarn: 1,
@@ -51,6 +53,7 @@ describe('SøknadContext', () => {
                             utbetaltPerMnd: 1054,
                             erPåvirketAvEndring: false,
                             prosent: 80,
+                            ytelseType: YtelseType.ORDINÆR_KONTANTSTØTTE,
                         },
                     ],
                     antallBarn: 1,

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
@@ -254,6 +254,7 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
             )}
             {aktivEtikett && (
                 <Oppsummeringsboks
+                    åpenBehandling={åpenBehandling}
                     utbetalingsperiode={finnUtbetalingsperiodeForAktivEtikett(
                         åpenBehandling.utbetalingsperioder
                     )}

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
@@ -34,8 +34,6 @@ import type {
 } from '../../../typer/eøsPerioder';
 import { ToggleNavn } from '../../../typer/toggles';
 import type { IRestEndretUtbetalingAndel } from '../../../typer/utbetalingAndel';
-import type { Utbetalingsperiode } from '../../../typer/vedtaksperiode';
-import { periodeOverlapperMedValgtDato } from '../../../utils/dato';
 import { formaterIdent, slåSammenListeTilStreng } from '../../../utils/formatter';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
@@ -127,20 +125,6 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
 
     const forrigeOnClick = () => {
         navigate(`/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/vilkaarsvurdering`);
-    };
-
-    const finnUtbetalingsperiodeForAktivEtikett = (
-        utbetalingsperioder: Utbetalingsperiode[]
-    ): Utbetalingsperiode | undefined => {
-        return aktivEtikett
-            ? utbetalingsperioder.find((utbetalingsperiode: Utbetalingsperiode) =>
-                  periodeOverlapperMedValgtDato(
-                      utbetalingsperiode.periodeFom,
-                      utbetalingsperiode.periodeTom,
-                      aktivEtikett.date
-                  )
-              )
-            : undefined;
     };
 
     const grunnlagPersoner = filterOgSorterGrunnlagPersonerMedAndeler(
@@ -255,9 +239,6 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
             {aktivEtikett && (
                 <Oppsummeringsboks
                     åpenBehandling={åpenBehandling}
-                    utbetalingsperiode={finnUtbetalingsperiodeForAktivEtikett(
-                        åpenBehandling.utbetalingsperioder
-                    )}
                     aktivEtikett={aktivEtikett}
                     kompetanser={kompetanser}
                     utbetaltAnnetLandBeløp={utbetaltAnnetLandBeløp}

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import type { PropsWithChildren } from 'react';
+import * as React from 'react';
 
 import styled from 'styled-components';
 
@@ -10,6 +10,8 @@ import type { Etikett } from '@navikt/familie-tidslinje';
 
 import { hentBarnehageplassBeskrivelse } from './OppsummeringsboksUtils';
 import { useTidslinje } from '../../../context/TidslinjeContext';
+import { BehandlingÅrsak, type IBehandling } from '../../../typer/behandling';
+import { YtelseType } from '../../../typer/beregning';
 import type {
     IEøsPeriodeStatus,
     IRestEøsPeriode,
@@ -35,18 +37,13 @@ const UtbetalingsbeløpStack = styled(VStack)`
     padding: ${ASpacing6} ${ASpacing10} ${ASpacing4} 0;
 `;
 
-const UtbetalingsbeløpRad: React.FC<PropsWithChildren> = ({ children }) => (
-    <HGrid columns="1fr 10rem 9rem 5rem" gap={'4'}>
-        {children}
-    </HGrid>
-);
-
 const TotaltUtbetaltRad = styled(HGrid)`
     border-top: 1px dashed;
     padding-top: ${ASpacing4};
 `;
 
 interface IProps {
+    åpenBehandling: IBehandling;
     utbetalingsperiode: Utbetalingsperiode | undefined;
     aktivEtikett: Etikett;
     kompetanser: IRestKompetanse[];
@@ -111,6 +108,7 @@ const erAllePerioderUtfyltForBarn = (eøsPeriodeStatus: IEøsPeriodeStatus[]) =>
 };
 
 const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
+    åpenBehandling,
     utbetalingsperiode,
     aktivEtikett,
     kompetanser,
@@ -142,6 +140,18 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
         );
     }, [utbetalingsperiode, kompetanser, utbetaltAnnetLandBeløp, valutakurser]);
 
+    const erOvergangsordning = åpenBehandling.årsak == BehandlingÅrsak.OVERGANGSORDNING_2024;
+
+    const UtbetalingsbeløpRad: React.FC<PropsWithChildren> = ({ children }) => {
+        const columns = erOvergangsordning ? '1fr 10rem 9rem 12rem 5rem' : '1fr 10rem 9rem 5rem';
+
+        return (
+            <HGrid columns={columns} gap={'4'}>
+                {children}
+            </HGrid>
+        );
+    };
+
     return (
         <Box borderColor="border-strong" borderWidth="1" padding="10">
             <HGrid columns="1fr 3rem" align="center">
@@ -165,6 +175,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                             <BodyShort>Person</BodyShort>
                             <BodyShort>Barnehageplass</BodyShort>
                             <BodyShort>Kontantstøtte</BodyShort>
+                            {erOvergangsordning && <BodyShort>Ytelsetype</BodyShort>}
                             <BodyShort>Beløp</BodyShort>
                         </UtbetalingsbeløpRad>
                         {utbetalingsperiode.utbetalingsperiodeDetaljer
@@ -180,7 +191,14 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                                             detalj.erPåvirketAvEndring
                                         )}
                                     </BodyShort>
-                                    <BodyShort>{detalj.prosent + '%'}</BodyShort>
+                                    <BodyShort>{detalj.prosent + '% '}</BodyShort>
+                                    {erOvergangsordning && (
+                                        <BodyShort>
+                                            {detalj.ytelseType == YtelseType.OVERGANGSORDNING
+                                                ? 'Overgangsordning'
+                                                : 'Ordinær'}
+                                        </BodyShort>
+                                    )}
                                     {utbetalingsBeløpStatusMap.get(detalj.person.personIdent) ? (
                                         <BodyShort>
                                             {formaterBeløp(detalj.utbetaltPerMnd)}

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -21,7 +21,11 @@ import type {
 } from '../../../typer/eøsPerioder';
 import { EøsPeriodeStatus, KompetanseResultat } from '../../../typer/eøsPerioder';
 import type { Utbetalingsperiode } from '../../../typer/vedtaksperiode';
-import { dateTilFormatertString, Datoformat } from '../../../utils/dato';
+import {
+    dateTilFormatertString,
+    Datoformat,
+    periodeOverlapperMedValgtDato,
+} from '../../../utils/dato';
 import {
     formaterBeløp,
     formaterIdent,
@@ -44,7 +48,6 @@ const TotaltUtbetaltRad = styled(HGrid)`
 
 interface IProps {
     åpenBehandling: IBehandling;
-    utbetalingsperiode: Utbetalingsperiode | undefined;
     aktivEtikett: Etikett;
     kompetanser: IRestKompetanse[];
     utbetaltAnnetLandBeløp: IRestUtenlandskPeriodeBeløp[];
@@ -109,7 +112,6 @@ const erAllePerioderUtfyltForBarn = (eøsPeriodeStatus: IEøsPeriodeStatus[]) =>
 
 const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
     åpenBehandling,
-    utbetalingsperiode,
     aktivEtikett,
     kompetanser,
     utbetaltAnnetLandBeløp,
@@ -129,6 +131,24 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
         return navn[0].toUpperCase() + navn.substring(1);
     };
 
+    const finnUtbetalingsperiodeForAktivEtikett = (
+        utbetalingsperioder: Utbetalingsperiode[]
+    ): Utbetalingsperiode | undefined => {
+        return aktivEtikett
+            ? utbetalingsperioder.find((utbetalingsperiode: Utbetalingsperiode) =>
+                  periodeOverlapperMedValgtDato(
+                      utbetalingsperiode.periodeFom,
+                      utbetalingsperiode.periodeTom,
+                      aktivEtikett.date
+                  )
+              )
+            : undefined;
+    };
+
+    const utbetalingsperiode = finnUtbetalingsperiodeForAktivEtikett(
+        åpenBehandling.utbetalingsperioder
+    );
+
     React.useEffect(() => {
         setUtbetalingsBeløpStatusMap(
             finnUtbetalingsBeløpStatusMap(
@@ -138,7 +158,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                 valutakurser
             )
         );
-    }, [utbetalingsperiode, kompetanser, utbetaltAnnetLandBeløp, valutakurser]);
+    }, [kompetanser, utbetaltAnnetLandBeløp, valutakurser]);
 
     const erOvergangsordning = åpenBehandling.årsak == BehandlingÅrsak.OVERGANGSORDNING_2024;
 

--- a/src/frontend/typer/vedtaksperiode.ts
+++ b/src/frontend/typer/vedtaksperiode.ts
@@ -1,3 +1,4 @@
+import type { YtelseType } from './beregning';
 import { ytelsetype } from './beregning';
 import type { IGrunnlagPerson } from './person';
 import type { Begrunnelse, BegrunnelseType } from './vedtak';
@@ -72,6 +73,7 @@ export interface IUtbetalingsperiodeDetalj {
     person: IGrunnlagPerson;
     utbetaltPerMnd: number;
     prosent: number;
+    ytelseType: YtelseType;
     erPåvirketAvEndring: boolean;
 }
 


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22613)

### 💰 Hva forsøker du å løse i denne PR'en
Når det overgangsordning som er årsaken for behandlingen ønsker vi å ha med en kolonne i oppsummeringsboksen slik at det er lettere å skille mellom ordinær og overgangsstønad. 

![67ec5bd5d57e005ee2105cce3b7dc400](https://github.com/user-attachments/assets/b4aed342-c1de-410b-ba7c-0a3ac21a08bf)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
