### PR TITLE
Vi ønsker å vise tom dato i vedatksperiodene, alltid, hvis det inneholder overgangsordning begrunnelser

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/EkspanderbartBegrunnelsePanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/EkspanderbartBegrunnelsePanel.tsx
@@ -36,6 +36,7 @@ const StyledExpansionTitle = styled(ExpansionCard.Title)`
 interface IEkspanderbartBegrunnelsePanelProps extends PropsWithChildren {
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
     sisteVedtaksperiodeFom?: string;
+    vedtaksperiodeInneholderOvergangsordningBegrunnelse: boolean;
     åpen: boolean;
     onClick?: () => void;
 }
@@ -50,10 +51,15 @@ const slutterSenereEnnInneværendeMåned = (tom?: string) =>
     );
 
 const finnPresentertTomDato = (
+    vedtaksperiodeInneholderOvergangsordningBegrunnelse: boolean,
     periodeFom?: string,
     periodeTom?: string,
     sisteVedtaksperiodeFom?: string
 ) => {
+    if (vedtaksperiodeInneholderOvergangsordningBegrunnelse) {
+        return periodeTom;
+    }
+
     if (erSammeFom(periodeFom, sisteVedtaksperiodeFom)) {
         return slutterSenereEnnInneværendeMåned(periodeTom) ? '' : periodeTom;
     }
@@ -63,6 +69,7 @@ const finnPresentertTomDato = (
 const EkspanderbartBegrunnelsePanel: React.FC<IEkspanderbartBegrunnelsePanelProps> = ({
     vedtaksperiodeMedBegrunnelser,
     sisteVedtaksperiodeFom,
+    vedtaksperiodeInneholderOvergangsordningBegrunnelse,
     åpen,
     onClick,
     children,
@@ -71,7 +78,6 @@ const EkspanderbartBegrunnelsePanel: React.FC<IEkspanderbartBegrunnelsePanelProp
         fom: vedtaksperiodeMedBegrunnelser.fom,
         tom: vedtaksperiodeMedBegrunnelser.tom,
     };
-
     const vedtaksperiodeTittel = hentVedtaksperiodeTittel(vedtaksperiodeMedBegrunnelser);
 
     return (
@@ -89,6 +95,7 @@ const EkspanderbartBegrunnelsePanel: React.FC<IEkspanderbartBegrunnelsePanelProp
                             {isoDatoPeriodeTilFormatertString({
                                 fom: periode.fom,
                                 tom: finnPresentertTomDato(
+                                    vedtaksperiodeInneholderOvergangsordningBegrunnelse,
                                     periode.fom,
                                     periode.tom,
                                     sisteVedtaksperiodeFom

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -31,6 +31,15 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
                 Standardbegrunnelse.OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS
         ).length > 0;
 
+    const vedtaksperiodeInneholderOvergangsordningBegrunnelse =
+        vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
+            vedtaksBegrunnelser =>
+                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
+                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING ||
+                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
+                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING
+        ).length > 0;
+
     const vedtaksperiodeStøtterFritekst =
         vedtaksperiodeMedBegrunnelser.støtterFritekst ||
         vedtaksperiodeMedBegrunnelser.fritekster.length > 0;
@@ -39,6 +48,9 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
         <EkspanderbartBegrunnelsePanel
             vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
             sisteVedtaksperiodeFom={sisteVedtaksperiodeFom}
+            vedtaksperiodeInneholderOvergangsordningBegrunnelse={
+                vedtaksperiodeInneholderOvergangsordningBegrunnelse
+            }
             åpen={erPanelEkspandert}
             onClick={() => onPanelClose(true)}
         >
@@ -49,7 +61,10 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
             />
             {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.AVSLAG && (
                 <BegrunnelserMultiselect
-                    tillatKunLesevisning={vedtaksperiodeInneholderFramtidigOpphørBegrunnelse}
+                    tillatKunLesevisning={
+                        vedtaksperiodeInneholderFramtidigOpphørBegrunnelse ||
+                        vedtaksperiodeInneholderOvergangsordningBegrunnelse
+                    }
                 />
             )}
             {genererteBrevbegrunnelser.status === RessursStatus.SUKSESS &&

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -45,6 +45,8 @@ export const begrunnelseTyper: Record<BegrunnelseType, string> = {
 
 export enum Standardbegrunnelse {
     OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS = 'NasjonalEllerFellesBegrunnelse$OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS',
+    INNVILGET_OVERGANGSORDNING = 'NasjonalEllerFellesBegrunnelse$INNVILGET_OVERGANGSORDNING',
+    INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING = 'NasjonalEllerFellesBegrunnelse$INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING',
 }
 
 export interface IRestKorrigertVedtak {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22614

Vi ønsker ALLTID å vise tom dato på periodene dersom vedtaksperiodene inneholder begrunnelser knyttet til overgangsordningen (disse settes av backend automatisk).
I tillegg ønsker vi ikke muligheten til å fjerne disse, på samme måte som framtidig opphør begrunnelsene som settes av backend. Se demo video.


https://github.com/user-attachments/assets/b0fb91f0-5639-4e9f-82f5-230fe3f44cbd

