### PR TITLE
Fikser slik at man går til KS sin tilbakekreving

### DIFF
--- a/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
@@ -413,7 +413,7 @@ export const OppgavebenkProvider = (props: PropsWithChildren) => {
                 },
             }).then((fagsak: Ressurs<IMinimalFagsak | undefined>) => {
                 if (fagsak.status === RessursStatus.SUKSESS && !!fagsak.data) {
-                    window.location.href = `/redirect/familie-tilbake/fagsystem/BA/fagsak/${fagsak.data.id}/behandling/${oppgave.saksreferanse}`;
+                    window.location.href = `/redirect/familie-tilbake/fagsystem/KS/fagsak/${fagsak.data.id}/behandling/${oppgave.saksreferanse}`;
                 }
             });
         }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25031


Når man tildeler tilbakekrevingsoppgaver til seg selv, så skal man bli tatt med til tilbakekrevingsløsningen.
Det skjer ikke i KS grunnet BA prefix.