### PR TITLE
Sjekk på ID fremfor visningsnavn

### DIFF
--- a/src/frontend/komponenter/Hendelsesoversikt/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/komponenter/Hendelsesoversikt/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -61,7 +61,7 @@ const Totrinnskontrollskjema: React.FunctionComponent<IProps> = ({
     const saksbehandler = totrinnskontroll?.saksbehandler ?? 'UKJENT SAKSBEHANDLER';
     const opprettetTidspunkt = totrinnskontroll?.opprettetTidspunkt ?? undefined;
 
-    const egetVedtak = totrinnskontroll?.saksbehandler === innloggetSaksbehandler?.displayName;
+    const egetVedtak = totrinnskontroll?.saksbehandlerId === innloggetSaksbehandler?.navIdent;
 
     return (
         <Fieldset

--- a/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -39,8 +39,8 @@ const EndreBehandlendeEnhet: React.FC = () => {
         if (
             steg &&
             hentStegNummer(steg) === hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK) &&
-            innloggetSaksbehandler?.displayName !==
-                åpenBehandlingData?.totrinnskontroll?.saksbehandler
+            innloggetSaksbehandler?.navIdent !==
+                åpenBehandlingData?.totrinnskontroll?.saksbehandlerId
         ) {
             return false;
         } else {

--- a/src/frontend/typer/totrinnskontroll.ts
+++ b/src/frontend/typer/totrinnskontroll.ts
@@ -12,6 +12,7 @@ export interface ITotrinnskontrollData {
 
 export interface ITotrinnskontroll {
     saksbehandler: string;
+    saksbehandlerId: string;
     beslutter?: string;
     godkjent: boolean;
     opprettetTidspunkt: string;

--- a/src/frontend/utils/test/behandling/behandling.mock.ts
+++ b/src/frontend/utils/test/behandling/behandling.mock.ts
@@ -75,6 +75,7 @@ export const mockBehandling = ({
         vedtak: undefined,
         totrinnskontroll: {
             saksbehandler: 'Saksbehandler',
+            saksbehandlerId: 'VL',
             beslutter: 'Beslutter',
             godkjent: true,
             opprettetTidspunkt,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25337

Per nå sammenlignes det på visningsnavn når man sjekker om noen er beslutter eller saksbehandler av eget vedtak.

Dette er ikke bra practice fordi:

- For kode 6/19 saker settes alle navn til Anonym Nav bruker, og da fungerer ikke logikken.
- En SB og Beslutter med samme navn vil føre til at systemet tror at beslutter er SB.