### PR TITLE
Vi legger til fødselsdato i registeropplysningen

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {
+    CalendarIcon,
     FlowerPetalFallingIcon,
     GlobeIcon,
     HeartIcon,
@@ -27,9 +28,13 @@ const SemiBoldHeading = styled(Heading)`
 
 interface IRegisteropplysningerProps {
     opplysninger: IRestRegisterhistorikk;
+    fødselsdato: string;
 }
 
-const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({ opplysninger }) => {
+const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({
+    opplysninger,
+    fødselsdato,
+}) => {
     const manglerRegisteropplysninger = opplysninger.statsborgerskap.length === 0;
 
     const personErDød = opplysninger.dødsboadresse.length > 0;
@@ -55,6 +60,24 @@ const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({ opplysning
                                 tilFormat: Datoformat.DATO_TID_SEKUNDER,
                             })
                         }
+                    />
+                    <RegisteropplysningerTabell
+                        opplysningstype={Registeropplysning.FØDSELSDATO}
+                        ikon={
+                            <CalendarIcon
+                                fontSize={'1.5rem'}
+                                title="Kalender-ikon"
+                                focusable="false"
+                            />
+                        }
+                        historikk={[
+                            {
+                                verdi: isoStringTilFormatertString({
+                                    isoString: fødselsdato,
+                                    tilFormat: Datoformat.DATO,
+                                }),
+                            },
+                        ]}
                     />
                     {personErDød && (
                         <RegisteropplysningerTabell

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingSkjema.tsx
@@ -101,6 +101,7 @@ const VilkårsvurderingSkjema: React.FunctionComponent = () => {
                                     {personResultat.person.registerhistorikk ? (
                                         <Registeropplysninger
                                             opplysninger={personResultat.person.registerhistorikk}
+                                            fødselsdato={personResultat.person.fødselsdato}
                                         />
                                     ) : (
                                         <Alert

--- a/src/frontend/typer/registeropplysning.ts
+++ b/src/frontend/typer/registeropplysning.ts
@@ -4,6 +4,7 @@ export enum Registeropplysning {
     STATSBORGERSKAP = 'STATSBORGERSKAP',
     BOSTEDSADRESSE = 'BOSTEDSADRESSE',
     DØDSBOADRESSE = 'DØDSBOADRESSE',
+    FØDSELSDATO = 'FØDSELSDATO',
 }
 
 export const registeropplysning: Record<Registeropplysning, string> = {
@@ -12,4 +13,5 @@ export const registeropplysning: Record<Registeropplysning, string> = {
     STATSBORGERSKAP: 'Statsborgerskap',
     BOSTEDSADRESSE: 'Adresse',
     DØDSBOADRESSE: 'Dødsboadresse',
+    FØDSELSDATO: 'Fødselsdato',
 };


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24263

Fødselsdato visning ble lagt til i BA-sak etter at KS ble utviklet.
Med tanke på at fødselsdato er viktig mtp regelverk og barnets alder vilkåret, så er det veldig gunstig å ha dette framme for SB. Det er derfor lagt til i denne PRn.

Før:
<img width="767" alt="før" src="https://github.com/user-attachments/assets/2f4d4d50-b1eb-488f-b7bb-5ff01fcf195f" />

Etter:
<img width="1044" alt="etter" src="https://github.com/user-attachments/assets/819a08c1-df8d-490f-999a-a37e2e68e141" />
