### PR TITLE
Endre valutakursdato for overgangsordning

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
@@ -55,7 +55,7 @@ const Valutakurser: React.FC<IProps> = ({ valutakurser, åpenBehandling, visFeil
                     variant={'warning'}
                     fullWidth
                     children={
-                        'For EØS-perioder med overgangsordning skal valutakursdato være 30.11.2024'
+                        'For EØS-perioder med overgangsordning skal valutakursdato være 29.11.2024'
                     }
                 />
             )}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

30.11.2024 er ikke en virkedag, så bytter til 29.11.2024