### PR TITLE
Fix: Validering av barnets alder-vilkår for adopsjon

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/BarnehageplassContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/BarnehageplassContext.ts
@@ -6,9 +6,7 @@ import {
     erAntallTimerGyldig,
     erUtdypendeVilkårsvurderingerGyldig,
 } from './BarnehageplassValidering';
-import { useApp } from '../../../../../../context/AppContext';
 import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import { ToggleNavn } from '../../../../../../typer/toggles';
 import type { Begrunnelse } from '../../../../../../typer/vedtak';
 import { UtdypendeVilkårsvurderingGenerell, VilkårType } from '../../../../../../typer/vilkår';
 import type { UtdypendeVilkårsvurdering } from '../../../../../../typer/vilkår';
@@ -45,9 +43,6 @@ export const useBarnehageplass = (vilkår: IVilkårResultat, person: IGrunnlagPe
         avslagBegrunnelser: vilkår.avslagBegrunnelser,
     };
 
-    const { toggles } = useApp();
-    const erLovendringTogglePå = toggles[ToggleNavn.lovendring7MndNyeBehandlinger];
-
     const vurderesEtter = useFelt<RegelverkType | undefined>({
         verdi: vilkårSkjema.vurderesEtter,
     });
@@ -78,7 +73,7 @@ export const useBarnehageplass = (vilkår: IVilkårResultat, person: IGrunnlagPe
             søkerHarMeldtFraOmBarnehageplass: søkerHarMeldtFraOmBarnehageplass.verdi,
         },
         valideringsfunksjon: (felt, avhengigheter) =>
