### PR TITLE
Ikke bruk commit SHA for versjonering av workflow template

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-yarn-app.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/build-yarn-app.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-yarn-app.yaml@main # ratchet:exclude
     with:
       build-image: true
       push-image: true
@@ -34,7 +34,7 @@ jobs:
     permissions:
       id-token: write
     needs: [build]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main # ratchet:exclude
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: dev-gcp
@@ -45,7 +45,7 @@ jobs:
     permissions:
       id-token: write
     needs: [build, deploy-dev]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main # ratchet:exclude
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: prod-gcp

--- a/.github/workflows/manual-deploy-dev.yaml
+++ b/.github/workflows/manual-deploy-dev.yaml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-yarn-app.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/build-yarn-app.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-yarn-app.yaml@main # ratchet:exclude
     with:
       build-image: true
       push-image: true
@@ -34,7 +34,7 @@ jobs:
     permissions:
       id-token: write
     needs: [build]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main # ratchet:exclude
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: dev-gcp

--- a/.github/workflows/manual-deploy-prod.yaml
+++ b/.github/workflows/manual-deploy-prod.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-yarn-app.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/build-yarn-app.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-yarn-app.yaml@main # ratchet:exclude
     with:
       build-image: true
       push-image: true
@@ -35,7 +35,7 @@ jobs:
     permissions:
       id-token: write
     needs: [build]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main # ratchet:exclude
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: prod-gcp

--- a/.github/workflows/manual-deploy-with-image.yaml
+++ b/.github/workflows/manual-deploy-with-image.yaml
@@ -19,7 +19,7 @@ jobs:
     if: inputs.image != ''
     permissions:
       id-token: write
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy-with-tag.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/deploy-with-tag.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy-with-tag.yaml@main # ratchet:exclude
     with:
       image-tag: ${{ inputs.image }}
       cluster: ${{ inputs.environment }}-gcp

--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -19,5 +19,5 @@ jobs:
     permissions:
       contents: write # to write sarif
       security-events: write # push sarif to github security
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-yarn.yaml@95b1f0f855f8c73015db7b815d249ee11f035906 # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-yarn.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-yarn.yaml@main # ratchet:exclude
     secrets: inherit


### PR DESCRIPTION
Blir for mye styr å vedlikeholde. Pluss at dependabot støtter ikke bumping av SHA med mindre man har release-nummer på templatene, som også er strevsomt