### PR TITLE
Lovverk 2025: støtt adopsjon

### DIFF
--- a/src/frontend/context/Vilkårsvurdering/vilkårsvurdering.ts
+++ b/src/frontend/context/Vilkårsvurdering/vilkårsvurdering.ts
@@ -66,7 +66,6 @@ export const mapFraRestPersonResultatTilPersonResultat = (
                 return {
                     person,
                     personIdent: personResultat.personIdent,
-                    lovverk: personResultat.lovverk,
                     vilkårResultater: sorterVilkårsvurderingForPerson(
                         personResultat.vilkårResultater.map(
                             (vilkårResultat: IRestVilkårResultat) => {

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
@@ -8,7 +8,6 @@ import { ASpacing5, ASpacing8, ASpacing16 } from '@navikt/ds-tokens/dist/tokens'
 
 import VilkårTabell from './VilkårTabell';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
-import type { Lovverk } from '../../../../typer/lovverk';
 import type { IGrunnlagPerson } from '../../../../typer/person';
 import type { IVilkårConfig, IVilkårResultat, VilkårType } from '../../../../typer/vilkår';
 import { Resultat } from '../../../../typer/vilkår';
@@ -16,7 +15,6 @@ import { useVilkårsvurderingApi } from '../useVilkårsvurderingApi';
 
 interface IProps {
     person: IGrunnlagPerson;
-    lovverk: Lovverk | undefined;
     vilkårResultater: IVilkårResultat[];
     vilkårFraConfig: IVilkårConfig;
     generiskVilkårKey: string;
@@ -35,7 +33,6 @@ const UtførKnapp = styled(Button)`
 
 const GeneriskVilkår: React.FC<IProps> = ({
     person,
-    lovverk,
     vilkårFraConfig,
     vilkårResultater,
     generiskVilkårKey,
@@ -77,7 +74,6 @@ const GeneriskVilkår: React.FC<IProps> = ({
                 </Heading>
                 <VilkårTabell
                     person={person}
-                    lovverk={lovverk}
                     vilkårFraConfig={vilkårFraConfig}
                     vilkårResultater={vilkårResultater}
                     settFokusPåKnapp={settFokusPåLeggTilPeriodeKnapp}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -17,6 +17,7 @@ interface IProps extends PropsWithChildren {
     erEksplisittAvslagPåSøknad: Felt<boolean>;
     resultat: Felt<Resultat>;
     visFeilmeldinger: boolean;
+    tomErPåkrevd: boolean;
 }
 
 const StyledLegend = styled.legend`
@@ -45,6 +46,7 @@ const VelgPeriode: React.FC<IProps> = ({
     resultat,
     visFeilmeldinger,
     children,
+    tomErPåkrevd,
 }) => {
     const { vurderErLesevisning } = useBehandling();
     const lesevisning = vurderErLesevisning();
@@ -81,7 +83,7 @@ const VelgPeriode: React.FC<IProps> = ({
                     readOnly={lesevisning}
                 />
                 <DatovelgerForGammelSkjemaløsning
-                    label={'T.o.m (valgfri)'}
+                    label={tomErPåkrevd ? 'T.o.m' : 'T.o.m (valgfri)'}
                     value={periode.verdi.tom}
                     readOnly={lesevisning}
                     onDateChange={(dato?: IsoDatoString) => {

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
@@ -12,16 +12,14 @@ import { Resultat } from '../../../../../../typer/vilkår';
 import {
     datoForLovendringAugust24,
     type IIsoDatoPeriode,
+    isoStringTilDate,
     isoStringTilDateEllerUndefinedHvisUgyldigDato,
 } from '../../../../../../utils/dato';
+import { utledLovverk } from '../../../../../../utils/lovverk';
 import Datovelger from '../../../../../Felleskomponenter/Datovelger/Datovelger';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
-
-type BarnetsAlderProps = IVilkårSkjemaBaseProps & {
-    lovverk: Lovverk | undefined;
-};
 
 const hentSpørsmålForLovverkFør2025 = (periode: IIsoDatoPeriode) => {
     const fraOgMedDato = isoStringTilDateEllerUndefinedHvisUgyldigDato(periode.fom);
@@ -45,22 +43,18 @@ const hentSpørsmålForLovverk = (lovverk: Lovverk | undefined, periode: IIsoDat
     }
 };
 
-export const BarnetsAlder: React.FC<BarnetsAlderProps> = ({
+export const BarnetsAlder: React.FC<IVilkårSkjemaBaseProps> = ({
     vilkårResultat,
     vilkårFraConfig,
     toggleForm,
     person,
-    lovverk,
     lesevisning,
-}: BarnetsAlderProps) => {
+}: IVilkårSkjemaBaseProps) => {
     const { toggles } = useApp();
-    const { felter } = useBarnetsAlder(
-        vilkårResultat,
-        person,
-        lovverk,
-        toggles[ToggleNavn.stotterAdopsjon]
-    );
+    const { felter } = useBarnetsAlder(vilkårResultat, person, toggles[ToggleNavn.stotterAdopsjon]);
     const vilkårSkjemaContext = useVilkårSkjema(vilkårResultat, felter, person, toggleForm);
+
+    const lovverk = utledLovverk(isoStringTilDate(person.fødselsdato), felter.adopsjonsdato.verdi);
     const spørsmål = hentSpørsmålForLovverk(
         lovverk,
         vilkårSkjemaContext.skjema.felter.periode.verdi

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
@@ -43,13 +43,15 @@ const hentSpørsmålForLovverk = (lovverk: Lovverk | undefined, periode: IIsoDat
     }
 };
 
-export const BarnetsAlder: React.FC<IVilkårSkjemaBaseProps> = ({
+type BarnetsAlderProps = IVilkårSkjemaBaseProps;
+
+export const BarnetsAlder: React.FC<BarnetsAlderProps> = ({
     vilkårResultat,
     vilkårFraConfig,
     toggleForm,
     person,
     lesevisning,
-}: IVilkårSkjemaBaseProps) => {
+}: BarnetsAlderProps) => {
     const { toggles } = useApp();
     const { felter } = useBarnetsAlder(vilkårResultat, person, toggles[ToggleNavn.stotterAdopsjon]);
     const vilkårSkjemaContext = useVilkårSkjema(vilkårResultat, felter, person, toggleForm);

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderContext.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { isValid, startOfDay } from 'date-fns';
+import { isBefore, isValid, startOfDay } from 'date-fns';
 
 import { feil, ok, useFelt, type Avhengigheter } from '@navikt/familie-skjema';
 
@@ -82,6 +82,8 @@ export const useBarnetsAlder = (
         valideringsfunksjon: felt => {
             if (!felt.verdi || !isValid(felt.verdi)) {
                 return feil(felt, 'Adopsjonsdato må fylles ut når adopsjon er valgt');
+            } else if (isBefore(felt.verdi, person.fødselsdato)) {
+                return feil(felt, 'Adopsjonsdato kan ikke være tidligere enn fødselsdato');
             } else {
                 return ok(felt);
             }

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering.ts
@@ -180,45 +180,53 @@ export const validerPeriodePåBarnetsAlder = ({
             return feilMedAdopsjonPåBarnetsAlder;
         }
     } else {
-        if (lovverk === Lovverk.LOVENDRING_FEBRUAR_2025) {
-            if (!datoErPersonsXÅrsdag(person, fom, 1)) {
-                return feil(felt, 'F.o.m datoen må være lik barnets 1 års dag');
-            }
-
-            if (
-                !datoErXAntallMånederEtterFødselsdato(person, tom, 20) &&
-                !datoErPersonsDødsfallsdag(person, tom)
-            ) {
-                return feil(felt, 'T.o.m datoen må være lik datoen barnet fyller 20 måneder');
-            }
-        } else {
-            if (isBefore(tom, datoForLovendringAugust24)) {
+        switch (lovverk) {
+            case Lovverk.LOVENDRING_FEBRUAR_2025:
                 if (!datoErPersonsXÅrsdag(person, fom, 1)) {
                     return feil(felt, 'F.o.m datoen må være lik barnets 1 års dag');
                 }
+
                 if (
-                    tom &&
-                    !datoErPersonsXÅrsdag(person, tom, 2) &&
-                    !isSameDay(tom, subDays(datoForLovendringAugust24, 1)) &&
+                    !datoErXAntallMånederEtterFødselsdato(person, tom, 20) &&
                     !datoErPersonsDødsfallsdag(person, tom)
                 ) {
-                    return feil(felt, 'T.o.m datoen må være lik barnets 2 års dag');
+                    return feil(felt, 'T.o.m datoen må være lik datoen barnet fyller 20 måneder');
                 }
-            } else {
-                if (
-                    !datoErXAntallMånederEtterFødselsdato(person, fom, 13) &&
-                    !isSameDay(fom, datoForLovendringAugust24)
-                ) {
-                    return feil(felt, 'F.o.m datoen må være lik datoen barnet fyller 13 måneder');
+                break;
+            case Lovverk.FØR_LOVENDRING_2025:
+                if (isBefore(tom, datoForLovendringAugust24)) {
+                    if (!datoErPersonsXÅrsdag(person, fom, 1)) {
+                        return feil(felt, 'F.o.m datoen må være lik barnets 1 års dag');
+                    }
+                    if (
+                        tom &&
+                        !datoErPersonsXÅrsdag(person, tom, 2) &&
+                        !isSameDay(tom, subDays(datoForLovendringAugust24, 1)) &&
+                        !datoErPersonsDødsfallsdag(person, tom)
+                    ) {
+                        return feil(felt, 'T.o.m datoen må være lik barnets 2 års dag');
+                    }
+                } else {
+                    if (
+                        !datoErXAntallMånederEtterFødselsdato(person, fom, 13) &&
+                        !isSameDay(fom, datoForLovendringAugust24)
+                    ) {
+                        return feil(
+                            felt,
+                            'F.o.m datoen må være lik datoen barnet fyller 13 måneder'
+                        );
+                    }
+                    if (
+                        tom &&
+                        !datoErXAntallMånederEtterFødselsdato(person, tom, 19) &&
+                        !datoErPersonsDødsfallsdag(person, tom)
+                    ) {
+                        return feil(
+                            felt,
+                            'T.o.m datoen må være lik datoen barnet fyller 19 måneder'
+                        );
+                    }
                 }
-                if (
-                    tom &&
-                    !datoErXAntallMånederEtterFødselsdato(person, tom, 19) &&
-                    !datoErPersonsDødsfallsdag(person, tom)
-                ) {
-                    return feil(felt, 'T.o.m datoen må være lik datoen barnet fyller 19 måneder');
-                }
-            }
         }
     }
 };

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering.ts
@@ -1,9 +1,18 @@
+import { addMonths, addYears, isAfter, isBefore, setMonth } from 'date-fns';
+
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok } from '@navikt/familie-skjema';
 
 import { muligeUtdypendeVilkårsvurderinger } from './BarnetsAlderContext';
+import { Lovverk } from '../../../../../../typer/lovverk';
+import type { IGrunnlagPerson } from '../../../../../../typer/person';
 import type { UtdypendeVilkårsvurdering } from '../../../../../../typer/vilkår';
 import { Regelverk } from '../../../../../../typer/vilkår';
+import {
+    datoForLovendringAugust24,
+    isoStringTilDate,
+    type IIsoDatoPeriode,
+} from '../../../../../../utils/dato';
 
 export const erUtdypendeVilkårsvurderingerGyldig = (
     felt: FeltState<UtdypendeVilkårsvurdering[]>
@@ -38,5 +47,64 @@ export const erBegrunnelseGyldig = (
             felt,
             'Du har gjort ett eller flere valg under "Utdypende vilkårsvurdering" og må derfor fylle inn en begrunnelse'
         );
+    }
+};
+
+const tomEtterAugustÅretBarnetFyller6 = (person: IGrunnlagPerson, tom?: Date): boolean => {
+    const datoBarnetFyller6 = addYears(isoStringTilDate(person.fødselsdato), 6);
+    const datoSeptemberÅretBarnetFyller6 = setMonth(datoBarnetFyller6, 8);
+    return tom ? isAfter(tom, datoSeptemberÅretBarnetFyller6) : false;
+};
+
+const datoDifferanseMerEnnXAntallMåneder = (fom: Date, tom: Date, antallMåneder: number) => {
+    const fomDatoPlussXAntallMåneder = addMonths(fom, antallMåneder);
+    return isBefore(fomDatoPlussXAntallMåneder, tom);
+};
+
+export const validerAdopsjonPåBarnetsAlder = (
+    felt: FeltState<IIsoDatoPeriode>,
+    person: IGrunnlagPerson,
+    adopsjonsdato: Date | undefined,
+    lovverk: Lovverk,
+    fom: Date,
+    tom: Date,
+    førsteFomPåVilkåret: Date
+): FeltState<IIsoDatoPeriode> | undefined => {
+    if (tomEtterAugustÅretBarnetFyller6(person, tom)) {
+        return feil(
+            felt,
+            'Du kan ikke sette en t.o.m dato som er etter august året barnet fyller 6 år'
+        );
+    }
+
+    if (adopsjonsdato && isBefore(fom, adopsjonsdato)) {
+        return feil(felt, 'F.o.m.-datoen kan ikke være før adopsjonsdatoen');
+    }
+
+    switch (lovverk) {
+        case Lovverk.LOVENDRING_FEBRUAR_2025:
+            if (datoDifferanseMerEnnXAntallMåneder(fom, tom, 8)) {
+                return feil(
+                    felt,
+                    'Differansen mellom f.o.m.-dato og t.o.m.-datoen kan ikke være mer enn 8 måneder'
+                );
+            }
+            break;
+        case Lovverk.FØR_LOVENDRING_2025:
+            if (isBefore(tom, datoForLovendringAugust24)) {
+                if (datoDifferanseMerEnnXAntallMåneder(fom, tom, 12)) {
+                    return feil(
+                        felt,
+                        'Differansen mellom f.o.m datoen og t.o.m datoen kan ikke være mer enn 1 år'
+                    );
+                }
+            } else {
+                if (datoDifferanseMerEnnXAntallMåneder(førsteFomPåVilkåret, tom, 6)) {
+                    return feil(
+                        felt,
+                        'Differansen mellom tidligste f.o.m.-dato og t.o.m.-datoen kan ikke være mer enn 6 måneder'
+                    );
+                }
+            }
     }
 };

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering.ts
@@ -83,15 +83,25 @@ const datoErPersonsDødsfallsdag = (person: IGrunnlagPerson, dato: Date) => {
     return !!personsDødsfallsdag && isSameDay(dato, isoStringTilDate(personsDødsfallsdag));
 };
 
-export const validerAdopsjonPåBarnetsAlder = (
-    felt: FeltState<IIsoDatoPeriode>,
-    person: IGrunnlagPerson,
-    adopsjonsdato: Date | undefined,
-    lovverk: Lovverk,
-    fom: Date,
-    tom: Date,
-    førsteFomPåVilkåret: Date
-): FeltState<IIsoDatoPeriode> | undefined => {
+interface ValiderAdopsjonPåBarnetsAlderProps {
+    felt: FeltState<IIsoDatoPeriode>;
+    person: IGrunnlagPerson;
+    adopsjonsdato: Date | undefined;
+    lovverk: Lovverk;
+    fom: Date;
+    tom: Date;
+    førsteFomPåVilkåret: Date;
+}
+
+export const validerAdopsjonPåBarnetsAlder = ({
+    felt,
+    person,
+    adopsjonsdato,
+    lovverk,
+    fom,
+    tom,
+    førsteFomPåVilkåret,
+}: ValiderAdopsjonPåBarnetsAlderProps): FeltState<IIsoDatoPeriode> | undefined => {
     if (tomEtterAugustÅretBarnetFyller6(person, tom)) {
         return feil(
             felt,
@@ -150,8 +160,6 @@ export const validerPeriodePåBarnetsAlder = ({
     tom,
     førsteLagredeFom,
 }: ValiderPeriodePåBarnetsAlderProps): FeltState<IIsoDatoPeriode> | undefined => {
-    const førsteFomPåVilkåret: Date = førsteLagredeFom ? isoStringTilDate(førsteLagredeFom) : fom;
-
     if (!tom) {
         return feil(felt, 'Det må registreres en t.o.m dato');
     }
@@ -159,15 +167,15 @@ export const validerPeriodePåBarnetsAlder = ({
     const lovverk = utledLovverk(isoStringTilDate(person.fødselsdato), adopsjonsdato);
 
     if (erAdopsjon) {
-        const feilMedAdopsjonPåBarnetsAlder = validerAdopsjonPåBarnetsAlder(
+        const feilMedAdopsjonPåBarnetsAlder = validerAdopsjonPåBarnetsAlder({
             felt,
             person,
             adopsjonsdato,
             lovverk,
             fom,
             tom,
-            førsteFomPåVilkåret
-        );
+            førsteFomPåVilkåret: førsteLagredeFom ? isoStringTilDate(førsteLagredeFom) : fom,
+        });
         if (feilMedAdopsjonPåBarnetsAlder !== undefined) {
             return feilMedAdopsjonPåBarnetsAlder;
         }

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering.ts
@@ -1,4 +1,13 @@
-import { addMonths, addYears, isAfter, isBefore, isSameDay, setMonth, subDays } from 'date-fns';
+import {
+    addMonths,
+    addYears,
+    isAfter,
+    isBefore,
+    isSameDay,
+    isValid,
+    setMonth,
+    subDays,
+} from 'date-fns';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok } from '@navikt/familie-skjema';
@@ -49,6 +58,19 @@ export const erBegrunnelseGyldig = (
             felt,
             'Du har gjort ett eller flere valg under "Utdypende vilkårsvurdering" og må derfor fylle inn en begrunnelse'
         );
+    }
+};
+
+export const erAdopsjonsdatoGyldig = (
+    felt: FeltState<Date | undefined>,
+    fødselsdato: Date
+): FeltState<Date | undefined> => {
+    if (!felt.verdi || !isValid(felt.verdi)) {
+        return feil(felt, 'Adopsjonsdato må fylles ut når adopsjon er valgt');
+    } else if (isBefore(felt.verdi, fødselsdato)) {
+        return feil(felt, 'Adopsjonsdato kan ikke være tidligere enn fødselsdato');
+    } else {
+        return ok(felt);
     }
 };
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
@@ -203,6 +203,7 @@ export const VilkårSkjema = <T extends IVilkårSkjemaContext>({
                 resultat={skjema.felter.resultat}
                 visFeilmeldinger={skjema.visFeilmeldinger}
                 children={periodeChildren}
+                tomErPåkrevd={vilkårResultat.vilkårType === VilkårType.BARNETS_ALDER}
             />
             <Textarea
                 readOnly={lesevisning}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { Table } from '@navikt/ds-react';
 
 import VilkårTabellRad from './VilkårTabellRad';
-import type { Lovverk } from '../../../../typer/lovverk';
 import type { IGrunnlagPerson } from '../../../../typer/person';
 import type { IVilkårConfig, IVilkårResultat } from '../../../../typer/vilkår';
 
@@ -17,7 +16,6 @@ export const vilkårBegrunnelseFeilmeldingId = (vilkårResultat: IVilkårResulta
 
 interface IProps {
     person: IGrunnlagPerson;
-    lovverk: Lovverk | undefined;
     vilkårResultater: IVilkårResultat[];
     vilkårFraConfig: IVilkårConfig;
     settFokusPåKnapp: () => void;
@@ -43,7 +41,6 @@ const TabellHeader = styled(Table.HeaderCell)`
 
 const VilkårTabell: React.FC<IProps> = ({
     person,
-    lovverk,
     vilkårFraConfig,
     vilkårResultater,
     settFokusPåKnapp,
@@ -69,7 +66,6 @@ const VilkårTabell: React.FC<IProps> = ({
                             person={person}
                             vilkårResultat={vilkårResultat}
                             settFokusPåKnapp={settFokusPåKnapp}
-                            lovverk={lovverk}
                         />
                     );
                 })}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -17,7 +17,6 @@ import { MedlemskapAnnenForelder } from './Vilkår/MedlemskapAnnenForelder/Medle
 import { vilkårFeilmeldingId } from './VilkårTabell';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import VilkårResultatIkon from '../../../../ikoner/VilkårResultatIkon';
-import type { Lovverk } from '../../../../typer/lovverk';
 import type { IGrunnlagPerson } from '../../../../typer/person';
 import type { IVilkårConfig, IVilkårResultat } from '../../../../typer/vilkår';
 import { Resultat, uiResultat, VilkårType } from '../../../../typer/vilkår';
@@ -30,7 +29,6 @@ import { alleRegelverk } from '../../../../utils/vilkår';
 
 interface IProps {
     person: IGrunnlagPerson;
-    lovverk: Lovverk | undefined;
     vilkårFraConfig: IVilkårConfig;
     vilkårResultat: IVilkårResultat;
     settFokusPåKnapp: () => void;
@@ -75,12 +73,7 @@ const StyledPersonIcon = styled(PersonIcon)`
     min-width: 1.5rem;
 `;
 
-const VilkårTabellRad: React.FC<IProps> = ({
-    person,
-    vilkårFraConfig,
-    vilkårResultat,
-    lovverk,
-}) => {
+const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårResultat }) => {
     const { vurderErLesevisning, åpenBehandling, behandlingPåVent } = useBehandling();
     const erLesevisning = vurderErLesevisning();
 
@@ -174,7 +167,6 @@ const VilkårTabellRad: React.FC<IProps> = ({
                         vilkårFraConfig={vilkårFraConfig}
                         toggleForm={toggleForm}
                         person={person}
-                        lovverk={lovverk}
                         lesevisning={erLesevisning}
                     />
                 );

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingSkjema.tsx
@@ -135,7 +135,6 @@ const VilkårsvurderingSkjema: React.FunctionComponent = () => {
                                                     key={`${index}_${personResultat.person.fødselsdato}_${vc.key}`}
                                                     generiskVilkårKey={`${index}_${personResultat.person.fødselsdato}_${vc.key}`}
                                                     person={personResultat.person}
-                                                    lovverk={personResultat.lovverk}
                                                     vilkårResultater={vilkårResultater}
                                                     vilkårFraConfig={vc}
                                                 />

--- a/src/frontend/typer/vilkår.ts
+++ b/src/frontend/typer/vilkår.ts
@@ -1,5 +1,4 @@
 import type { BehandlingSteg, BehandlingStegStatus } from './behandling';
-import type { Lovverk } from './lovverk';
 import type { IGrunnlagPerson } from './person';
 import { PersonType } from './person';
 import type { IRestBegrunnelseTilknyttetVilkår, Begrunnelse, BegrunnelseType } from './vedtak';
@@ -41,7 +40,6 @@ export enum Regelverk {
 // Vilkårsvurdering typer for ui
 export interface IPersonResultat {
     personIdent: string;
-    lovverk: Lovverk | undefined;
     vilkårResultater: IVilkårResultat[];
     andreVurderinger: IAnnenVurdering[];
     person: IGrunnlagPerson;
@@ -80,7 +78,6 @@ export interface IVilkårResultat {
 // Vilkårsvurdering typer for api
 export interface IRestPersonResultat {
     personIdent: string;
-    lovverk: Lovverk | undefined;
     vilkårResultater: IRestVilkårResultat[];
     andreVurderinger: IRestAnnenVurdering[];
 }

--- a/src/frontend/utils/dato/dato.ts
+++ b/src/frontend/utils/dato/dato.ts
@@ -23,6 +23,8 @@ export const tidenesEnde = new Date(3000, 1, 1);
 
 export const datoForLovendringAugust24 = startOfDay(new Date(2024, 7, 1));
 
+export const fødselsdatoGrenseLovendringFebruar2025 = startOfDay(new Date(2024, 0, 1));
+
 export enum Datoformat {
     DATO = 'dd.MM.yyyy',
     DATO_FORKORTTET = 'dd.MM.yy',

--- a/src/frontend/utils/lovverk.ts
+++ b/src/frontend/utils/lovverk.ts
@@ -1,0 +1,14 @@
+import { isBefore } from 'date-fns';
+
+import { fødselsdatoGrenseLovendringFebruar2025 } from './dato';
+import { Lovverk } from '../typer/lovverk';
+
+export const utledLovverk = (fødselsdato: Date, adopsjonsdato?: Date): Lovverk => {
+    const fødselsdatoEllerAdopsjonsdato = adopsjonsdato ?? fødselsdato;
+
+    if (isBefore(fødselsdatoEllerAdopsjonsdato, fødselsdatoGrenseLovendringFebruar2025)) {
+        return Lovverk.FØR_LOVENDRING_2025;
+    } else {
+        return Lovverk.LOVENDRING_FEBRUAR_2025;
+    }
+};

--- a/src/frontend/utils/test/vilkårsvurdering/vilkår.mock.ts
+++ b/src/frontend/utils/test/vilkårsvurdering/vilkår.mock.ts
@@ -1,4 +1,3 @@
-import { Lovverk } from '../../../typer/lovverk';
 import type {
     IRestAnnenVurdering,
     IRestPersonResultat,
@@ -70,5 +69,4 @@ export const mockRestPersonResultat = ({
     personIdent,
     vilkårResultater,
     andreVurderinger,
-    lovverk: Lovverk.FØR_LOVENDRING_2025,
 });

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -167,23 +167,41 @@ export const erPeriodeGyldig = (
                             );
                         }
 
-                        if (isBefore(tom, datoForLovendringAugust24)) {
-                            if (tom && datoDifferanseMerEnn1År(fom, tom)) {
-                                return feil(
-                                    felt,
-                                    'Differansen mellom f.o.m datoen og t.o.m datoen kan ikke være mer enn 1 år'
-                                );
-                            }
-                        } else {
-                            if (
-                                tom &&
-                                datoDifferanseMerEnnXAntallMåneder(førsteFomPåVilkåret, tom, 6)
-                            ) {
-                                return feil(
-                                    felt,
-                                    'Differansen mellom tidligste f.o.m.-dato og t.o.m.-datoen kan ikke være mer enn 6 måneder'
-                                );
-                            }
+                        if (adopsjonsdato && isBefore(fom, adopsjonsdato)) {
+                            return feil(felt, 'F.o.m.-datoen kan ikke være før adopsjonsdatoen');
+                        }
+
+                        switch (lovverk) {
+                            case Lovverk.LOVENDRING_FEBRUAR_2025:
+                                if (datoDifferanseMerEnnXAntallMåneder(fom, tom, 8)) {
+                                    return feil(
+                                        felt,
+                                        'Differansen mellom f.o.m.-dato og t.o.m.-datoen kan ikke være mer enn 8 måneder'
+                                    );
+                                }
+                                break;
+                            case Lovverk.FØR_LOVENDRING_2025:
+                                if (isBefore(tom, datoForLovendringAugust24)) {
+                                    if (datoDifferanseMerEnn1År(fom, tom)) {
+                                        return feil(
+                                            felt,
+                                            'Differansen mellom f.o.m datoen og t.o.m datoen kan ikke være mer enn 1 år'
+                                        );
+                                    }
+                                } else {
+                                    if (
+                                        datoDifferanseMerEnnXAntallMåneder(
+                                            førsteFomPåVilkåret,
+                                            tom,
+                                            6
+                                        )
+                                    ) {
+                                        return feil(
+                                            felt,
+                                            'Differansen mellom tidligste f.o.m.-dato og t.o.m.-datoen kan ikke være mer enn 6 måneder'
+                                        );
+                                    }
+                                }
                         }
                     } else {
                         if (lovverk === Lovverk.LOVENDRING_FEBRUAR_2025) {

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -23,6 +23,7 @@ import {
     type IsoDatoString,
     isoStringTilDate,
 } from './dato';
+import { utledLovverk } from './lovverk';
 import { erBegrunnelsePåkrevd } from '../komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema';
 import { Lovverk } from '../typer/lovverk';
 import type { IGrunnlagPerson } from '../typer/person';
@@ -152,6 +153,12 @@ export const erPeriodeGyldig = (
                         return feil(felt, 'Det må registreres en t.o.m dato');
                     }
 
+                    const adopsjonsdato: Date | undefined = avhengigheter?.adopsjonsdato;
+                    const lovverk = utledLovverk(
+                        isoStringTilDate(person.fødselsdato),
+                        adopsjonsdato
+                    );
+
                     if (erAdopsjon) {
                         if (tomEtterAugustÅretBarnetFyller6(person, tom)) {
                             return feil(
@@ -179,7 +186,7 @@ export const erPeriodeGyldig = (
                             }
                         }
                     } else {
-                        if (avhengigheter?.lovverk === Lovverk.LOVENDRING_FEBRUAR_2025) {
+                        if (lovverk === Lovverk.LOVENDRING_FEBRUAR_2025) {
                             if (!datoErPersonsXÅrsdag(person, fom, 1)) {
                                 return feil(felt, 'F.o.m datoen må være lik barnets 1 års dag');
                             }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22760

Denne PRen støtter adopsjon mtp lovendring februar 2025. Har måttet revertere en tidligere endring, hvor vi baserer oss på lovverk sendt fra backend når det gjelder validering og teksten på barnets alder-spørsmålet. Dette er fordi lovverk utledes fra fødselsdato og adopsjonsdato, og adopsjonsdatoen kan endres i frontend og vi ønsker at både spørsmål og tekst på vilkåret skal oppdatere seg før man faktisk trykker på lagre-knappen. Jeg tenker dette er uproblematisk siden koden for å utlede lovverk er såpass enkel, men det er jo en ekstra ting å tenke på når/hvis det kommer fremtidig lovendring.

Har også trukket ut validering knyttet til barnets alder-periodene i en egen fil, så validators.ts-filen skal bli enklere å lese, ref [dette favro-kortet](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24163).

I tillegg fikser jeg en liten greie som har irritert meg under test: tom-dato på barnets alder står som valgfri selv om den ikke er det. Sørger for at den ikke står som valgfri for dette vilkåret lenger.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Lurt å lese commit for commit!!

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Spørsmålet endrer seg når man velger adopsjonsdato 1.1.24 eller senere hvis fødselsdato var før 1.1.24
![image](https://github.com/user-attachments/assets/8d1baba6-39d7-4a18-81bf-cd3fa16f55fb)
![image](https://github.com/user-attachments/assets/1925b43b-64a6-44e7-a57a-c3864a90957d)

Validering adopsjonsdato etter 1.1.24
![image](https://github.com/user-attachments/assets/b259f23f-d2b3-4cf5-b857-242900f88645)

Validering adopsjonsdato før 1.1.24
![image](https://github.com/user-attachments/assets/99f107a0-c281-4f59-b5fd-3c6bf660a928)

Validering fom-dato før adopsjonsdato
![image](https://github.com/user-attachments/assets/fa4f628d-fac0-40f9-8240-d8f24e1f1d95)
