### PR TITLE
Bruk nye enhetsgrupper ved tilgangssjekk

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -37,6 +37,14 @@ spec:
           - id: "52fe1bef-224f-49df-a40a-29f92d4520f8"  # '0000-GA-Kontantstotte-Beslutter' - Beslutter
           - id: "314fa714-f13c-4cdc-ac5c-e13ce08e241c"  # '0000-GA-Kontantstotte-Superbruker' - Superbruker
           - id: "c62e908a-cf20-4ad0-b7b3-3ff6ca4bf38b"  # teamfamilie-forvaltning
+          - id: "e2cf416e-eb2b-4c86-8b5b-8c5b00385bcf"  # 0000-GA-ENHET_2103 (VIKAFOSSEN)
+          - id: "16d14203-a5e0-4813-ba76-6d0a69aeb88b"  # 0000-GA-ENHET_4806 (DRAMMEN)
+          - id: "a996c91f-6dd1-466d-bed0-06ddccab87f5"  # 0000-GA-ENHET_4820 (VADSØ)
+          - id: "48ff353a-fd52-4109-be32-d0e825322b1f"  # 0000-GA-ENHET_4833 (OSLO)
+          - id: "b00084c4-0325-4ec3-b17f-70aa0a03ed37"  # 0000-GA-ENHET_4842 (STORD)
+          - id: "b5a21ebf-d8c7-415c-9a88-6b4735f845cd"  # 0000-GA-ENHET_4817 (STEINKJER)
+          - id: "9a0b01fd-64ec-4912-8c32-d041417fc8ec"  # 0000-GA-ENHET_4863 (BERGEN)
+          - id: "22a9b5f5-645f-4090-ae2d-29a38a126de6"  # 0000-GA-ENHET_4863 (MIDLERTIDIG_ENHET)
   resources:
     limits:
       cpu: 2000m

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -35,13 +35,14 @@ spec:
           - id: "4e7f23d9-5db1-45c0-acec-89c86a9ec678"  # '0000-GA-Kontantstotte-Beslutter' - Beslutter
           - id: "b8158d87-a284-4620-9bf9-f0aa3f62c8aa"  # '0000-GA-Kontantstotte-Superbruker' - Superbruker
           - id: "3d718ae5-f25e-47a4-b4b3-084a97604c1d"  # teamfamilie-forvaltning
-          - id: "833f1f77-b64b-4708-b479-389ca4009af5"  # MEDLEM: 2103 NAV Vikafossen
-          - id: "c2cf4114-1f5d-47f2-bb6e-c7a06fd26412"  # MEDLEM: 4806 NAV Familie- og pensjonsytelser Drammen
-          - id: "6c8c5d93-0e08-4bd8-960c-5c4c0ce5c609"  # MEDLEM: 4820 NAV Familie- og pensjonsytelser Vadsø
-          - id: "9cd89ac3-5587-46ba-b571-a625f2af481d"  # MEDLEM: 4833 NAV Familie- og pensjonsytelser Oslo 1
-          - id: "7af5f216-6a5e-4228-9c99-687658c5b957"  # MEDLEM: 4842 NAV Familie- og pensjonsytelser Stord
-          - id: "0feaea21-ada1-48c0-9300-3f6aec36b993"  # MEDLEM: 4817 NAV Familie- og pensjonsytelser Steinkjer
-          - id: "7342c168-80f4-4978-8a88-68cb43b85675"  # MEDLEM: 4812 NAV Familie- og pensjonsytelser Bergen
+          - id: "60102d01-2521-40b4-97b9-e2d738f642c1"  # 0000-GA-ENHET_2103 (VIKAFOSSEN)
+          - id: "0d746128-7cb0-431b-9420-885e7a75260f"  # 0000-GA-ENHET_4806 (DRAMMEN)
+          - id: "4a9058c7-daae-452a-9fea-23beaa0778ff"  # 0000-GA-ENHET_4820 (VADSØ)
+          - id: "fde8342e-d9e6-4879-be17-a8f17cb9abfb"  # 0000-GA-ENHET_4833 (OSLO)
+          - id: "4c0aff0d-78f9-4a4d-94d3-a31a28d75142"  # 0000-GA-ENHET_4842 (STORD)
+          - id: "8672ac10-31f5-44df-b4a2-16d5443847bc"  # 0000-GA-ENHET_4817 (STEINKJER)
+          - id: "4bfcd9dc-0290-4562-b352-6c56861a2dad"  # 0000-GA-ENHET_4812 (BERGEN)
+          - id: "946a9fb3-1d6c-4cda-9bfe-aaa8b857dd1b"  # 0000-GA-ENHET_4863 (MIDLERTIDIG_ENHET)
   resources:
     limits:
       cpu: 2000m

