### PR TITLE
Ekskluderer XU i brevmottaker landvelger

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -74,8 +74,8 @@ const BrevmottakerSkjema = ({ erLesevisning, skjema, navnErPreutfylt }: Props) =
                         utenMargin
                         eksluderLand={
                             skjema.felter.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
-                                ? ['NO']
-                                : undefined
+                                ? ['NO', 'XU']
+                                : ['XU']
                         }
                         feil={
                             skjema.visFeilmeldinger &&


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23347

Vi ønsker ikke at SB skal kunne velge Ukjent Land (XU) når brevmottaker opprettes.