### PR TITLE
Bytter til bruk av POST endepunkter for søk av personer slik at vi går bort fra sensitiv infoo i header

### DIFF
--- a/src/backend/cypress-server.ts
+++ b/src/backend/cypress-server.ts
@@ -33,7 +33,7 @@ app.get('/familie-ks-sak/api/fagsaker/*splat/hent-klagebehandlinger', (_, res) =
 app.get('/familie-ks-sak/api/fagsaker/*splat', (_, res) => {
     res.status(200).send(fagsakMock);
 });
-app.get('/familie-ks-sak/api/person', (_, res) => {
+app.post('/familie-ks-sak/api/person', (_, res) => {
     res.status(200).send(personMock);
 });
 app.get('/user/profile', (_, res) => {

--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -205,11 +205,11 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
     };
 
     const endreBruker = async (personId: string) => {
-        const hentetPerson = await request<void, IPersonInfo>({
-            method: 'GET',
+        const hentetPerson = await request<{ ident: string }, IPersonInfo>({
+            method: 'POST',
             url: '/familie-ks-sak/api/person',
-            headers: {
-                personIdent: personId,
+            data: {
+                ident: personId,
             },
         });
 

--- a/src/frontend/context/fagsak/FagsakContext.tsx
+++ b/src/frontend/context/fagsak/FagsakContext.tsx
@@ -80,11 +80,11 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
 
     const hentBruker = (personIdent: string): void => {
         settBruker(byggHenterRessurs());
-        request<void, IPersonInfo>({
-            method: 'GET',
+        request<{ ident: string }, IPersonInfo>({
+            method: 'POST',
             url: '/familie-ks-sak/api/person',
-            headers: {
-                personIdent,
+            data: {
+                ident: personIdent,
             },
             påvirkerSystemLaster: true,
         }).then((hentetPerson: Ressurs<IPersonInfo>) => {

--- a/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
@@ -188,11 +188,11 @@ const LeggTilBarn: React.FC<IProps> = ({
                 }).then((ressurs: Ressurs<IRestTilgang>) => {
                     if (ressurs.status === RessursStatus.SUKSESS) {
                         if (ressurs.data.saksbehandlerHarTilgang) {
-                            request<void, IPersonInfo>({
-                                method: 'GET',
+                            request<{ ident: string }, IPersonInfo>({
+                                method: 'POST',
                                 url: '/familie-ks-sak/api/person/enkel',
-                                headers: {
-                                    personIdent: registrerBarnSkjema.felter.ident.verdi,
+                                data: {
+                                    ident: registrerBarnSkjema.felter.ident.verdi,
                                 },
                             }).then((hentetPerson: Ressurs<IPersonInfo>) => {
                                 settSubmitRessurs(hentetPerson);


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24650

Bytter til POST fra GET ved henting av personer.
Da unngår vi å måtte legge personident i header, men heller i body mtp sensitiv info i headers.

PR i backend: https://github.com/navikt/familie-ks-sak/pull/1170