### PR TITLE
Fjerner eslint-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-prettier": "^5.4.0",
-    "eslint-webpack-plugin": "^5.0.1",
     "express-static-gzip": "^2.2.0",
     "file-loader": "^6.2.0",
     "fork-ts-checker-webpack-plugin": "^9.1.0",

--- a/src/webpack/webpack.common.js
+++ b/src/webpack/webpack.common.js
@@ -5,7 +5,6 @@ import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import TypeScriptTypeChecker from 'fork-ts-checker-webpack-plugin';
-import ESLintPlugin from 'eslint-webpack-plugin';
 
 const publicUrl = '/assets';
 
@@ -39,11 +38,6 @@ const baseConfig = {
                 },
                 mode: 'write-references',
             },
-        }),
-        new ESLintPlugin({
-            extensions: [`ts`, `tsx`],
-            configType: 'flat',
-            failOnError: process.env.NODE_ENV === 'production',
         }),
     ],
     devtool: 'inline-source-map',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2435,7 +2435,7 @@
     "@types/eslint" "*"
     "@types/estree" "*"
 
-"@types/eslint@*", "@types/eslint@^9.6.1":
+"@types/eslint@*":
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-9.6.1.tgz#d5795ad732ce81715f27f75da913004a56751584"
   integrity sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==
@@ -5480,17 +5480,6 @@ eslint-visitor-keys@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz#687bacb2af884fcdda8a6e7d65c606f46a14cd45"
   integrity sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==
-
-eslint-webpack-plugin@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-5.0.1.tgz#411ea796918e26659e3aef3a776527609e837817"
-  integrity sha512-Ur100Vi+z0uP7j4Z8Ccah0pXmNHhl3f7P2hCYZj3mZCOSc33G5c1R/vZ4KCapwWikPgRyD4dkangx6JW3KaVFQ==
-  dependencies:
-    "@types/eslint" "^9.6.1"
-    jest-worker "^29.7.0"
-    micromatch "^4.0.8"
-    normalize-path "^3.0.0"
-    schema-utils "^4.3.0"
 
 eslint@^9.28.0:
   version "9.28.0"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi ønsker ikke å blokkere grensesnittet når vi har lintfeil slik som eslint-webpack-plugin gjorde. Jeg fjerner den dermed, vi har linting på både pre-commit hook og bygging. Det burde være nok. :)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingenting å fremheve

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Ingen visuelle endringer