-            erPeriodeGyldig(felt, VilkårType.BARNEHAGEPLASS, erLovendringTogglePå, avhengigheter),
+            erPeriodeGyldig(felt, VilkårType.BARNEHAGEPLASS, avhengigheter),
     });
 
     const felter = {

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
@@ -5,8 +5,6 @@ import { isBefore } from 'date-fns';
 import { Label, Radio, RadioGroup } from '@navikt/ds-react';
 
 import { muligeUtdypendeVilkårsvurderinger, useBarnetsAlder } from './BarnetsAlderContext';
-import { useApp } from '../../../../../../context/AppContext';
-import { ToggleNavn } from '../../../../../../typer/toggles';
 import { Resultat } from '../../../../../../typer/vilkår';
 import {
     datoForLovendringAugust24,
@@ -19,11 +17,11 @@ import { useVilkårSkjema } from '../../VilkårSkjemaContext';
 
 type BarnetsAlderProps = IVilkårSkjemaBaseProps;
 
-const hentSpørsmålForPeriode = (periode: IIsoDatoPeriode, erLovendringTogglePå: boolean) => {
+const hentSpørsmålForPeriode = (periode: IIsoDatoPeriode) => {
     const fraOgMedDato = isoStringTilDateEllerUndefinedHvisUgyldigDato(periode.fom);
     const fraOgMedErFørLovendring =
         fraOgMedDato && isBefore(fraOgMedDato, datoForLovendringAugust24);
-    if (fraOgMedErFørLovendring || !erLovendringTogglePå) {
+    if (fraOgMedErFørLovendring) {
         return 'Er barnet mellom 1 og 2 år eller adoptert?';
     } else {
         return 'Er barnet mellom 13 og 19 måneder eller adoptert?';
@@ -39,12 +37,7 @@ export const BarnetsAlder: React.FC<BarnetsAlderProps> = ({
 }: BarnetsAlderProps) => {
     const { felter } = useBarnetsAlder(vilkårResultat, person);
     const vilkårSkjemaContext = useVilkårSkjema(vilkårResultat, felter, person, toggleForm);
-    const { toggles } = useApp();
-    const erLovendringTogglePå = toggles[ToggleNavn.lovendring7MndNyeBehandlinger];
-    const spørsmål = hentSpørsmålForPeriode(
-        vilkårSkjemaContext.skjema.felter.periode.verdi,
-        erLovendringTogglePå
-    );
+    const spørsmål = hentSpørsmålForPeriode(vilkårSkjemaContext.skjema.felter.periode.verdi);
 
     return (
         <VilkårSkjema

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderContext.ts
@@ -1,10 +1,8 @@
 import { useFelt } from '@navikt/familie-skjema';
 
 import { erBegrunnelseGyldig, erUtdypendeVilkårsvurderingerGyldig } from './BarnetsAlderValidering';
-import { useApp } from '../../../../../../context/AppContext';
 import { useVilkårsvurdering } from '../../../../../../context/Vilkårsvurdering/VilkårsvurderingContext';
 import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import { ToggleNavn } from '../../../../../../typer/toggles';
 import type { Begrunnelse } from '../../../../../../typer/vedtak';
 import { UtdypendeVilkårsvurderingGenerell, VilkårType } from '../../../../../../typer/vilkår';
 import type { UtdypendeVilkårsvurdering } from '../../../../../../typer/vilkår';
@@ -52,9 +50,6 @@ export const useBarnetsAlder = (vilkår: IVilkårResultat, person: IGrunnlagPers
 
     const førsteLagredeFom = alleBarnetsAlderVilkårsResultaterSortert[0].periodeFom;
 
-    const { toggles } = useApp();
-    const erLovendringTogglePå = toggles[ToggleNavn.lovendring7MndNyeBehandlinger];
-
     const vurderesEtter = useFelt<RegelverkType | undefined>({
         verdi: vilkårSkjema.vurderesEtter,
     });
@@ -86,12 +81,7 @@ export const useBarnetsAlder = (vilkår: IVilkårResultat, person: IGrunnlagPers
                 førsteLagredeFom,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(
-                    felt,
-                    VilkårType.BARNETS_ALDER,
-                    erLovendringTogglePå,
-                    avhengigheter
-                ),
+                erPeriodeGyldig(felt, VilkårType.BARNETS_ALDER, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BorMedSøker/BorMedSøkerContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BorMedSøker/BorMedSøkerContext.ts
@@ -1,9 +1,7 @@
 import { useFelt } from '@navikt/familie-skjema';
 
 import { erUtdypendeVilkårsvurderingerGyldig } from './BorMedSøkerValidering';
-import { useApp } from '../../../../../../context/AppContext';
 import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import { ToggleNavn } from '../../../../../../typer/toggles';
 import type { Begrunnelse } from '../../../../../../typer/vedtak';
 import type { UtdypendeVilkårsvurdering } from '../../../../../../typer/vilkår';
 import type { IVilkårResultat } from '../../../../../../typer/vilkår';
@@ -33,9 +31,6 @@ export const useBorMedSøker = (vilkår: IVilkårResultat, person: IGrunnlagPers
         erEksplisittAvslagPåSøknad: vilkår.erEksplisittAvslagPåSøknad ?? false,
         avslagBegrunnelser: vilkår.avslagBegrunnelser,
     };
-
-    const { toggles } = useApp();
-    const erLovendringTogglePå = toggles[ToggleNavn.lovendring7MndNyeBehandlinger];
 
     const vurderesEtter = useFelt<RegelverkType | undefined>({
         verdi: vilkårSkjema.vurderesEtter,
@@ -69,12 +64,7 @@ export const useBorMedSøker = (vilkår: IVilkårResultat, person: IGrunnlagPers
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(
-                    felt,
-                    VilkårType.BOR_MED_SØKER,
-                    erLovendringTogglePå,
-                    avhengigheter
-                ),
+                erPeriodeGyldig(felt, VilkårType.BOR_MED_SØKER, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiketContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiketContext.ts
@@ -1,10 +1,8 @@
 import { useFelt } from '@navikt/familie-skjema';
 
 import { erUtdypendeVilkårsvurderingerGyldig } from './BosattIRiketValidering';
-import { useApp } from '../../../../../../context/AppContext';
 import { PersonType } from '../../../../../../typer/person';
 import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import { ToggleNavn } from '../../../../../../typer/toggles';
 import type { Begrunnelse } from '../../../../../../typer/vedtak';
 import type { UtdypendeVilkårsvurdering } from '../../../../../../typer/vilkår';
 import type { IVilkårResultat } from '../../../../../../typer/vilkår';
@@ -34,9 +32,6 @@ export const useBosattIRiket = (vilkår: IVilkårResultat, person: IGrunnlagPers
         erEksplisittAvslagPåSøknad: vilkår.erEksplisittAvslagPåSøknad ?? false,
         avslagBegrunnelser: vilkår.avslagBegrunnelser,
     };
-
-    const { toggles } = useApp();
-    const erLovendringTogglePå = toggles[ToggleNavn.lovendring7MndNyeBehandlinger];
 
     const vurderesEtter = useFelt<RegelverkType | undefined>({
         verdi: vilkårSkjema.vurderesEtter,
@@ -71,12 +66,7 @@ export const useBosattIRiket = (vilkår: IVilkårResultat, person: IGrunnlagPers
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(
-                    felt,
-                    VilkårType.BOSATT_I_RIKET,
-                    erLovendringTogglePå,
-                    avhengigheter
-                ),
+                erPeriodeGyldig(felt, VilkårType.BOSATT_I_RIKET, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOppholdContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOppholdContext.ts
@@ -1,8 +1,6 @@
 import { useFelt } from '@navikt/familie-skjema';
 
-import { useApp } from '../../../../../../context/AppContext';
 import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import { ToggleNavn } from '../../../../../../typer/toggles';
 import type { Begrunnelse } from '../../../../../../typer/vedtak';
 import type {
     IVilkårResultat,
@@ -28,9 +26,6 @@ export const useLovligOpphold = (vilkår: IVilkårResultat, person: IGrunnlagPer
         erEksplisittAvslagPåSøknad: vilkår.erEksplisittAvslagPåSøknad ?? false,
         avslagBegrunnelser: vilkår.avslagBegrunnelser,
     };
-
-    const { toggles } = useApp();
-    const erLovendringTogglePå = toggles[ToggleNavn.lovendring7MndNyeBehandlinger];
 
     const skalViseDatoVarsel =
         vilkår.resultat === Resultat.IKKE_VURDERT && vilkår.periode.fom !== undefined;
@@ -63,12 +58,7 @@ export const useLovligOpphold = (vilkår: IVilkårResultat, person: IGrunnlagPer
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(
-                    felt,
-                    VilkårType.LOVLIG_OPPHOLD,
-                    erLovendringTogglePå,
-                    avhengigheter
-                ),
+                erPeriodeGyldig(felt, VilkårType.LOVLIG_OPPHOLD, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Medlemskap/MedlemskapContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Medlemskap/MedlemskapContext.ts
@@ -1,8 +1,6 @@
 import { useFelt } from '@navikt/familie-skjema';
 
-import { useApp } from '../../../../../../context/AppContext';
 import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import { ToggleNavn } from '../../../../../../typer/toggles';
 import type { Begrunnelse } from '../../../../../../typer/vedtak';
 import type {
     IVilkårResultat,
@@ -28,9 +26,6 @@ export const useMedlemskap = (vilkår: IVilkårResultat, person: IGrunnlagPerson
         erEksplisittAvslagPåSøknad: vilkår.erEksplisittAvslagPåSøknad ?? false,
         avslagBegrunnelser: vilkår.avslagBegrunnelser,
     };
-
-    const { toggles } = useApp();
-    const erLovendringTogglePå = toggles[ToggleNavn.lovendring7MndNyeBehandlinger];
 
     const skalViseDatoVarsel =
         vilkår.resultat === Resultat.IKKE_VURDERT && vilkår.periode.fom !== undefined;
@@ -63,7 +58,7 @@ export const useMedlemskap = (vilkår: IVilkårResultat, person: IGrunnlagPerson
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
             },
             valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(felt, VilkårType.MEDLEMSKAP, erLovendringTogglePå, avhengigheter),
+                erPeriodeGyldig(felt, VilkårType.MEDLEMSKAP, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelderContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelderContext.ts
@@ -1,9 +1,7 @@
 import { useFelt } from '@navikt/familie-skjema';
 
 import { erPeriodeGyldig } from './MedlemskapAnnenForelderValidering';
-import { useApp } from '../../../../../../context/AppContext';
 import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import { ToggleNavn } from '../../../../../../typer/toggles';
 import type { Begrunnelse } from '../../../../../../typer/vedtak';
 import type { IVilkårResultat } from '../../../../../../typer/vilkår';
 import type {
@@ -25,9 +23,6 @@ export const useMedlemskapAnnenForelder = (vilkår: IVilkårResultat, person: IG
         erEksplisittAvslagPåSøknad: vilkår.erEksplisittAvslagPåSøknad ?? false,
         avslagBegrunnelser: vilkår.avslagBegrunnelser,
     };
-
-    const { toggles } = useApp();
-    const erLovendringTogglePå = toggles[ToggleNavn.lovendring7MndNyeBehandlinger];
 
     const vurderesEtter = useFelt<RegelverkType | undefined>({
         verdi: vilkårSkjema.vurderesEtter,
@@ -58,8 +53,7 @@ export const useMedlemskapAnnenForelder = (vilkår: IVilkårResultat, person: IG
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
                 erMedlemskapAnnenForelderVilkår: true,
             },
-            valideringsfunksjon: (felt, avhengigheter) =>
-                erPeriodeGyldig(felt, erLovendringTogglePå, avhengigheter),
+            valideringsfunksjon: (felt, avhengigheter) => erPeriodeGyldig(felt, avhengigheter),
         }),
         begrunnelse: useFelt<string>({
             verdi: vilkårSkjema.begrunnelse,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelderValidering.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelderValidering.ts
@@ -7,16 +7,10 @@ import { erPeriodeGyldig as erPeriodeGyldigDefault } from '../../../../../../uti
 
 export const erPeriodeGyldig = (
     felt: FeltState<IIsoDatoPeriode>,
-    erLovendringTogglePå: boolean,
     avhengigheter?: Avhengigheter
 ): FeltState<IIsoDatoPeriode> => {
     if (avhengigheter && avhengigheter.resultat.verdi === Resultat.IKKE_AKTUELT) {
         return ok(felt);
     }
-    return erPeriodeGyldigDefault(
-        felt,
-        VilkårType.MEDLEMSKAP_ANNEN_FORELDER,
-        erLovendringTogglePå,
-        avhengigheter
-    );
+    return erPeriodeGyldigDefault(felt, VilkårType.MEDLEMSKAP_ANNEN_FORELDER, avhengigheter);
 };

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -7,7 +7,6 @@ export enum ToggleNavn {
     kanManueltKorrigereMedVedtaksbrev = 'familie-ks-sak.behandling.korreksjon-vedtaksbrev',
     tekniskVedlikeholdHenleggelse = 'familie-ks-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring',
     kanBehandleKlage = 'familie-ks-sak.klage',
-    lovendring7MndNyeBehandlinger = 'familie-ks-sak.lov-endring-7-mnd-nye-behandlinger',
     kanOppretteOgEndreSammensatteKontrollsaker = 'familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker',
     skalObfuskereData = 'familie-ks-sak.anonymiser-persondata',
     overgangsordningErTilgjengelig = 'familie-ks-sak.overgangsordning',

--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -38,7 +38,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('400220', undefined)
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson(),
             erEksplisittAvslagPåSøknad: false,
         });
@@ -50,7 +50,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2020-06-17', '400220')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson(),
             erEksplisittAvslagPåSøknad: false,
         });
@@ -62,7 +62,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode(undefined, undefined)
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson(),
             erEksplisittAvslagPåSøknad: false,
         });
@@ -74,7 +74,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode(undefined, '2010-05-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson(),
             erEksplisittAvslagPåSøknad: true,
         });
@@ -88,7 +88,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode(undefined, undefined)
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson(),
             erEksplisittAvslagPåSøknad: true,
         });
@@ -99,7 +99,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2010-06-17', '2010-01-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson(),
             erEksplisittAvslagPåSøknad: true,
         });
@@ -111,7 +111,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('1999-05-17', '2018-05-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson(),
             erEksplisittAvslagPåSøknad: false,
         });
@@ -125,7 +125,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2000-05-17', '2021-05-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson({ dødsfallDato: '2020-12-12' }),
             erEksplisittAvslagPåSøknad: true,
         });
@@ -139,7 +139,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2020-12-12', '2020-12-12')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson(),
             erEksplisittAvslagPåSøknad: false,
         });
@@ -151,7 +151,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2020-12-12', '2020-12-12')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson({ dødsfallDato: '2020-12-12' }),
             erEksplisittAvslagPåSøknad: false,
         });
@@ -162,7 +162,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2001-05-17', '2018-05-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, {
             person: lagGrunnlagPerson(),
             erEksplisittAvslagPåSøknad: false,
         });
@@ -176,7 +176,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2024-08-01', '2024-12-01')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, {
             person: lagGrunnlagPerson({ fødselsdato: '2023-05-17' }),
             erEksplisittAvslagPåSøknad: false,
         });
@@ -190,7 +190,7 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2001-05-17', '2018-05-18')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.LOVLIG_OPPHOLD, {
             person: lagGrunnlagPerson(),
             erEksplisittAvslagPåSøknad: false,
         });
@@ -201,19 +201,8 @@ describe('utils/validators', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
             nyIsoDatoPeriode('2001-05-17', '2002-05-17')
         );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, true, {
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, {
             person: lagGrunnlagPerson(),
-            erEksplisittAvslagPåSøknad: false,
-        });
-        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
-    });
-
-    test('Skal validere ok etter gamle regler hvis toggle er av', () => {
-        const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
-            nyIsoDatoPeriode('2024-05-17', '2025-05-17')
-        );
-        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, false, {
-            person: lagGrunnlagPerson({ fødselsdato: '2023-05-17' }),
             erEksplisittAvslagPåSøknad: false,
         });
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);

--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -8,7 +8,7 @@ import generator from '../../testverktøy/fnr/fnr-generator';
 import type { IGrunnlagPerson } from '../../typer/person';
 import { PersonType } from '../../typer/person';
 import { Målform } from '../../typer/søknad';
-import { Resultat, VilkårType } from '../../typer/vilkår';
+import { Resultat, UtdypendeVilkårsvurderingGenerell, VilkårType } from '../../typer/vilkår';
 import type { IIsoDatoPeriode } from '../dato';
 import { nyIsoDatoPeriode } from '../dato';
 import { erPeriodeGyldig, erResultatGyldig, identValidator } from '../validators';
@@ -206,6 +206,32 @@ describe('utils/validators', () => {
             erEksplisittAvslagPåSøknad: false,
         });
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
+    });
+
+    test('Periode innenfor 7mnd etter lovendring 2024 gir ok for adopsjon', () => {
+        const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
+            nyIsoDatoPeriode('2024-10-28', '2025-05-28')
+        );
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, {
+            person: lagGrunnlagPerson({ fødselsdato: '2023-05-17' }),
+            erEksplisittAvslagPåSøknad: false,
+            førsteLagredeFom: undefined,
+            utdypendeVilkårsvurdering: [UtdypendeVilkårsvurderingGenerell.ADOPSJON],
+        });
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
+    });
+
+    test('Periode lengre enn 7mnd etter lovendring 2024 gir feil for adopsjon', () => {
+        const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
+            nyIsoDatoPeriode('2024-10-28', '2025-06-28')
+        );
+        const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, {
+            person: lagGrunnlagPerson({ fødselsdato: '2023-05-17' }),
+            erEksplisittAvslagPåSøknad: false,
+            førsteLagredeFom: undefined,
+            utdypendeVilkårsvurdering: [UtdypendeVilkårsvurderingGenerell.ADOPSJON],
+        });
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
     });
 
     test('Validering av ident', () => {

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -82,8 +82,8 @@ const datoDifferanseMerEnn1År = (fom: Date, tom: Date) => {
 };
 
 const datoDifferanseMerEnnXAntallMåneder = (fom: Date, tom: Date, antallMåneder: number) => {
-    const fomDatoPluss1År = addMonths(fom, antallMåneder);
-    return isBefore(fomDatoPluss1År, tom);
+    const fomDatoPlussXAntallMåneder = addMonths(fom, antallMåneder);
+    return isBefore(fomDatoPlussXAntallMåneder, tom);
 };
 
 const finnesDatoFørFødselsdato = (person: IGrunnlagPerson, fom: Date, tom?: Date) => {

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -103,7 +103,6 @@ const valgtDatoErSenereEnnNesteMåned = (valgtDato: Date) =>
 export const erPeriodeGyldig = (
     felt: FeltState<IIsoDatoPeriode>,
     vilkår: VilkårType,
-    erLovendringTogglePå: boolean,
     avhengigheter?: Avhengigheter
 ): FeltState<IIsoDatoPeriode> => {
     const person: IGrunnlagPerson | undefined = avhengigheter?.person;
@@ -154,7 +153,7 @@ export const erPeriodeGyldig = (
                             );
                         }
 
-                        if (isBefore(tom, datoForLovendringAugust24) || !erLovendringTogglePå) {
+                        if (isBefore(tom, datoForLovendringAugust24)) {
                             if (tom && datoDifferanseMerEnn1År(fom, tom)) {
                                 return feil(
                                     felt,
@@ -173,7 +172,7 @@ export const erPeriodeGyldig = (
                             }
                         }
                     } else {
-                        if (isBefore(tom, datoForLovendringAugust24) || !erLovendringTogglePå) {
+                        if (isBefore(tom, datoForLovendringAugust24)) {
                             if (!datoErPersonsXÅrsdag(person, fom, 1)) {
                                 return feil(felt, 'F.o.m datoen må være lik barnets 1 års dag');
                             }

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -20,6 +20,7 @@ import {
     dagensDato,
     datoForLovendringAugust24,
     type IIsoDatoPeriode,
+    type IsoDatoString,
     isoStringTilDate,
 } from './dato';
 import { erBegrunnelsePåkrevd } from '../komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema';
@@ -136,7 +137,12 @@ export const erPeriodeGyldig = (
                     return feil(felt, 'Du kan ikke legge til periode før barnets fødselsdato');
                 }
                 if (erBarnetsAlderVilkår) {
-                    const førsteLagredeFom = avhengigheter?.førsteLagredeFom;
+                    const førsteLagredeFom: IsoDatoString | undefined =
+                        avhengigheter?.førsteLagredeFom;
+
+                    const førsteFomPåVilkåret: Date = førsteLagredeFom
+                        ? isoStringTilDate(førsteLagredeFom)
+                        : fom;
 
                     const erAdopsjon = utdypendeVilkårsvurdering?.includes(
                         UtdypendeVilkårsvurderingGenerell.ADOPSJON
@@ -163,7 +169,7 @@ export const erPeriodeGyldig = (
                         } else {
                             if (
                                 tom &&
-                                datoDifferanseMerEnnXAntallMåneder(førsteLagredeFom, tom, 7)
+                                datoDifferanseMerEnnXAntallMåneder(førsteFomPåVilkåret, tom, 7)
                             ) {
                                 return feil(
                                     felt,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23765

Gjør to ting:
- Fjerner toggle for lovendring som har vært skrudd på i prod siden sommeren
- Fikser opp i buggen i favro-kortet over. Grunnen til feilen var at når man skal lagre og validere den aller første perioden så er `førsteLagredeFom = undefined`. Retter feilen ved å defaulte til `fom`-verdien til vilkåret man holder på å opprette hvis det ikke finnes noen allerede lagrede fom

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ja. Validering for adopsjon fungerer kun i frontend hvis det er 1 periode, eller den eldste perioden blir lagt til først. Hvis man legger til en eldre periode ETTER at man har lagt til en nyere periode så får man lov til å legge inn oppfylt vilkår i alt for lang tidsperiode. Dette er ikke så lett å fikse i valideringen frontend fordi vi her kun ser på en og en vilkårperiode. Dette kan fikses i backend, men jeg er usikker på hvor mye tid vi skal bruke på det da det er en veldig nisje edge case OG saksbehandler blir stoppet i neste steg så det er ikke faktisk mulig å utbetalt for for mange måneder. Vil gjerne ha innspill her! 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit er nok lurt

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
