### PR TITLE
NAV-24429: La til utfall sjekk som ikke ble kopiert over fra BA

### DIFF
--- a/src/frontend/typer/klage.test.ts
+++ b/src/frontend/typer/klage.test.ts
@@ -3,6 +3,7 @@ import {
     erKlageFeilregistrertAvKA,
     harAnkeEksistertPåKlagebehandling,
     KlageinstansEventType,
+    KlageinstansUtfall,
     klageinstansUtfallTilTekst,
     utledKlagebehandlingResultattekst,
 } from './klage';
@@ -81,7 +82,10 @@ describe('Klage', () => {
         test.each(alleKlageinstansUtfall)('skal utlede forventet tekst fra utfall', utfall => {
             // Arrange
             const klagebehandling = KlageTestdata.lagKlagebehandling({
-                klageinstansResultat: [KlageTestdata.lagKlageinstansResultat({ utfall })],
+                klageinstansResultat: [
+                    KlageTestdata.lagKlageinstansResultat({ utfall: undefined }),
+                    KlageTestdata.lagKlageinstansResultat({ utfall }),
+                ],
             });
 
             // Act
@@ -96,8 +100,12 @@ describe('Klage', () => {
             const klagebehandling = KlageTestdata.lagKlagebehandling({
                 klageinstansResultat: [
                     KlageTestdata.lagKlageinstansResultat({
-                        type: KlageinstansEventType.BEHANDLING_FEILREGISTRERT,
+                        type: KlageinstansEventType.KLAGEBEHANDLING_AVSLUTTET,
                         utfall: undefined,
+                    }),
+                    KlageTestdata.lagKlageinstansResultat({
+                        type: KlageinstansEventType.BEHANDLING_FEILREGISTRERT,
+                        utfall: KlageinstansUtfall.AVVIST,
                     }),
                 ],
             });

--- a/src/frontend/typer/klage.ts
+++ b/src/frontend/typer/klage.ts
@@ -102,7 +102,8 @@ function finnAvsluttetKlagebehandlingUtfall(
     behandling: IKlagebehandling
 ): KlageinstansUtfall | undefined {
     return behandling.klageinstansResultat.find(
-        resultat => resultat.type === KlageinstansEventType.KLAGEBEHANDLING_AVSLUTTET
+        resultat =>
+            resultat.utfall && resultat.type === KlageinstansEventType.KLAGEBEHANDLING_AVSLUTTET
     )?.utfall;
 }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-24429](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24429)

Glemte å kopiere over en liten del.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Nei.