### PR TITLE
Vedtakbegrunnelser istedenfor begrunnelser i endret utbetaling andel

### DIFF
--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -48,7 +48,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 søknadstidspunkt: Date | undefined;
                 begrunnelse: string | undefined;
                 erEksplisittAvslagPåSøknad: boolean | undefined;
-                vedtakbegrunnelser: Begrunnelse[] | undefined;
+                vedtaksbegrunnelser: Begrunnelse[] | undefined;
             },
             IBehandling
         >({
@@ -84,7 +84,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                         felt.verdi ? ok(felt) : feil(felt, 'Du må oppgi en begrunnelse.'),
                 }),
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad,
-                vedtakbegrunnelser: useFelt<Begrunnelse[] | undefined>({
+                vedtaksbegrunnelser: useFelt<Begrunnelse[] | undefined>({
                     verdi: undefined,
                     valideringsfunksjon: erAvslagBegrunnelseGyldig,
                     avhengigheter: {
@@ -108,8 +108,8 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
                 endretUtbetalingAndel.erEksplisittAvslagPåSøknad
             );
-            skjema.felter.vedtakbegrunnelser.validerOgSettFelt(
-                endretUtbetalingAndel.vedtakbegrunnelser
+            skjema.felter.vedtaksbegrunnelser.validerOgSettFelt(
+                endretUtbetalingAndel.vedtaksbegrunnelser
             );
             skjema.felter.søknadstidspunkt.validerOgSettFelt(
                 endretUtbetalingAndel.søknadstidspunkt
@@ -139,7 +139,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 begrunnelse,
                 søknadstidspunkt,
                 erEksplisittAvslagPåSøknad,
-                vedtakbegrunnelser,
+                vedtaksbegrunnelser,
             } = skjema.felter;
             return {
                 id: endretUtbetalingAndel.id,
@@ -152,7 +152,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 søknadstidspunkt: dateTilIsoDatoStringEllerUndefined(søknadstidspunkt.verdi),
                 erTilknyttetAndeler: endretUtbetalingAndel.erTilknyttetAndeler,
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
-                vedtakbegrunnelser: vedtakbegrunnelser && vedtakbegrunnelser.verdi,
+                vedtaksbegrunnelser: vedtaksbegrunnelser && vedtaksbegrunnelser.verdi,
             };
         };
 

--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -48,7 +48,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 søknadstidspunkt: Date | undefined;
                 begrunnelse: string | undefined;
                 erEksplisittAvslagPåSøknad: boolean | undefined;
-                begrunnelser: Begrunnelse[] | undefined;
+                vedtakbegrunnelser: Begrunnelse[] | undefined;
             },
             IBehandling
         >({
@@ -84,7 +84,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                         felt.verdi ? ok(felt) : feil(felt, 'Du må oppgi en begrunnelse.'),
                 }),
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad,
-                begrunnelser: useFelt<Begrunnelse[] | undefined>({
+                vedtakbegrunnelser: useFelt<Begrunnelse[] | undefined>({
                     verdi: undefined,
                     valideringsfunksjon: erAvslagBegrunnelseGyldig,
                     avhengigheter: {
@@ -108,7 +108,9 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
                 endretUtbetalingAndel.erEksplisittAvslagPåSøknad
             );
-            skjema.felter.begrunnelser.validerOgSettFelt(endretUtbetalingAndel.begrunnelser);
+            skjema.felter.vedtakbegrunnelser.validerOgSettFelt(
+                endretUtbetalingAndel.vedtakbegrunnelser
+            );
             skjema.felter.søknadstidspunkt.validerOgSettFelt(
                 endretUtbetalingAndel.søknadstidspunkt
                     ? new Date(endretUtbetalingAndel.søknadstidspunkt)
@@ -137,7 +139,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 begrunnelse,
                 søknadstidspunkt,
                 erEksplisittAvslagPåSøknad,
-                begrunnelser,
+                vedtakbegrunnelser,
             } = skjema.felter;
             return {
                 id: endretUtbetalingAndel.id,
@@ -150,7 +152,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 søknadstidspunkt: dateTilIsoDatoStringEllerUndefined(søknadstidspunkt.verdi),
                 erTilknyttetAndeler: endretUtbetalingAndel.erTilknyttetAndeler,
                 erEksplisittAvslagPåSøknad: erEksplisittAvslagPåSøknad.verdi,
-                begrunnelser: begrunnelser && begrunnelser.verdi,
+                vedtakbegrunnelser: vedtakbegrunnelser && vedtakbegrunnelser.verdi,
             };
         };
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -150,10 +150,10 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
     useEffect(() => {
         if (
             skjema.felter.årsak.verdi !== IEndretUtbetalingAndelÅrsak.ALLEREDE_UTBETALT &&
-            skjema.felter.begrunnelser.verdi &&
-            skjema.felter.begrunnelser.verdi.length > 0
+            skjema.felter.vedtakbegrunnelser.verdi &&
+            skjema.felter.vedtakbegrunnelser.verdi.length > 0
         ) {
-            skjema.felter.begrunnelser.validerOgSettFelt([]);
+            skjema.felter.vedtakbegrunnelser.validerOgSettFelt([]);
         }
     }, [skjema.felter.årsak.verdi]);
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -150,10 +150,10 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
     useEffect(() => {
         if (
             skjema.felter.årsak.verdi !== IEndretUtbetalingAndelÅrsak.ALLEREDE_UTBETALT &&
-            skjema.felter.vedtakbegrunnelser.verdi &&
-            skjema.felter.vedtakbegrunnelser.verdi.length > 0
+            skjema.felter.vedtaksbegrunnelser.verdi &&
+            skjema.felter.vedtaksbegrunnelser.verdi.length > 0
         ) {
-            skjema.felter.vedtakbegrunnelser.validerOgSettFelt([]);
+            skjema.felter.vedtaksbegrunnelser.validerOgSettFelt([]);
         }
     }, [skjema.felter.årsak.verdi]);
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAvslagBegrunnelse.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAvslagBegrunnelse.tsx
@@ -26,8 +26,9 @@ export const EndretUtbetalingAvslagBegrunnelse: React.FC = () => {
     const { skjema } = useEndretUtbetalingAndel();
 
     const prevalgtBegrunnelse =
-        skjema.felter.vedtakbegrunnelser.verdi && skjema.felter.vedtakbegrunnelser.verdi.length > 0
-            ? skjema.felter.vedtakbegrunnelser.verdi[0]
+        skjema.felter.vedtaksbegrunnelser.verdi &&
+        skjema.felter.vedtaksbegrunnelser.verdi.length > 0
+            ? skjema.felter.vedtaksbegrunnelser.verdi[0]
             : undefined;
 
     const gyldigeBegrunnelseTyper = [BegrunnelseType.AVSLAG];
@@ -92,7 +93,7 @@ export const EndretUtbetalingAvslagBegrunnelse: React.FC = () => {
 
     return (
         <FamilieReactSelect
-            {...skjema.felter.vedtakbegrunnelser.hentNavInputProps(skjema.visFeilmeldinger)}
+            {...skjema.felter.vedtaksbegrunnelser.hentNavInputProps(skjema.visFeilmeldinger)}
             value={finnBegrunnelseForSelect(prevalgtBegrunnelse)}
             label={'Velg standardtekst i brev'}
             creatable={false}
@@ -106,9 +107,9 @@ export const EndretUtbetalingAvslagBegrunnelse: React.FC = () => {
                         Vi ønsker kun en begrunnelse her, men modellen tilsier at det skal være en array.
                         Hardkoder dermed den ene valgte verdien som en array med en begrunnelse.
                     */
-                    skjema.felter.vedtakbegrunnelser.validerOgSettFelt([options.value]);
+                    skjema.felter.vedtaksbegrunnelser.validerOgSettFelt([options.value]);
                 } else {
-                    skjema.felter.vedtakbegrunnelser.validerOgSettFelt([]);
+                    skjema.felter.vedtaksbegrunnelser.validerOgSettFelt([]);
                 }
             }}
             formatGroupLabel={(group: GroupBase<OptionType>) => {

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAvslagBegrunnelse.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAvslagBegrunnelse.tsx
@@ -26,8 +26,8 @@ export const EndretUtbetalingAvslagBegrunnelse: React.FC = () => {
     const { skjema } = useEndretUtbetalingAndel();
 
     const prevalgtBegrunnelse =
-        skjema.felter.begrunnelser.verdi && skjema.felter.begrunnelser.verdi.length > 0
-            ? skjema.felter.begrunnelser.verdi[0]
+        skjema.felter.vedtakbegrunnelser.verdi && skjema.felter.vedtakbegrunnelser.verdi.length > 0
+            ? skjema.felter.vedtakbegrunnelser.verdi[0]
             : undefined;
 
     const gyldigeBegrunnelseTyper = [BegrunnelseType.AVSLAG];
@@ -92,7 +92,7 @@ export const EndretUtbetalingAvslagBegrunnelse: React.FC = () => {
 
     return (
         <FamilieReactSelect
-            {...skjema.felter.begrunnelser.hentNavInputProps(skjema.visFeilmeldinger)}
+            {...skjema.felter.vedtakbegrunnelser.hentNavInputProps(skjema.visFeilmeldinger)}
             value={finnBegrunnelseForSelect(prevalgtBegrunnelse)}
             label={'Velg standardtekst i brev'}
             creatable={false}
@@ -106,9 +106,9 @@ export const EndretUtbetalingAvslagBegrunnelse: React.FC = () => {
                         Vi ønsker kun en begrunnelse her, men modellen tilsier at det skal være en array.
                         Hardkoder dermed den ene valgte verdien som en array med en begrunnelse.
                     */
-                    skjema.felter.begrunnelser.validerOgSettFelt([options.value]);
+                    skjema.felter.vedtakbegrunnelser.validerOgSettFelt([options.value]);
                 } else {
-                    skjema.felter.begrunnelser.validerOgSettFelt([]);
+                    skjema.felter.vedtakbegrunnelser.validerOgSettFelt([]);
                 }
             }}
             formatGroupLabel={(group: GroupBase<OptionType>) => {

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../../utils/test/vedtak/vedtaksperiode.mock';
 import { filtrerOgSorterPerioderMedBegrunnelseBehov } from '../../../../../utils/vedtakUtils';
 
-describe('VedtakBegrunnelserContext', () => {
+describe('VedtaksBegrunnelserContext', () => {
     describe('Test filtrerOgSorterPerioderMedBegrunnelseBehov', () => {
         const fom = '2020-01-01';
         const tom = '2020-02-28';

--- a/src/frontend/typer/utbetalingAndel.ts
+++ b/src/frontend/typer/utbetalingAndel.ts
@@ -14,7 +14,7 @@ export interface IRestEndretUtbetalingAndel {
     årsak?: IEndretUtbetalingAndelÅrsak;
     erTilknyttetAndeler?: boolean;
     erEksplisittAvslagPåSøknad?: boolean;
-    vedtakbegrunnelser?: Begrunnelse[];
+    vedtaksbegrunnelser?: Begrunnelse[];
 }
 
 export enum IEndretUtbetalingAndelÅrsak {

--- a/src/frontend/typer/utbetalingAndel.ts
+++ b/src/frontend/typer/utbetalingAndel.ts
@@ -14,7 +14,7 @@ export interface IRestEndretUtbetalingAndel {
     årsak?: IEndretUtbetalingAndelÅrsak;
     erTilknyttetAndeler?: boolean;
     erEksplisittAvslagPåSøknad?: boolean;
-    begrunnelser?: Begrunnelse[];
+    vedtakbegrunnelser?: Begrunnelse[];
 }
 
 export enum IEndretUtbetalingAndelÅrsak {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23583

I EndretUtbetalingAndel har vi både feltet "begrunnelse" og "begrunnelser", som er noe forvirrende. Sistnevnte burde døpes om til å bli "vedtakbegrunnelser" i stedet. Det er snakk om Sanity-begrunnelsene som saksbehandler velger som vises i brevet.