### PR TITLE
Tilbake: ikke ta ned løsning hvis tilbake er nede + vis warning hvis nede

### DIFF
--- a/src/frontend/api/useTilbakekrevingApi.ts
+++ b/src/frontend/api/useTilbakekrevingApi.ts
@@ -15,7 +15,7 @@ export const useTilbakekrevingApi = () => {
 
         return request<void, ITilbakekrevingsbehandling[]>({
             method: 'GET',
-            url: `/familie-ks-sak/api/tilbakekreving/${fagsakId}/hent-tilbakekrevingsbehandlinger`,
+            url: `/familie-ks-sak/api/tilbakekreving/fagsak/${fagsakId}`,
             påvirkerSystemLaster: true,
         });
     };

--- a/src/frontend/api/useTilbakekrevingApi.ts
+++ b/src/frontend/api/useTilbakekrevingApi.ts
@@ -1,0 +1,26 @@
+import { useHttp } from '@navikt/familie-http';
+import { byggTomRessurs, type Ressurs } from '@navikt/familie-typer';
+
+import type { ITilbakekrevingsbehandling } from '../typer/tilbakekrevingsbehandling';
+
+export const useTilbakekrevingApi = () => {
+    const { request } = useHttp();
+
+    const hentTilbakekrevingsbehandlinger = (
+        fagsakId: number | undefined
+    ): Promise<Ressurs<ITilbakekrevingsbehandling[]>> => {
+        if (!fagsakId) {
+            return Promise.resolve(byggTomRessurs());
+        }
+
+        return request<void, ITilbakekrevingsbehandling[]>({
+            method: 'GET',
+            url: `/familie-ks-sak/api/tilbakekreving/${fagsakId}/hent-tilbakekrevingsbehandlinger`,
+            påvirkerSystemLaster: true,
+        });
+    };
+
+    return {
+        hentTilbakekrevingsbehandlinger,
+    };
+};

--- a/src/frontend/context/fagsak/FagsakContext.tsx
+++ b/src/frontend/context/fagsak/FagsakContext.tsx
@@ -15,7 +15,7 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
-import { useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg } from './useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg';
+import { useOppdaterBrukerOgEksterneBehandlingerNårFagsakEndrerSeg } from './useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg';
 import { useTilbakekrevingApi } from '../../api/useTilbakekrevingApi';
 import type { SkjemaBrevmottaker } from '../../komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import type { IInternstatistikk, IMinimalFagsak } from '../../typer/fagsak';
@@ -161,7 +161,7 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
         );
     };
 
