### PR TITLE
Fix: endre maks differanse på barnets alder vilkår til å være 6mnd for adopsjon

### DIFF
--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -208,9 +208,9 @@ describe('utils/validators', () => {
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
     });
 
-    test('Periode innenfor 7mnd etter lovendring 2024 gir ok for adopsjon', () => {
+    test('Periode innenfor 6mnd etter lovendring 2024 gir ok for adopsjon', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
-            nyIsoDatoPeriode('2024-10-28', '2025-05-28')
+            nyIsoDatoPeriode('2024-10-28', '2025-04-28')
         );
         const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, {
             person: lagGrunnlagPerson({ fødselsdato: '2023-05-17' }),
@@ -221,9 +221,9 @@ describe('utils/validators', () => {
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
     });
 
-    test('Periode lengre enn 7mnd etter lovendring 2024 gir feil for adopsjon', () => {
+    test('Periode lengre enn 6mnd etter lovendring 2024 gir feil for adopsjon', () => {
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(
-            nyIsoDatoPeriode('2024-10-28', '2025-06-28')
+            nyIsoDatoPeriode('2024-10-28', '2025-05-28')
         );
         const valideringsresultat = erPeriodeGyldig(periode, VilkårType.BARNETS_ALDER, {
             person: lagGrunnlagPerson({ fødselsdato: '2023-05-17' }),

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -169,11 +169,11 @@ export const erPeriodeGyldig = (
                         } else {
                             if (
                                 tom &&
-                                datoDifferanseMerEnnXAntallMåneder(førsteFomPåVilkåret, tom, 7)
+                                datoDifferanseMerEnnXAntallMåneder(førsteFomPåVilkåret, tom, 6)
                             ) {
                                 return feil(
                                     felt,
-                                    'Differansen mellom tidligste f.o.m.-dato og t.o.m.-datoen kan ikke være mer enn 7 måneder'
+                                    'Differansen mellom tidligste f.o.m.-dato og t.o.m.-datoen kan ikke være mer enn 6 måneder'
                                 );
                             }
                         }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23940

For barnets alder-vilkåret har vi tillatt en måned for mye for adopsjonssaker, så de har fått generert andeler i 8 måneder i stedet for 7. Som man kan se i favro-kortet så blir man stoppet av en feilmelding på behandlingsresultat-siden, men dette burde ikke vært tillatt å legge inn i vilkåret, slik at saksbehandler får feilmeldingen tidligere. For vanlige saker er det 6 måneder diff som tillates i vilkåret (fom=13mnd og tom=16mnd = 6mnd diff).

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Backend PR: https://github.com/navikt/familie-ks-sak/pull/1035

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
