### PR TITLE
NAV-24779: Fjerner behandlingsårsak 'Klage' fra mulige behandlingsårsaker ved opprettelse av revurdering

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/BehandlingsårsakFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/BehandlingsårsakFelt.tsx
@@ -24,6 +24,18 @@ export const BehandlingårsakFelt: React.FC<IProps> = ({
 }) => {
     const { toggles } = useApp();
 
+    const behandlingÅrsakerSomIkkeSkalSettesManuelt = [
+        BehandlingÅrsak.KLAGE,
+        BehandlingÅrsak.LOVENDRING_2024,
+        BehandlingÅrsak.SATSENDRING,
+        toggles[ToggleNavn.kanOppretteRevurderingMedAarsakIverksetteKaVedtak]
+            ? null
+            : BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
+        toggles[ToggleNavn.kanManueltKorrigereMedVedtaksbrev]
+            ? null
+            : BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
+    ].filter(behandlingsårsak => behandlingsårsak != null);
+
     return (
         <Select
             {...behandlingsårsak.hentNavBaseSkjemaProps(visFeilmeldinger)}
@@ -39,16 +51,10 @@ export const BehandlingårsakFelt: React.FC<IProps> = ({
             </option>
             {Object.values(BehandlingÅrsak)
                 .filter(
-                    årsak =>
-                        årsak !== BehandlingÅrsak.SATSENDRING &&
-                        (årsak !== BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
-                            toggles[ToggleNavn.kanManueltKorrigereMedVedtaksbrev])
-                )
-                .filter(årsak => årsak !== BehandlingÅrsak.LOVENDRING_2024)
-                .filter(
-                    årsak =>
-                        årsak !== BehandlingÅrsak.IVERKSETTE_KA_VEDTAK ||
-                        toggles[ToggleNavn.kanOppretteRevurderingMedAarsakIverksetteKaVedtak]
+                    behandlingsårsak =>
+                        !behandlingÅrsakerSomIkkeSkalSettesManuelt.find(
+                            årsak => årsak == behandlingsårsak
+                        )
                 )
                 .map(årsak => {
                     return (

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/BehandlingsårsakFelt.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/BehandlingsårsakFelt.tsx
@@ -4,8 +4,11 @@ import { Select } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../../../context/AppContext';
-import { behandlingÅrsak, BehandlingÅrsak } from '../../../../../typer/behandling';
-import { ToggleNavn } from '../../../../../typer/toggles';
+import {
+    behandlingÅrsak,
+    BehandlingÅrsak,
+    behandlingÅrsakerSomIkkeSkalSettesManuelt,
+} from '../../../../../typer/behandling';
 
 interface BehandlingÅrsakSelect extends HTMLSelectElement {
     value: BehandlingÅrsak | '';
@@ -24,18 +27,6 @@ export const BehandlingårsakFelt: React.FC<IProps> = ({
 }) => {
     const { toggles } = useApp();
 
-    const behandlingÅrsakerSomIkkeSkalSettesManuelt = [
-        BehandlingÅrsak.KLAGE,
-        BehandlingÅrsak.LOVENDRING_2024,
-        BehandlingÅrsak.SATSENDRING,
-        toggles[ToggleNavn.kanOppretteRevurderingMedAarsakIverksetteKaVedtak]
-            ? null
-            : BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
-        toggles[ToggleNavn.kanManueltKorrigereMedVedtaksbrev]
-            ? null
-            : BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
-    ].filter(behandlingsårsak => behandlingsårsak != null);
-
     return (
         <Select
             {...behandlingsårsak.hentNavBaseSkjemaProps(visFeilmeldinger)}
@@ -52,8 +43,8 @@ export const BehandlingårsakFelt: React.FC<IProps> = ({
             {Object.values(BehandlingÅrsak)
                 .filter(
                     behandlingsårsak =>
-                        !behandlingÅrsakerSomIkkeSkalSettesManuelt.find(
-                            årsak => årsak == behandlingsårsak
+                        !behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles).includes(
+                            behandlingsårsak
                         )
                 )
                 .map(årsak => {

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -14,6 +14,7 @@ import type {
     TilbakekrevingsbehandlingResultat,
     TilbakekrevingsbehandlingÅrsak,
 } from './tilbakekrevingsbehandling';
+import { type IToggles, ToggleNavn } from './toggles';
 import type { ITotrinnskontroll } from './totrinnskontroll';
 import type { IRestEndretUtbetalingAndel } from './utbetalingAndel';
 import type { Utbetalingsperiode } from './utbetalingsperiode';
@@ -61,6 +62,19 @@ export enum BehandlingÅrsak {
     OVERGANGSORDNING_2024 = 'OVERGANGSORDNING_2024',
     IVERKSETTE_KA_VEDTAK = 'IVERKSETTE_KA_VEDTAK',
 }
+
+export const behandlingÅrsakerSomIkkeSkalSettesManuelt = (toggles: IToggles): BehandlingÅrsak[] =>
+    [
+        BehandlingÅrsak.KLAGE,
+        BehandlingÅrsak.LOVENDRING_2024,
+        BehandlingÅrsak.SATSENDRING,
+        toggles[ToggleNavn.kanOppretteRevurderingMedAarsakIverksetteKaVedtak]
+            ? null
+            : BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
+        toggles[ToggleNavn.kanManueltKorrigereMedVedtaksbrev]
+            ? null
+            : BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
+    ].filter(behandlingsårsak => behandlingsårsak !== null);
 
 export const behandlingÅrsak: Record<
     BehandlingÅrsak | TilbakekrevingsbehandlingÅrsak | KlageÅrsak,

--- a/src/frontend/typer/test/behandling.test.ts
+++ b/src/frontend/typer/test/behandling.test.ts
@@ -1,4 +1,10 @@
-import { BehandlingResultat, erBehandlingHenlagt } from '../behandling';
+import {
+    BehandlingResultat,
+    BehandlingÅrsak,
+    behandlingÅrsakerSomIkkeSkalSettesManuelt,
+    erBehandlingHenlagt,
+} from '../behandling';
+import { type IToggles } from '../toggles';
 
 describe('Behandlingstester', () => {
     test('Alle henleggelsesresultater skal trigge erHenlagt', () => {
@@ -9,5 +15,114 @@ describe('Behandlingstester', () => {
                 expect(erBehandlingHenlagt(resultat)).toBe(false);
             }
         });
+    });
+});
+
+describe('behandlingÅrsakerSomIkkeSkalSettesManuelt inneholde alle behandlingsårsaker som ikke skal kunne velges manuelt', () => {
+    test('Alle relevante toggles er skrudd på', () => {
+        // Arrange
+        const toggles: IToggles = {
+            kanOppretteRevurderingMedAarsakIverksetteKaVedtak: true,
+            kanManueltKorrigereMedVedtaksbrev: true,
+        };
+
+        const forventedeBehandlingsårsaker = new Set([
+            BehandlingÅrsak.KLAGE,
+            BehandlingÅrsak.LOVENDRING_2024,
+            BehandlingÅrsak.SATSENDRING,
+        ]);
+
+        // Act
+        const behandlingsårsaker = behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles);
+
+        // Assert
+        const behandlingsårsakerSet = new Set(behandlingsårsaker);
+        const forventedeBehandlingsårsakerSet = new Set(forventedeBehandlingsårsaker);
+        expect(behandlingsårsakerSet.size == forventedeBehandlingsårsakerSet.size);
+        expect(
+            [...behandlingsårsakerSet].every(behandlingÅrsak =>
+                [...forventedeBehandlingsårsakerSet].includes(behandlingÅrsak)
+            )
+        );
+    });
+    test('Alle relevante toggles er skrudd av', () => {
+        // Arrange
+        const toggles: IToggles = {
+            kanOppretteRevurderingMedAarsakIverksetteKaVedtak: false,
+            kanManueltKorrigereMedVedtaksbrev: false,
+        };
+
+        const forventedeBehandlingsårsaker = new Set([
+            BehandlingÅrsak.KLAGE,
+            BehandlingÅrsak.LOVENDRING_2024,
+            BehandlingÅrsak.SATSENDRING,
+            BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
+            BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
+        ]);
+
+        // Act
+        const behandlingsårsaker = behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles);
+
+        // Assert
+        const behandlingsårsakerSet = new Set(behandlingsårsaker);
+        const forventedeBehandlingsårsakerSet = new Set(forventedeBehandlingsårsaker);
+        expect(behandlingsårsakerSet.size == forventedeBehandlingsårsakerSet.size);
+        expect(
+            [...behandlingsårsakerSet].every(behandlingÅrsak =>
+                [...forventedeBehandlingsårsakerSet].includes(behandlingÅrsak)
+            )
+        );
+    });
+    test('Toggelen kanOppretteRevurderingMedAarsakIverksetteKaVedtak er skrudd på', () => {
+        // Arrange
+        const toggles: IToggles = {
+            kanOppretteRevurderingMedAarsakIverksetteKaVedtak: true,
+            kanManueltKorrigereMedVedtaksbrev: false,
+        };
+
+        const forventedeBehandlingsårsaker = new Set([
+            BehandlingÅrsak.KLAGE,
+            BehandlingÅrsak.LOVENDRING_2024,
+            BehandlingÅrsak.SATSENDRING,
+            BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
+        ]);
+        // Act
+        const behandlingsårsaker = behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles);
+
+        // Assert
+        const behandlingsårsakerSet = new Set(behandlingsårsaker);
+        const forventedeBehandlingsårsakerSet = new Set(forventedeBehandlingsårsaker);
+        expect(behandlingsårsakerSet.size == forventedeBehandlingsårsakerSet.size);
+        expect(
+            [...behandlingsårsakerSet].every(behandlingÅrsak =>
+                [...forventedeBehandlingsårsakerSet].includes(behandlingÅrsak)
+            )
+        );
+    });
+    test('Toggelen kanManueltKorrigereMedVedtaksbrev er skrudd på', () => {
+        // Arrange
+        const toggles: IToggles = {
+            kanOppretteRevurderingMedAarsakIverksetteKaVedtak: false,
+            kanManueltKorrigereMedVedtaksbrev: true,
+        };
+
+        const forventedeBehandlingsårsaker = new Set([
+            BehandlingÅrsak.KLAGE,
+            BehandlingÅrsak.LOVENDRING_2024,
+            BehandlingÅrsak.SATSENDRING,
+            BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
+        ]);
+        // Act
+        const behandlingsårsaker = behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles);
+
+        // Assert
+        const behandlingsårsakerSet = new Set(behandlingsårsaker);
+        const forventedeBehandlingsårsakerSet = new Set(forventedeBehandlingsårsaker);
+        expect(behandlingsårsakerSet.size == forventedeBehandlingsårsakerSet.size);
+        expect(
+            [...behandlingsårsakerSet].every(behandlingÅrsak =>
+                [...forventedeBehandlingsårsakerSet].includes(behandlingÅrsak)
+            )
+        );
     });
 });


### PR DESCRIPTION
Favro: [NAV-24779](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24779)

### 💰 Hva forsøker du å løse i denne PR'en
Det skal ikke lenger være mulig å opprette revurderinger med årsak "Klage".

Filtrerer her ut "Klage" fra de mulige behandlingsårsakene.

### 👀 Screen shots
Før:
![image](https://github.com/user-attachments/assets/262f696f-f58b-463e-8dcf-d2d7a1d80914)

Etter:
![image](https://github.com/user-attachments/assets/9a574f62-4349-44b6-9d19-fb9673b27aa9)
