### PR TITLE
Valider tom dato på endret utbetaling periode andel, det må velges.

### DIFF
--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -70,6 +70,10 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 }),
                 tom: useFelt<IsoMånedString | undefined>({
                     verdi: undefined,
+                    valideringsfunksjon: felt =>
+                        erIsoStringGyldig(felt.verdi)
+                            ? ok(felt)
+                            : feil(felt, 'Du må velge t.o.m-dato'),
                 }),
                 periodeSkalUtbetalesTilSøker: periodeSkalUtbetalesTilSøkerFelt,
                 årsak: årsakFelt,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23676

Vi må validere at bruker skal sette tom dato.
Det er ingen grunn for at man ikke skal sette tom dato, etter at vi fjerner årsak endre mottaker.