### PR TITLE
Nå som tom ikke lenger er valgfri må vi fjerne teksten som sier at det er valgfritt

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -218,7 +218,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     </Feltmargin>
                     <MånedÅrVelger
                         {...skjema.felter.tom.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        label="T.o.m (valgfri)"
+                        label="T.o.m"
                         value={skjema.felter.tom.verdi}
                         antallÅrFrem={finnÅrFremTilStønadTom()}
                         antallÅrTilbake={finnÅrTilbakeTilStønadFra()}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23943

Ikke direkte relatert til favrokortet.
Men tom er ikke lenger valgfritt når man oppdaterer endret utbetaling andel, og vi fjerner derfor teksten om at det er valgfritt.