### PR TITLE
Allerede utbetalt: Det skal være mulig å velge "Perioden skal utbetales" og fremdeles gi avslag

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -158,6 +158,9 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
     }, [skjema.felter.årsak.verdi]);
 
     const erLesevisning = vurderErLesevisning();
+    const skalViseEksplisittAvslagsfelt =
+        skjema.felter.årsak.verdi === IEndretUtbetalingAndelÅrsak.ALLEREDE_UTBETALT ||
+        !skjema.felter.periodeSkalUtbetalesTilSøker.verdi;
 
     return (
         <>
@@ -293,7 +296,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                   children={'Vurderingen er et avslag'}
                               />
                           )
-                        : !skjema.felter.periodeSkalUtbetalesTilSøker.verdi && (
+                        : skalViseEksplisittAvslagsfelt && (
                               <Checkbox
                                   value={'Vurderingen er et avslag'}
                                   checked={skjema.felter.erEksplisittAvslagPåSøknad.verdi}

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -166,7 +166,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
         <>
             <StyledFieldset
                 error={hentFrontendFeilmelding(skjema.submitRessurs)}
-                legend={'Skjema for å endre utbetalingsandel'}
+                legend="Skjema for å endre utbetalingsandel"
                 hideLegend
             >
                 <Feltmargin>
@@ -202,7 +202,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     <Feltmargin>
                         <MånedÅrVelger
                             {...skjema.felter.fom.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                            label={'F.o.m'}
+                            label="F.o.m"
                             value={skjema.felter.fom.verdi}
                             antallÅrFrem={finnÅrFremTilStønadTom()}
                             antallÅrTilbake={finnÅrTilbakeTilStønadFra()}
@@ -218,7 +218,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     </Feltmargin>
                     <MånedÅrVelger
                         {...skjema.felter.tom.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        label={'T.o.m (valgfri)'}
+                        label="T.o.m (valgfri)"
                         value={skjema.felter.tom.verdi}
                         antallÅrFrem={finnÅrFremTilStønadTom()}
                         antallÅrTilbake={finnÅrTilbakeTilStønadFra()}
@@ -272,18 +272,18 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                             }}
                         >
                             <Radio
-                                name={'utbetaling'}
+                                name="utbetaling"
                                 value={true}
-                                id={'ja-perioden-utbetales-til-søker'}
+                                id="ja-perioden-utbetales-til-søker"
                             >
-                                {'Perioden skal utbetales'}
+                                Perioden skal utbetales
                             </Radio>
                             <Radio
-                                name={'utbetaling'}
+                                name="utbetaling"
                                 value={false}
-                                id={'nei-perioden-skal-ikke-utbetales-til-søker'}
+                                id="nei-perioden-skal-ikke-utbetales-til-søker"
                             >
-                                {'Perioden skal ikke utbetales'}
+                                Perioden skal ikke utbetales
                             </Radio>
                         </RadioGroup>
                     )}
@@ -293,12 +293,12 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                         ? skjema.felter.erEksplisittAvslagPåSøknad.verdi && (
                               <BodyShort
                                   className={classNames('skjemaelement', 'lese-felt')}
-                                  children={'Vurderingen er et avslag'}
+                                  children="Vurderingen er et avslag"
                               />
                           )
                         : skalViseEksplisittAvslagsfelt && (
                               <Checkbox
-                                  value={'Vurderingen er et avslag'}
+                                  value="Vurderingen er et avslag"
                                   checked={skjema.felter.erEksplisittAvslagPåSøknad.verdi}
                                   onChange={event =>
                                       skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
@@ -306,7 +306,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                       )
                                   }
                               >
-                                  {'Vurderingen er et avslag'}
+                                  Vurderingen er et avslag
                               </Checkbox>
                           )}
                 </Feltmargin>
@@ -321,7 +321,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                 <Feltmargin>
                     <Datovelger
                         felt={skjema.felter.søknadstidspunkt}
-                        label={'Søknadstidspunkt'}
+                        label="Søknadstidspunkt"
                         visFeilmeldinger={skjema.visFeilmeldinger}
                         readOnly={erLesevisning}
                         kanKunVelgeFortid
@@ -332,8 +332,8 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     <StyledTextarea
                         {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
                         readOnly={erLesevisning}
-                        placeholder={'Begrunn hvorfor utbetalingsperioden er endret.'}
-                        label={'Begrunnelse'}
+                        placeholder="Begrunn hvorfor utbetalingsperioden er endret."
+                        label="Begrunnelse"
                         value={
                             skjema.felter.begrunnelse.verdi !== null &&
                             skjema.felter.begrunnelse.verdi !== undefined
@@ -349,8 +349,8 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     <Knapperekke>
                         <KnapperekkeVenstre>
                             <StyledFerdigKnapp
-                                size={'small'}
-                                variant={'secondary'}
+                                size="small"
+                                variant="secondary"
                                 onClick={() => oppdaterEndretUtbetaling(lukkSkjema)}
                             >
                                 Bekreft
@@ -369,13 +369,13 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
 
                         {!erLesevisning && (
                             <Button
-                                variant={'tertiary'}
+                                variant="tertiary"
                                 id={`sletteknapp-endret-utbetaling-andel-${endretUtbetalingAndel.id}`}
-                                size={'small'}
+                                size="small"
                                 onClick={slettEndretUtbetaling}
                                 icon={<TrashIcon />}
                             >
-                                {'Fjern periode'}
+                                Fjern periode
                             </Button>
                         )}
                     </Knapperekke>


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23815

### 💰 Hva forsøker du å løse i denne PR'en
I en revurdering der søker har fått pengene sine i første omgang og søker om de samme pengene på nytt ønsker vi å bruke endrede utbetalingsperioder til å si at ja, pengene skal utbetales, men nei, søker får ikke mer penger fordi alt allerede er utbetalt. Dermed har jeg tilrettelagt for å vise avhukingsboksen (og implisitt begrunnelsen for avslaget) også for "Perioden skal utbetales", for årsaken Allerede utbetalt.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Jeg har også fikset opp i unødvendige krøllparenteser rundt tekststrenger, derfor er det mer gjort enn kun den lille visningsendringen. Dette burde kanskje tas commit for commit for å gjøre reviewjobben enklest mulig.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Det fantes ingen tester for dette fra før av.

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Før:
<img width="610" alt="image" src="https://github.com/user-attachments/assets/025451f5-f53d-4a47-93de-28075305f4cf" />

Etter:
<img width="570" alt="image" src="https://github.com/user-attachments/assets/2f481890-9b6b-4558-be98-68a60333e14d" />