-    useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg({
+    useOppdaterBrukerOgEksterneBehandlingerNårFagsakEndrerSeg({
         minimalFagsak,
         settBruker,
         oppdaterBrukerHvisFagsakEndres,

--- a/src/frontend/context/fagsak/FagsakContext.tsx
+++ b/src/frontend/context/fagsak/FagsakContext.tsx
@@ -184,6 +184,7 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
         klageStatus: klagebehandlinger.status,
         oppdaterKlagebehandlingerPåFagsak,
         tilbakekrevingsbehandlinger: hentDataFraRessurs(tilbakekrevingsbehandlinger) ?? [],
+        tilbakekrevingStatus: tilbakekrevingsbehandlinger.status,
         manuelleBrevmottakerePåFagsak,
         settManuelleBrevmottakerePåFagsak,
     };

--- a/src/frontend/context/fagsak/useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg.ts
+++ b/src/frontend/context/fagsak/useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg.ts
@@ -16,6 +16,7 @@ interface Props {
     ) => void;
     bruker: Ressurs<IPersonInfo>;
     oppdaterKlagebehandlingerPåFagsak: () => void;
+    oppdaterTilbakekrevingsbehandlingerPåFagsak: () => void;
     settManuelleBrevmottakerePåFagsak: (manuelleBrevmottakere: SkjemaBrevmottaker[]) => void;
 }
 
@@ -25,6 +26,7 @@ export const useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg = ({
     oppdaterBrukerHvisFagsakEndres,
     bruker,
     oppdaterKlagebehandlingerPåFagsak,
+    oppdaterTilbakekrevingsbehandlingerPåFagsak,
     settManuelleBrevmottakerePåFagsak,
 }: Props) =>
     useEffect(() => {
@@ -40,5 +42,6 @@ export const useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg = ({
             );
         }
         oppdaterKlagebehandlingerPåFagsak();
+        oppdaterTilbakekrevingsbehandlingerPåFagsak();
         settManuelleBrevmottakerePåFagsak([]);
     }, [minimalFagsak]);

--- a/src/frontend/context/fagsak/useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg.ts
+++ b/src/frontend/context/fagsak/useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg.ts
@@ -20,7 +20,7 @@ interface Props {
     settManuelleBrevmottakerePåFagsak: (manuelleBrevmottakere: SkjemaBrevmottaker[]) => void;
 }
 
-export const useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg = ({
+export const useOppdaterBrukerOgEksterneBehandlingerNårFagsakEndrerSeg = ({
     minimalFagsak,
     settBruker,
     oppdaterBrukerHvisFagsakEndres,

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -36,9 +36,13 @@ interface IBehandlingshistorikkProps {
 }
 
 const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) => {
-    const { klagebehandlinger, klageStatus } = useFagsakContext();
+    const { klagebehandlinger, klageStatus, tilbakekrevingsbehandlinger } = useFagsakContext();
 
-    const behandlinger = hentBehandlingerTilSaksoversikten(minimalFagsak, klagebehandlinger);
+    const behandlinger = hentBehandlingerTilSaksoversikten(
+        minimalFagsak,
+        klagebehandlinger,
+        tilbakekrevingsbehandlinger
+    );
 
     const finnesRadSomKanFiltreresBort = behandlinger.some(
         (behandling: Saksoversiktsbehandling) => !skalRadVises(behandling, false)

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -36,7 +36,8 @@ interface IBehandlingshistorikkProps {
 }
 
 const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) => {
-    const { klagebehandlinger, klageStatus, tilbakekrevingsbehandlinger } = useFagsakContext();
+    const { klagebehandlinger, klageStatus, tilbakekrevingsbehandlinger, tilbakekrevingStatus } =
+        useFagsakContext();
 
     const behandlinger = hentBehandlingerTilSaksoversikten(
         minimalFagsak,
@@ -55,6 +56,11 @@ const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) =
             {ressursHarFeilet(klageStatus) && (
                 <Alert variant="warning">
                     <BodyShort>Klagebehandlinger er ikke tilgjengelig for øyeblikket.</BodyShort>
+                </Alert>
+            )}
+            {ressursHarFeilet(tilbakekrevingStatus) && (
+                <Alert variant="warning">
+                    <BodyShort>Tilbakekreving er ikke tilgjengelig for øyeblikket.</BodyShort>
                 </Alert>
             )}
             <div>

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/utils.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/utils.tsx
@@ -91,7 +91,8 @@ export const hentBehandlingId = (saksoversiktsbehandling: Saksoversiktsbehandlin
 
 export const hentBehandlingerTilSaksoversikten = (
     minimalFagsak: IMinimalFagsak,
-    klagebehandlinger: IKlagebehandling[]
+    klagebehandlinger: IKlagebehandling[],
+    tilbakekrevingsbehandlinger: ITilbakekrevingsbehandling[]
 ): Saksoversiktsbehandling[] => {
     const kontantstøtteBehandlinger: Saksoversiktsbehandling[] = minimalFagsak.behandlinger.map(
         behandling => ({
@@ -99,8 +100,8 @@ export const hentBehandlingerTilSaksoversikten = (
             saksoversiktstype: Saksoversiktstype.KONTANTSTØTTE,
         })
     );
-    const tilbakekrevingsbehandlinger: Saksoversiktsbehandling[] =
-        minimalFagsak.tilbakekrevingsbehandlinger.map(behandling => ({
+    const saksoversiktTilbakekrevingsbehandlinger: Saksoversiktsbehandling[] =
+        tilbakekrevingsbehandlinger.map(behandling => ({
             ...behandling,
             saksoversiktstype: Saksoversiktstype.TILBAKEBETALING,
         }));
@@ -112,7 +113,7 @@ export const hentBehandlingerTilSaksoversikten = (
     );
     return [
         ...kontantstøtteBehandlinger,
-        ...tilbakekrevingsbehandlinger,
+        ...saksoversiktTilbakekrevingsbehandlinger,
         ...saksoversiktKlagebehandlinger,
     ];
 };

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -1,7 +1,6 @@
 import type { BehandlingÅrsak } from './behandling';
 import type { BehandlingKategori } from './behandlingstema';
 import type { INøkkelPar } from './common';
-import type { ITilbakekrevingsbehandling } from './tilbakekrevingsbehandling';
 import type { Utbetalingsperiode } from './utbetalingsperiode';
 import type { VisningBehandling } from '../komponenter/Fagsak/Saksoversikt/visningBehandling';
 
@@ -25,7 +24,6 @@ interface IBaseFagsak {
 
 export interface IMinimalFagsak extends IBaseFagsak {
     behandlinger: VisningBehandling[];
-    tilbakekrevingsbehandlinger: ITilbakekrevingsbehandling[];
     gjeldendeUtbetalingsperioder: Utbetalingsperiode[];
 }
 

--- a/src/frontend/utils/test/minimalFagsak/minimalFagsak.mock.ts
+++ b/src/frontend/utils/test/minimalFagsak/minimalFagsak.mock.ts
@@ -36,6 +36,5 @@ export const mockMinimalFagsak = ({
     status,
     underBehandling,
     gjeldendeUtbetalingsperioder,
-    tilbakekrevingsbehandlinger: [],
     løpendeKategori,
 });


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24805

Hent tilbakekrevingsbehandlinger i eget endepunkt sånn at løsningen vår ikke går ned om tilbakekreving er nede. Viser warning på saksoversikt hvis tilbakekreving er nede. Dette er løst likt som for klage.

Tilhørende backend PR som må merges først: https://github.com/navikt/familie-ks-sak/pull/1197

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Syns ikke det gir mening

### 🤷‍♀ ️Hvor er det lurt å starte?
Samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Hvis tilbakekreving er nede får vi nå opp denne alerten: 
![image](https://github.com/user-attachments/assets/ad11346f-850b-42c3-a1b2-f18e4075eba8)

