### PR TITLE
Alltid vis alle vedtaksperioder på vedtak-siden

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -6,7 +6,9 @@ import { Alert, Heading, HelpText } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import VedtaksperiodeMedBegrunnelserPanel from './VedtaksperiodeMedBegrunnelserPanel';
+import { useApp } from '../../../../../context/AppContext';
 import type { IBehandling } from '../../../../../typer/behandling';
+import { ToggleNavn } from '../../../../../typer/toggles';
 import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../typer/vedtaksperiode';
 import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
 import { partition } from '../../../../../utils/commons';
@@ -36,12 +38,14 @@ const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
     åpenBehandling,
 }) => {
     const { vedtaksbegrunnelseTekster } = useVedtaksbegrunnelseTekster();
+    const { toggles } = useApp();
 
     const sorterteVedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
         åpenBehandling.vedtak?.vedtaksperioderMedBegrunnelser ?? [],
         åpenBehandling.resultat,
         åpenBehandling.status,
-        åpenBehandling.sisteVedtaksperiodeVisningDato
+        åpenBehandling.sisteVedtaksperiodeVisningDato,
+        toggles[ToggleNavn.skalAlltidViseAlleVedtaksperioder]
     );
 
     if (

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
@@ -27,7 +27,8 @@ describe('VedtaksBegrunnelserContext', () => {
                 vedtaksperioder,
                 BehandlingResultat.AVSLÅTT_ENDRET_OG_OPPHØRT,
                 BehandlingStatus.UTREDES,
-                undefined
+                undefined,
+                true
             );
             expect(perioder.length).toBe(3);
             expect(perioder[0].type).toBe(Vedtaksperiodetype.UTBETALING);
@@ -45,7 +46,8 @@ describe('VedtaksBegrunnelserContext', () => {
                     vedtaksperioder,
                     BehandlingResultat.INNVILGET_OG_OPPHØRT,
                     BehandlingStatus.AVSLUTTET,
-                    undefined
+                    undefined,
+                    true
                 );
                 expect(perioder.length).toBe(1);
                 expect(perioder[0].type).toEqual(Vedtaksperiodetype.OPPHØR);
@@ -65,7 +67,8 @@ describe('VedtaksBegrunnelserContext', () => {
                     ],
                     BehandlingResultat.INNVILGET,
                     BehandlingStatus.UTREDES,
-                    undefined
+                    undefined,
+                    false
                 );
                 expect(perioder.length).toBe(1);
             });
@@ -82,7 +85,8 @@ describe('VedtaksBegrunnelserContext', () => {
                     ],
                     BehandlingResultat.INNVILGET,
                     BehandlingStatus.UTREDES,
-                    undefined
+                    undefined,
+                    false
                 );
                 expect(perioder.length).toBe(0);
             });
@@ -96,7 +100,8 @@ describe('VedtaksBegrunnelserContext', () => {
                     vedtaksperioder,
                     BehandlingResultat.OPPHØRT,
                     BehandlingStatus.UTREDES,
-                    undefined
+                    undefined,
+                    true
                 );
                 expect(perioder.length).toBe(1);
                 expect(perioder[0].type).toBe(Vedtaksperiodetype.OPPHØR);

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -10,6 +10,7 @@ export enum ToggleNavn {
     kanOppretteOgEndreSammensatteKontrollsaker = 'familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker',
     skalObfuskereData = 'familie-ks-sak.anonymiser-persondata',
     kanOppretteRevurderingMedAarsakIverksetteKaVedtak = 'familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak',
+    skalAlltidViseAlleVedtaksperioder = 'familie-ks-sak-frontend.alltid-vis-alle-vedtaksperioder',
 }
 
 export const alleTogglerAv = (): IToggles => {

--- a/src/frontend/utils/vedtakUtils.ts
+++ b/src/frontend/utils/vedtakUtils.ts
@@ -35,7 +35,8 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
     vedtaksperioder: IVedtaksperiodeMedBegrunnelser[],
     behandlingResultat: BehandlingResultat,
     behandlingStatus: BehandlingStatus,
-    sisteVedtaksperiodeVisningDato: IsoDatoString | undefined
+    sisteVedtaksperiodeVisningDato: IsoDatoString | undefined,
+    skalAlltidViseAlleVedtaksperioder: boolean
 ): IVedtaksperiodeMedBegrunnelser[] => {
     const sorterteOgFiltrertePerioder = vedtaksperioder
         .slice()
@@ -48,6 +49,8 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
         .filter((vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {
             if (behandlingStatus === BehandlingStatus.AVSLUTTET) {
                 return harPeriodeBegrunnelse(vedtaksperiode);
+            } else if (skalAlltidViseAlleVedtaksperioder) {
+                return true;
             } else {
                 return (
                     (sisteVedtaksperiodeVisningDato &&


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
I forbindelse med arbeid på [denne](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24038) oppgaven har Brage og jeg funnet ut at alle vedtaksperioder alltid vil vises på vedtak-siden i praksis i dag siden datoen man filtrerer mot alltid vil være maks dato man kan få andeler til. Ønsker derfor å teste om vi kan fjerne filtreringen i sin helhet. Avklart med Anna at vi skal prøve å fjerne koden (bak toggle) og Dorota skal teste.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
