### PR TITLE
Fikser visning av preutfylt dato fra eksisterende korrigert vedtak

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
@@ -1,26 +1,10 @@
 import * as React from 'react';
 
-import styled, { css } from 'styled-components';
+import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
+import { Dropdown } from '@navikt/ds-react';
 
-import { ArrowUndoIcon, ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
-import { BodyLong, Button, Fieldset, Modal, Dropdown, Textarea } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
-
-import { useKorrigerVedtakSkjemaContext } from '../../../../context/KorrigerVedtak/KorrigerVedtakSkjemaContext';
+import KorrigerVedtakModal from './KorrigerVedtakModal';
 import type { IRestKorrigertVedtak } from '../../../../typer/vedtak';
-import Datovelger from '../../../Felleskomponenter/Datovelger/Datovelger';
-
-const AngreKnapp = styled(Button)`
-    margin: 0.5rem 0;
-`;
-
-const baseSkjemaelementStyle = css`
-    margin-bottom: 1.5rem;
-`;
-
-const StyledTextarea = styled(Textarea)`
-    ${baseSkjemaelementStyle}
-`;
 
 interface IKorrigerVedtak {
     korrigertVedtak?: IRestKorrigertVedtak;
@@ -35,19 +19,6 @@ const KorrigerVedtak: React.FC<IKorrigerVedtak> = ({
 }) => {
     const [visModal, settVisModal] = React.useState<boolean>(false);
 
-    const { skjema, valideringErOk, lagreKorrigertVedtak, angreKorrigering, restFeil } =
-        useKorrigerVedtakSkjemaContext({
-            onSuccess: () => settVisModal(false),
-            korrigertVedtak,
-            behandlingId,
-        });
-
-    const lukkModal = () => {
-        settVisModal(false);
-    };
-
-    const visAngreKnapp = korrigertVedtak != null;
-
     return (
         <>
             <Dropdown.Menu.List.Item
@@ -58,91 +29,13 @@ const KorrigerVedtak: React.FC<IKorrigerVedtak> = ({
                 <ExclamationmarkTriangleIcon fontSize={'1.4rem'} />
                 {korrigertVedtak ? <>Vis korrigert vedtak</> : <>Korriger vedtak</>}
             </Dropdown.Menu.List.Item>
-
             {visModal && (
-                <Modal
-                    open
-                    onClose={lukkModal}
-                    header={{ heading: 'Korriger vedtak', size: 'medium' }}
-                    width={'35rem'}
-                    portal
-                >
-                    <Modal.Body>
-                        <BodyLong>
-                            Dersom det har blitt gjort feil tidligere vedtak, kan denne teksten
-                            legges til i vedtaksbrevet:
-                        </BodyLong>
-                        <ul>
-                            <li>
-                                Vi har oppdaget en feil i vedtaket vi gjorde [DATO]. Derfor har vi
-                                vurdert saken din på nytt.
-                            </li>
-                        </ul>
-                        <Fieldset
-                            legend={'Korriger vedtak'}
-                            hideLegend
-                            errorPropagation={false}
-                            error={skjema.visFeilmeldinger && restFeil}
-                        >
-                            <Datovelger
-                                felt={skjema.felter.vedtaksdato}
-                                label={'Vedtaksdato'}
-                                visFeilmeldinger={skjema.visFeilmeldinger}
-                                readOnly={erLesevisning}
-                                kanKunVelgeFortid
-                            />
-                            <StyledTextarea
-                                {...skjema.felter.begrunnelse?.hentNavBaseSkjemaProps(
-                                    skjema.visFeilmeldinger
-                                )}
-                                id={'korriger-vedtak-begrunnelse'}
-                                label={'Begrunnelse (valgfri)'}
-                                description={'Begrunn hva som er gjort feil i tidligere vedtak'}
-                                readOnly={erLesevisning}
-                                value={skjema.felter.begrunnelse.verdi}
-                                onChange={changeEvent =>
-                                    skjema.felter.begrunnelse.validerOgSettFelt(
-                                        changeEvent.target.value
-                                    )
-                                }
-                            />
-                        </Fieldset>
-                    </Modal.Body>
-                    <Modal.Footer>
-                        {!erLesevisning && (
-                            <>
-                                <Button
-                                    onClick={lagreKorrigertVedtak}
-                                    variant={valideringErOk() ? 'primary' : 'secondary'}
-                                    loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                    disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                >
-                                    {korrigertVedtak ? 'Oppdater' : 'Legg til'}
-                                </Button>
-                                <Button onClick={lukkModal} variant={'tertiary'}>
-                                    Avbryt
-                                </Button>
-                                {visAngreKnapp && (
-                                    <AngreKnapp
-                                        size={'small'}
-                                        onClick={angreKorrigering}
-                                        variant={'tertiary'}
-                                        loading={
-                                            skjema.submitRessurs.status === RessursStatus.HENTER
-                                        }
-                                        disabled={
-                                            skjema.submitRessurs.status === RessursStatus.HENTER
-                                        }
-                                        icon={<ArrowUndoIcon />}
-                                    >
-                                        Fjern korrigering
-                                    </AngreKnapp>
-                                )}
-                            </>
-                        )}
-                        {erLesevisning && <Button onClick={lukkModal}>Lukk</Button>}
-                    </Modal.Footer>
-                </Modal>
+                <KorrigerVedtakModal
+                    behandlingId={behandlingId}
+                    korrigertVedtak={korrigertVedtak}
+                    erLesevisning={erLesevisning}
+                    lukkModal={() => settVisModal(false)}
+                />
             )}
         </>
     );

--- a/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtakModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtakModal.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+
+import styled from 'styled-components';
+
+import { ArrowUndoIcon } from '@navikt/aksel-icons';
+import { BodyLong, Button, Fieldset, Modal, Textarea } from '@navikt/ds-react';
+import { RessursStatus } from '@navikt/familie-typer';
+
+import { useKorrigerVedtakSkjemaContext } from '../../../../context/KorrigerVedtak/KorrigerVedtakSkjemaContext';
+import type { IRestKorrigertVedtak } from '../../../../typer/vedtak';
+import Datovelger from '../../../Felleskomponenter/Datovelger/Datovelger';
+
+const AngreKnapp = styled(Button)`
+    margin: 0.5rem 0;
+`;
+
+interface IProps {
+    lukkModal: () => void;
+    korrigertVedtak?: IRestKorrigertVedtak;
+    behandlingId: number;
+    erLesevisning: boolean;
+}
+
+const KorrigerVedtakModal = ({
+    lukkModal,
+    korrigertVedtak,
+    behandlingId,
+    erLesevisning,
+}: IProps) => {
+    const { skjema, valideringErOk, lagreKorrigertVedtak, angreKorrigering, restFeil } =
+        useKorrigerVedtakSkjemaContext({
+            lukkModal,
+            korrigertVedtak,
+            behandlingId,
+        });
+
+    const visAngreKnapp = korrigertVedtak != null;
+
+    return (
+        <Modal
+            open
+            onClose={lukkModal}
+            header={{ heading: 'Korriger vedtak', size: 'medium' }}
+            width={'35rem'}
+            portal
+        >
+            <Modal.Body>
+                <BodyLong>
+                    Dersom det har blitt gjort feil tidligere vedtak, kan denne teksten legges til i
+                    vedtaksbrevet:
+                </BodyLong>
+                <ul>
+                    <li>
+                        Vi har oppdaget en feil i vedtaket vi gjorde [DATO]. Derfor har vi vurdert
+                        saken din på nytt.
+                    </li>
+                </ul>
+                <Fieldset
+                    legend="Korriger vedtak"
+                    hideLegend
+                    errorPropagation={false}
+                    error={skjema.visFeilmeldinger && restFeil}
+                >
+                    <Datovelger
+                        felt={skjema.felter.vedtaksdato}
+                        label={'Vedtaksdato'}
+                        readOnly={erLesevisning}
+                        visFeilmeldinger={skjema.visFeilmeldinger}
+                        kanKunVelgeFortid
+                    />
+                    <Textarea
+                        {...skjema.felter.begrunnelse?.hentNavBaseSkjemaProps(
+                            skjema.visFeilmeldinger
+                        )}
+                        id={'korriger-vedtak-begrunnelse'}
+                        label={'Begrunnelse (valgfri)'}
+                        description={'Begrunn hva som er gjort feil i tidligere vedtak'}
+                        readOnly={erLesevisning}
+                        value={skjema.felter.begrunnelse.verdi}
+                        onChange={changeEvent =>
+                            skjema.felter.begrunnelse.validerOgSettFelt(changeEvent.target.value)
+                        }
+                    />
+                </Fieldset>
+            </Modal.Body>
+            <Modal.Footer>
+                {!erLesevisning && (
+                    <>
+                        <Button
+                            onClick={lagreKorrigertVedtak}
+                            variant={valideringErOk() ? 'primary' : 'secondary'}
+                            loading={skjema.submitRessurs.status === RessursStatus.HENTER}
+                            disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
+                        >
+                            {korrigertVedtak ? 'Oppdater' : 'Legg til'}
+                        </Button>
+                        <Button onClick={lukkModal} variant={'tertiary'}>
+                            Avbryt
+                        </Button>
+                        {visAngreKnapp && (
+                            <AngreKnapp
+                                size={'small'}
+                                onClick={angreKorrigering}
+                                variant={'tertiary'}
+                                loading={skjema.submitRessurs.status === RessursStatus.HENTER}
+                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
+                                icon={<ArrowUndoIcon />}
+                            >
+                                Fjern korrigering
+                            </AngreKnapp>
+                        )}
+                    </>
+                )}
+                {erLesevisning && <Button onClick={lukkModal}>Lukk</Button>}
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default KorrigerVedtakModal;


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23633

Samme fiks som i https://github.com/navikt/familie-ba-sak-frontend/pull/3484.
Oppdaterer filer i samme slengen slik at det blir likt på hvordan man har gjort det i BA (ba har blitt oppdatert i nyere tid)