### PR TITLE
Fix: tilbakestill vilkårskjema 

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
@@ -19,7 +19,9 @@ const StyledTextField = styled(TextField)`
     margin-bottom: 1rem;
 `;
 
-type BarnehageplassProps = IVilkårSkjemaBaseProps;
+type BarnehageplassProps = IVilkårSkjemaBaseProps & {
+    toggleForm: (visSkjema: boolean) => void;
+};
 
 export const Barnehageplass: React.FC<BarnehageplassProps> = ({
     vilkårResultat,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
@@ -15,9 +15,11 @@ import {
 } from '../../../../../../utils/dato';
 import { utledLovverk } from '../../../../../../utils/lovverk';
 import Datovelger from '../../../../../Felleskomponenter/Datovelger/Datovelger';
+import VilkårEkspanderbarTabell from '../../VilkårEkspanderbarTabell';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
+import { useVilkårTabell } from '../../VilkårTabellContext';
 
 const hentSpørsmålForLovverkFør2025 = (periode: IIsoDatoPeriode) => {
     const fraOgMedDato = isoStringTilDateEllerUndefinedHvisUgyldigDato(periode.fom);
@@ -41,15 +43,20 @@ const hentSpørsmålForLovverk = (lovverk: Lovverk | undefined, periode: IIsoDat
     }
 };
 
+const erVilkårEndret = (): boolean => {
+    return true;
+};
+
 type BarnetsAlderProps = IVilkårSkjemaBaseProps;
 
 export const BarnetsAlder: React.FC<BarnetsAlderProps> = ({
     vilkårResultat,
     vilkårFraConfig,
-    toggleForm,
     person,
     lesevisning,
 }: BarnetsAlderProps) => {
+    const { ekspandertVilkår, toggleForm } = useVilkårTabell(erVilkårEndret, vilkårResultat);
+
     const { felter } = useBarnetsAlder(vilkårResultat, person);
     const vilkårSkjemaContext = useVilkårSkjema(vilkårResultat, felter, person, toggleForm);
 
@@ -60,65 +67,73 @@ export const BarnetsAlder: React.FC<BarnetsAlderProps> = ({
     );
 
     return (
-        <VilkårSkjema
-            vilkårSkjemaContext={vilkårSkjemaContext}
-            visVurderesEtter={false}
-            visSpørsmål={false}
-            muligeUtdypendeVilkårsvurderinger={muligeUtdypendeVilkårsvurderinger}
+        <VilkårEkspanderbarTabell
             vilkårResultat={vilkårResultat}
-            vilkårFraConfig={vilkårFraConfig}
             toggleForm={toggleForm}
-            person={person}
-            lesevisning={lesevisning}
-            utdypendeVilkårsvurderingChildren={
-                felter.adopsjonsdato.erSynlig ? (
-                    <Datovelger
-                        felt={felter.adopsjonsdato}
-                        label="Adopsjonsdato"
-                        visFeilmeldinger={vilkårSkjemaContext.skjema.visFeilmeldinger}
-                        kanKunVelgeFortid
-                        readOnly={lesevisning}
-                    />
-                ) : null
-            }
+            ekspandertVilkår={ekspandertVilkår}
         >
-            <RadioGroup
-                readOnly={lesevisning}
-                value={vilkårSkjemaContext.skjema.felter.resultat.verdi}
-                legend={<Label>{spørsmål}</Label>}
-                error={
-                    vilkårSkjemaContext.skjema.visFeilmeldinger
-                        ? vilkårSkjemaContext.skjema.felter.resultat.feilmelding
-                        : ''
+            <VilkårSkjema
+                vilkårSkjemaContext={vilkårSkjemaContext}
+                visVurderesEtter={false}
+                visSpørsmål={false}
+                muligeUtdypendeVilkårsvurderinger={muligeUtdypendeVilkårsvurderinger}
+                vilkårResultat={vilkårResultat}
+                vilkårFraConfig={vilkårFraConfig}
+                toggleForm={toggleForm}
+                person={person}
+                lesevisning={lesevisning}
+                utdypendeVilkårsvurderingChildren={
+                    felter.adopsjonsdato.erSynlig ? (
+                        <Datovelger
+                            felt={felter.adopsjonsdato}
+                            label="Adopsjonsdato"
+                            visFeilmeldinger={vilkårSkjemaContext.skjema.visFeilmeldinger}
+                            kanKunVelgeFortid
+                            readOnly={lesevisning}
+                        />
+                    ) : null
                 }
             >
-                <Radio
-                    name={`${vilkårResultat.vilkårType}_${vilkårResultat.id}`}
-                    value={Resultat.OPPFYLT}
-                    onChange={() => {
-                        vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
-                            Resultat.OPPFYLT
-                        );
-                        vilkårSkjemaContext.skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
-                            false
-                        );
-                        vilkårSkjemaContext.skjema.felter.avslagBegrunnelser.validerOgSettFelt([]);
-                    }}
-                >
-                    Ja
-                </Radio>
-                <Radio
-                    name={`${vilkårResultat.vilkårType}_${vilkårResultat.id}`}
-                    value={Resultat.IKKE_OPPFYLT}
-                    onChange={() =>
-                        vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
-                            Resultat.IKKE_OPPFYLT
-                        )
+                <RadioGroup
+                    readOnly={lesevisning}
+                    value={vilkårSkjemaContext.skjema.felter.resultat.verdi}
+                    legend={<Label>{spørsmål}</Label>}
+                    error={
+                        vilkårSkjemaContext.skjema.visFeilmeldinger
+                            ? vilkårSkjemaContext.skjema.felter.resultat.feilmelding
+                            : ''
                     }
                 >
-                    Nei
-                </Radio>
-            </RadioGroup>
-        </VilkårSkjema>
+                    <Radio
+                        name={`${vilkårResultat.vilkårType}_${vilkårResultat.id}`}
+                        value={Resultat.OPPFYLT}
+                        onChange={() => {
+                            vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
+                                Resultat.OPPFYLT
+                            );
+                            vilkårSkjemaContext.skjema.felter.erEksplisittAvslagPåSøknad.validerOgSettFelt(
+                                false
+                            );
+                            vilkårSkjemaContext.skjema.felter.avslagBegrunnelser.validerOgSettFelt(
+                                []
+                            );
+                        }}
+                    >
+                        Ja
+                    </Radio>
+                    <Radio
+                        name={`${vilkårResultat.vilkårType}_${vilkårResultat.id}`}
+                        value={Resultat.IKKE_OPPFYLT}
+                        onChange={() =>
+                            vilkårSkjemaContext.skjema.felter.resultat.validerOgSettFelt(
+                                Resultat.IKKE_OPPFYLT
+                            )
+                        }
+                    >
+                        Nei
+                    </Radio>
+                </RadioGroup>
+            </VilkårSkjema>
+        </VilkårEkspanderbarTabell>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BorMedSøker/BorMedSøker.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BorMedSøker/BorMedSøker.tsx
@@ -9,7 +9,9 @@ import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
 
-type BosattIRiketProps = IVilkårSkjemaBaseProps;
+type BosattIRiketProps = IVilkårSkjemaBaseProps & {
+    toggleForm: (visSkjema: boolean) => void;
+};
 
 export const BorMedSøker: React.FC<BosattIRiketProps> = ({
     vilkårResultat,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiket.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiket.tsx
@@ -9,7 +9,9 @@ import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
 
-type BosattIRiketProps = IVilkårSkjemaBaseProps;
+type BosattIRiketProps = IVilkårSkjemaBaseProps & {
+    toggleForm: (visSkjema: boolean) => void;
+};
 
 export const BosattIRiket: React.FC<BosattIRiketProps> = ({
     vilkårResultat,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOpphold.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOpphold.tsx
@@ -10,7 +10,9 @@ import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
 
-type LovligOppholdProps = IVilkårSkjemaBaseProps;
+type LovligOppholdProps = IVilkårSkjemaBaseProps & {
+    toggleForm: (visSkjema: boolean) => void;
+};
 
 const StyledAlert = styled(Alert)`
     margin-top: 1rem;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Medlemskap/Medlemskap.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/Medlemskap/Medlemskap.tsx
@@ -10,7 +10,9 @@ import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
 
-type MedlemskapProps = IVilkårSkjemaBaseProps;
+type MedlemskapProps = IVilkårSkjemaBaseProps & {
+    toggleForm: (visSkjema: boolean) => void;
+};
 
 const StyledAlert = styled(Alert)`
     margin-top: 1rem;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
@@ -10,7 +10,9 @@ import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
 import { useVilkårSkjema } from '../../VilkårSkjemaContext';
 
-type MedlemskapAnnenForelderProps = IVilkårSkjemaBaseProps;
+type MedlemskapAnnenForelderProps = IVilkårSkjemaBaseProps & {
+    toggleForm: (visSkjema: boolean) => void;
+};
 
 const StyledAlert = styled(Alert)`
     margin-top: 1rem;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårEkspanderbarTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårEkspanderbarTabell.tsx
@@ -1,0 +1,133 @@
+import React, { type ReactElement } from 'react';
+
+import styled from 'styled-components';
+
+import { CogIcon, CogRotationIcon, PersonIcon } from '@navikt/aksel-icons';
+import { BodyShort, Table } from '@navikt/ds-react';
+import { RessursStatus } from '@navikt/familie-typer';
+
+import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
+import VilkårResultatIkon from '../../../../ikoner/VilkårResultatIkon';
+import type { IVilkårResultat } from '../../../../typer/vilkår';
+import { uiResultat } from '../../../../typer/vilkår';
+import {
+    Datoformat,
+    isoStringTilFormatertString,
+    isoDatoPeriodeTilFormatertString,
+} from '../../../../utils/dato';
+import { alleRegelverk } from '../../../../utils/vilkår';
+
+interface IProps {
+    toggleForm: (visAlert: boolean) => void;
+    vilkårResultat: IVilkårResultat;
+    ekspandertVilkår: boolean;
+    children: ReactElement;
+}
+
+const BeskrivelseCelle = styled(BodyShort)`
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 20rem;
+`;
+
+const VurderingCelle = styled.div`
+    display: flex;
+    svg {
+        margin-right: 1rem;
+    }
+`;
+
+const FlexDiv = styled.div`
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: center;
+    > div:nth-child(n + 2) {
+        padding-left: 0.5rem;
+    }
+`;
+
+const StyledCogIcon = styled(CogIcon)`
+    font-size: 1.5rem;
+    min-width: 1.5rem;
+`;
+
+const StyledCogRotationIcon = styled(CogRotationIcon)`
+    font-size: 1.5rem;
+    min-width: 1.5rem;
+`;
+
+const StyledPersonIcon = styled(PersonIcon)`
+    font-size: 1.5rem;
+    min-width: 1.5rem;
+`;
+
+const VilkårEkspanderbarTabell: React.FC<IProps> = ({
+    toggleForm,
+    children,
+    vilkårResultat,
+    ekspandertVilkår,
+}) => {
+    const { åpenBehandling } = useBehandling();
+
+    const periodeErTom = !vilkårResultat.periode.fom && !vilkårResultat.periode.tom;
+
+    return (
+        <Table.ExpandableRow
+            open={ekspandertVilkår}
+            togglePlacement="right"
+            onOpenChange={() => toggleForm(true)}
+            content={children}
+        >
+            <Table.DataCell>
+                <VurderingCelle>
+                    <VilkårResultatIkon resultat={vilkårResultat.resultat} />
+                    <BodyShort>{uiResultat[vilkårResultat.resultat]}</BodyShort>
+                </VurderingCelle>
+            </Table.DataCell>
+            <Table.DataCell>
+                <BodyShort>
+                    {periodeErTom ? '-' : isoDatoPeriodeTilFormatertString(vilkårResultat.periode)}
+                </BodyShort>
+            </Table.DataCell>
+            <Table.DataCell>
+                <BeskrivelseCelle children={vilkårResultat.begrunnelse} />
+            </Table.DataCell>
+            <Table.DataCell>
+                {vilkårResultat.vurderesEtter ? (
+                    <FlexDiv>
+                        {alleRegelverk[vilkårResultat.vurderesEtter].symbol}
+                        <div>{alleRegelverk[vilkårResultat.vurderesEtter].tekst}</div>
+                    </FlexDiv>
+                ) : (
+                    <FlexDiv>
+                        <StyledCogIcon title={'Generell vurdering'} />
+                        <div>Generell vurdering</div>
+                    </FlexDiv>
+                )}
+            </Table.DataCell>
+            <Table.DataCell>
+                <FlexDiv>
+                    {vilkårResultat.erAutomatiskVurdert ? (
+                        <StyledCogRotationIcon title={'Automatisk Vurdering'} />
+                    ) : (
+                        <StyledPersonIcon title={'Manuell vurdering'} />
+                    )}
+                    <div>
+                        {åpenBehandling.status === RessursStatus.SUKSESS && vilkårResultat.erVurdert
+                            ? vilkårResultat.behandlingId === åpenBehandling.data.behandlingId
+                                ? 'Vurdert i denne behandlingen'
+                                : `Vurdert ${isoStringTilFormatertString({
+                                      isoString: vilkårResultat.endretTidspunkt,
+                                      tilFormat: Datoformat.DATO_FORKORTTET,
+                                  })}`
+                            : ''}
+                    </div>
+                </FlexDiv>
+            </Table.DataCell>
+        </Table.ExpandableRow>
+    );
+};
+
+export default VilkårEkspanderbarTabell;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
@@ -54,7 +54,6 @@ export interface IVilkårSkjemaBaseProps {
     vilkårResultat: IVilkårResultat;
     vilkårFraConfig: IVilkårConfig;
     person: IGrunnlagPerson;
-    toggleForm: (visSkjema: boolean) => void;
 }
 
 interface IVilkårSkjema<T extends IVilkårSkjemaContext> extends IVilkårSkjemaBaseProps {
@@ -66,6 +65,7 @@ interface IVilkårSkjema<T extends IVilkårSkjemaContext> extends IVilkårSkjema
     periodeChildren?: ReactNode;
     children?: ReactNode;
     vurderesEtterEndringer?: (vurderesEtter: Regelverk) => void;
+    toggleForm: (visSkjema: boolean) => void;
 }
 
 export const VilkårSkjema = <T extends IVilkårSkjemaContext>({

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.tsx
@@ -4,9 +4,10 @@ import styled from 'styled-components';
 
 import { Table } from '@navikt/ds-react';
 
+import { BarnetsAlder } from './Vilkår/BarnetsAlder/BarnetsAlder';
 import VilkårTabellRad from './VilkårTabellRad';
 import type { IGrunnlagPerson } from '../../../../typer/person';
-import type { IVilkårConfig, IVilkårResultat } from '../../../../typer/vilkår';
+import { VilkårType, type IVilkårConfig, type IVilkårResultat } from '../../../../typer/vilkår';
 
 export const vilkårFeilmeldingId = (vilkårResultat: IVilkårResultat) =>
     `vilkår_${vilkårResultat.vilkårType}_${vilkårResultat.id}`;
@@ -59,6 +60,16 @@ const VilkårTabell: React.FC<IProps> = ({
             </Table.Header>
             <Table.Body>
                 {vilkårResultater.map((vilkårResultat: IVilkårResultat, index: number) => {
+                    if (vilkårResultat.vilkårType === VilkårType.BARNETS_ALDER) {
+                        return (
+                            <BarnetsAlder
+                                vilkårResultat={vilkårResultat}
+                                vilkårFraConfig={vilkårFraConfig}
+                                person={person}
+                                lesevisning={false}
+                            />
+                        );
+                    }
                     return (
                         <VilkårTabellRad
                             key={`${index}_${person.fødselsdato}_${vilkårResultat.vilkårType}_${vilkårResultat.id}`}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellContext.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
+import { Resultat, type IVilkårResultat } from '../../../../typer/vilkår';
+
+export const useVilkårTabell = (erVilkårEndret: () => boolean, vilkårResultat: IVilkårResultat) => {
+    const { vurderErLesevisning, behandlingPåVent } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
+
+    const hentInitiellEkspandering = () =>
+        erLesevisning || vilkårResultat.resultat === Resultat.IKKE_VURDERT;
+
+    const [ekspandertVilkår, settEkspandertVilkår] = useState(hentInitiellEkspandering());
+
+    useEffect(() => {
+        settEkspandertVilkår(hentInitiellEkspandering());
+    }, [behandlingPåVent]);
+
+    const toggleForm = (visAlert: boolean) => {
+        if (ekspandertVilkår && visAlert && erVilkårEndret()) {
+            alert('Vurderingen har endringer som ikke er lagret!');
+        } else {
+            settEkspandertVilkår(!ekspandertVilkår);
+        }
+    };
+
+    return {
+        ekspandertVilkår,
+        toggleForm,
+    };
+};

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -181,7 +181,11 @@ const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårR
             togglePlacement="right"
             onOpenChange={() => toggleForm(true)}
             id={vilkårFeilmeldingId(vilkårResultat)}
-            content={VilkårSkjema()}
+            content={
+                <VilkårSkjema
+                    key={`${vilkårResultat.id}-${ekspandertVilkår ? 'ekspandert' : 'lukket'}`}
+                />
+            }
         >
             <Table.DataCell>
                 <VurderingCelle>

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -8,7 +8,6 @@ import { BodyShort, Table } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { Barnehageplass } from './Vilkår/Barnehageplass/Barnehageplass';
-import { BarnetsAlder } from './Vilkår/BarnetsAlder/BarnetsAlder';
 import { BorMedSøker } from './Vilkår/BorMedSøker/BorMedSøker';
 import { BosattIRiket } from './Vilkår/BosattIRiket/BosattIRiket';
 import { LovligOpphold } from './Vilkår/LovligOpphold/LovligOpphold';
@@ -160,16 +159,6 @@ const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårR
                         lesevisning={erLesevisning}
                     />
                 );
-            case VilkårType.BARNETS_ALDER:
-                return (
-                    <BarnetsAlder
-                        vilkårResultat={vilkårResultat}
-                        vilkårFraConfig={vilkårFraConfig}
-                        toggleForm={toggleForm}
-                        person={person}
-                        lesevisning={erLesevisning}
-                    />
-                );
             default:
                 return null;
         }
@@ -181,11 +170,7 @@ const VilkårTabellRad: React.FC<IProps> = ({ person, vilkårFraConfig, vilkårR
             togglePlacement="right"
             onOpenChange={() => toggleForm(true)}
             id={vilkårFeilmeldingId(vilkårResultat)}
-            content={
-                <VilkårSkjema
-                    key={`${vilkårResultat.id}-${ekspandertVilkår ? 'ekspandert' : 'lukket'}`}
-                />
-            }
+            content={VilkårSkjema()}
         >
             <Table.DataCell>
                 <VurderingCelle>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24376

Sørger for at man rerendrer vilkår-skjema hver gang man åpner/lukker det. Det sørger for at man alltid vil ha verdier fra backend når man åpner skjemaet.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ja, dette vil også gjøre at skjemaet tømmes når man lukker skjemaet ved "pil opp"-ikonet, og ikke bare når man trykker "avbryt". 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