--- a/src/frontend/typer/enhet.ts
+++ b/src/frontend/typer/enhet.ts
@@ -16,8 +16,8 @@ export const enhetsgrupper: Record<string, string> = {
     '4820': '4a9058c7-daae-452a-9fea-23beaa0778ff',
     '4833': 'fde8342e-d9e6-4879-be17-a8f17cb9abfb',
     '4842': '4c0aff0d-78f9-4a4d-94d3-a31a28d75142',
-    '4817': '4bfcd9dc-0290-4562-b352-6c56861a2dad',
-    '4812': '7342c168-80f4-4978-8a88-68cb43b85675',
+    '4817': '8672ac10-31f5-44df-b4a2-16d5443847bc',
+    '4812': '4bfcd9dc-0290-4562-b352-6c56861a2dad',
 };
 
 export interface IArbeidsfordelingsenhet {

--- a/src/frontend/typer/enhet.ts
+++ b/src/frontend/typer/enhet.ts
@@ -11,12 +11,12 @@ export const behandendeEnheter: IArbeidsfordelingsenhet[] = [
 ];
 
 export const enhetsgrupper: Record<string, string> = {
-    '2103': '833f1f77-b64b-4708-b479-389ca4009af5',
-    '4806': 'c2cf4114-1f5d-47f2-bb6e-c7a06fd26412',
-    '4820': '6c8c5d93-0e08-4bd8-960c-5c4c0ce5c609',
-    '4833': '9cd89ac3-5587-46ba-b571-a625f2af481d',
-    '4842': '7af5f216-6a5e-4228-9c99-687658c5b957',
-    '4817': '0feaea21-ada1-48c0-9300-3f6aec36b993',
+    '2103': '60102d01-2521-40b4-97b9-e2d738f642c1',
+    '4806': '0d746128-7cb0-431b-9420-885e7a75260f',
+    '4820': '4a9058c7-daae-452a-9fea-23beaa0778ff',
+    '4833': 'fde8342e-d9e6-4879-be17-a8f17cb9abfb',
+    '4842': '4c0aff0d-78f9-4a4d-94d3-a31a28d75142',
+    '4817': '4bfcd9dc-0290-4562-b352-6c56861a2dad',
     '4812': '7342c168-80f4-4978-8a88-68cb43b85675',
 };
 

--- a/src/frontend/typer/test/enhet.test.ts
+++ b/src/frontend/typer/test/enhet.test.ts
@@ -3,7 +3,7 @@ import { enhetsgrupper, harTilgangTilEnhet } from '../enhet';
 describe('Enhet typer', () => {
     test('Skal sjekke tilgangsstyring på enheter', () => {
         expect(
-            harTilgangTilEnhet('4806', ['c2cf4114-1f5d-47f2-bb6e-c7a06fd26412'], () => false)
+            harTilgangTilEnhet('4806', ['0d746128-7cb0-431b-9420-885e7a75260f'], () => false)
         ).toBe(true);
         expect(harTilgangTilEnhet('4806', [], () => false)).toBe(false);
     });


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25336

Det er noen saksbehandlere fra 4820 som skal kunne jobbe med behandlinger i enhet 4812.
Det viser seg at de har fått rollen 4812-GF-enhetsmedlem, noe som ikke stemmer overrens med gruppeId 7342c168-80f4-4978-8a88-68cb43b85675 som er den vi sjekker på per i dag.

Det er veldig vanskelig for dem å få "riktig" 4812 gruppe siden det eksisterer så mange, her skulle man egentlig hatt "7342c168-80f4-4978-8a88-68cb43b85675" med navn "4812 NAV Familie- og pensjonsytelser Bergen".

Jeg endrer derfor vår tilgangssjekk i frontend til å sjekke på gruppene som har navn "0000-GA-ENHET_XXXX", da dette er noe alle sb får tildelt automatisk hvis de er koblet til enheten. 