### PR TITLE
NAV-23889: Bedre feilmelding ved manglende tilgang til person/personer i fagsak

### DIFF
--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -136,7 +136,11 @@ const FagsakContainer: React.FunctionComponent = () => {
             }
         case RessursStatus.IKKE_TILGANG:
             return (
-                <Alert children={`Du har ikke tilgang til å se denne saken.`} variant="warning" />
+                <Alert
+                    children={minimalFagsak.frontendFeilmelding}
+                    variant="error"
+                    contentMaxWidth={false}
+                />
             );
         case RessursStatus.FEILET:
         case RessursStatus.FUNKSJONELL_FEIL:


### PR DESCRIPTION
Favro: [NAV-23889](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23889)

### 💰 Hva forsøker du å løse i denne PR'en
Gir saksbehandler en bedre feilmelding ved manglende tilgang til fagsak ved å erstatte hardkodet feilmelding med `frontendFeilmelding` fra backend.
  
### 👀 Screen shots
![image](https://github.com/user-attachments/assets/b80dbf67-c086-49a9-b5e8-329da61b87dd)