### PR TITLE
Fjern validering av barnets alder under 1 år

### DIFF
--- a/src/frontend/context/SøknadContext.ts
+++ b/src/frontend/context/SøknadContext.ts
@@ -49,7 +49,6 @@ const [SøknadProvider, useSøknad] = createUseContext(
         const { fagsakId } = useSakOgBehandlingParams();
         const navigate = useNavigate();
         const { bruker, minimalFagsakRessurs } = useFagsakContext();
-        const [visBekreftModal, settVisBekreftModal] = React.useState<boolean>(false);
 
         const barnMedLøpendeUtbetaling =
             minimalFagsakRessurs.status === RessursStatus.SUKSESS
@@ -181,11 +180,6 @@ const [SøknadProvider, useSøknad] = createUseContext(
                                     `/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/vilkaarsvurdering`
                                 );
                             }
-                        },
-                        (errorResponse: Ressurs<IBehandling>) => {
-                            if (errorResponse.status === RessursStatus.FUNKSJONELL_FEIL) {
-                                settVisBekreftModal(true);
-                            }
                         }
                     );
                 }
@@ -196,10 +190,8 @@ const [SøknadProvider, useSøknad] = createUseContext(
             barnMedLøpendeUtbetaling,
             hentFeilTilOppsummering,
             nesteAction,
-            settVisBekreftModal,
             skjema,
             søknadErLastetFraBackend,
-            visBekreftModal,
         };
     }
 );

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/RegistrerSøknad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/RegistrerSøknad.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, BodyShort, Button, ErrorSummary, Modal } from '@navikt/ds-react';
+import { Alert, ErrorSummary } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import Annet from './Annet';
@@ -13,11 +13,6 @@ import MålformVelger from '../../../../../komponenter/MålformVelger';
 import Skjemasteg from '../../../../../komponenter/Skjemasteg/Skjemasteg';
 import { BehandlingSteg } from '../../../../../typer/behandling';
 
-const FjernVilkårAdvarsel = styled(BodyShort)`
-    white-space: pre-wrap;
-    padding-bottom: 3.5rem;
-`;
-
 const StyledSkjemasteg = styled(Skjemasteg)`
     max-width: 40rem;
 `;
@@ -26,14 +21,7 @@ const RegistrerSøknad: React.FC = () => {
     const { vurderErLesevisning } = useBehandling();
     const erLesevisning = vurderErLesevisning();
 
-    const {
-        hentFeilTilOppsummering,
-        nesteAction,
-        settVisBekreftModal,
-        skjema,
-        søknadErLastetFraBackend,
-        visBekreftModal,
-    } = useSøknad();
+    const { hentFeilTilOppsummering, nesteAction, skjema, søknadErLastetFraBackend } = useSøknad();
 
     return (
         <StyledSkjemasteg
@@ -84,50 +72,6 @@ const RegistrerSøknad: React.FC = () => {
                         </ErrorSummary.Item>
                     ))}
                 </ErrorSummary>
-            )}
-
-            {visBekreftModal && (
-                <Modal
-                    open
-                    onClose={() => settVisBekreftModal(false)}
-                    header={{
-                        heading: 'Er du sikker på at du vil gå videre?',
-                        size: 'small',
-                        closeButton: false,
-                    }}
-                    width={'35rem'}
-                >
-                    <Modal.Body>
-                        <FjernVilkårAdvarsel>
-                            {skjema.submitRessurs.status === RessursStatus.FEILET ||
-                                (skjema.submitRessurs.status === RessursStatus.FUNKSJONELL_FEIL &&
-                                    skjema.submitRessurs.frontendFeilmelding)}
-                        </FjernVilkårAdvarsel>
-                    </Modal.Body>
-                    <Modal.Footer>
-                        <Button
-                            key={'ja'}
-                            variant={'primary'}
-                            size={'small'}
-                            onClick={() => {
-                                settVisBekreftModal(false);
-                                nesteAction(true);
-                            }}
-                            children={'Ja'}
-                            loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                            disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
-                        />
-                        <Button
-                            variant={'secondary'}
-                            key={'nei'}
-                            size={'small'}
-                            onClick={() => {
-                                settVisBekreftModal(false);
-                            }}
-                            children={'Nei'}
-                        />
-                    </Modal.Footer>
-                </Modal>
             )}
         </StyledSkjemasteg>
     );


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24724

Vi fjerner validering av at barn ikke kan være under 1 år når vi behandler behandlingene.
Det skal heller gis avslag på disse, som er derfor jeg også har lagt inn en ny begrunnelse.

<img width="470" alt="Screenshot 2025-04-22 at 18 44 43" src="https://github.com/user-attachments/assets/e2b28d97-0bec-4c3d-a833-658b14d0f386" />