### PR TITLE
Legg til bosatt på svalbard valg i utdypende vilkårsvurdering for bosatt i riket

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
@@ -27,6 +27,7 @@ interface Props {
 
 const utdypendeVilkårsvurderingTekst: Record<UtdypendeVilkårsvurdering, string> = {
     [UtdypendeVilkårsvurderingGenerell.VURDERING_ANNET_GRUNNLAG]: 'Vurdering annet grunnlag',
+    [UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD]: 'Bosatt på Svalbard',
     [UtdypendeVilkårsvurderingDeltBosted.DELT_BOSTED]: 'Delt bosted: skal deles',
     [UtdypendeVilkårsvurderingDeltBosted.DELT_BOSTED_SKAL_IKKE_DELES]:
         'Delt bosted: skal ikke deles',

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiketContext.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiketContext.ts
@@ -3,26 +3,26 @@ import { useState } from 'react';
 import { useFelt } from '@navikt/familie-skjema';
 
 import { erUtdypendeVilkårsvurderingerGyldig } from './BosattIRiketValidering';
-import { PersonType } from '../../../../../../../../typer/person';
 import type { IGrunnlagPerson } from '../../../../../../../../typer/person';
+import { PersonType } from '../../../../../../../../typer/person';
 import type { Begrunnelse } from '../../../../../../../../typer/vedtak';
-import type { UtdypendeVilkårsvurdering } from '../../../../../../../../typer/vilkår';
-import type { IVilkårResultat } from '../../../../../../../../typer/vilkår';
-import type { Resultat } from '../../../../../../../../typer/vilkår';
-import { Regelverk as RegelverkType, VilkårType } from '../../../../../../../../typer/vilkår';
+import type { IVilkårResultat, Resultat } from '../../../../../../../../typer/vilkår';
 import {
-    UtdypendeVilkårsvurderingGenerell,
-    UtdypendeVilkårsvurderingEøsSøkerBosattIRiket,
+    Regelverk as RegelverkType,
+    type UtdypendeVilkårsvurdering,
     UtdypendeVilkårsvurderingEøsBarnBosattIRiket,
+    UtdypendeVilkårsvurderingEøsSøkerBosattIRiket,
+    UtdypendeVilkårsvurderingGenerell,
+    VilkårType,
 } from '../../../../../../../../typer/vilkår';
 import type { IIsoDatoPeriode } from '../../../../../../../../utils/dato';
 import {
     erAvslagBegrunnelserGyldig,
+    erBegrunnelseGyldig,
     erPeriodeGyldig,
     erResultatGyldig,
-    erBegrunnelseGyldig,
 } from '../../../../../../../../utils/validators';
-import { useVilkårSkjema, type IVilkårSkjemaContext } from '../../VilkårSkjemaContext';
+import { type IVilkårSkjemaContext, useVilkårSkjema } from '../../VilkårSkjemaContext';
 
 export const useBosattIRiket = (lagretVilkår: IVilkårResultat, person: IGrunnlagPerson) => {
     const vilkårSkjemaMedLagredeVerdier: IVilkårSkjemaContext = {
@@ -150,5 +150,8 @@ export const bestemMuligeUtdypendeVilkårsvurderingerIBosattIRiketVilkår = (
             ];
         }
     }
-    return [UtdypendeVilkårsvurderingGenerell.VURDERING_ANNET_GRUNNLAG];
+    return [
+        UtdypendeVilkårsvurderingGenerell.VURDERING_ANNET_GRUNNLAG,
+        UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD,
+    ];
 };

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiketContext.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiketContext.ts
@@ -3,8 +3,10 @@ import { useState } from 'react';
 import { useFelt } from '@navikt/familie-skjema';
 
 import { erUtdypendeVilkårsvurderingerGyldig } from './BosattIRiketValidering';
+import { useAppContext } from '../../../../../../../../context/AppContext';
 import type { IGrunnlagPerson } from '../../../../../../../../typer/person';
 import { PersonType } from '../../../../../../../../typer/person';
+import { ToggleNavn } from '../../../../../../../../typer/toggles';
 import type { Begrunnelse } from '../../../../../../../../typer/vedtak';
 import type { IVilkårResultat, Resultat } from '../../../../../../../../typer/vilkår';
 import {
@@ -90,10 +92,17 @@ export const useBosattIRiket = (lagretVilkår: IVilkårResultat, person: IGrunnl
         }),
     };
 
+    const { toggles } = useAppContext();
+    const bosattPåSvalbardToggleErPå = toggles[ToggleNavn.bosattSvalbard];
+
     const initielleMuligeUtdypendeVilkårsvurderinger =
         bestemMuligeUtdypendeVilkårsvurderingerIBosattIRiketVilkår(
             vilkårSkjemaMedLagredeVerdier.vurderesEtter,
             person
+        ).filter(
+            utdypendeVilkårsvurdering =>
+                bosattPåSvalbardToggleErPå ||
+                utdypendeVilkårsvurdering !== UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD
         );
 
     const [muligeUtdypendeVilkårsvurderinger, settMuligeUtdypendeVilkårsvurderinger] = useState<

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -10,6 +10,7 @@ export enum ToggleNavn {
     skalObfuskereData = 'familie-ks-sak.anonymiser-persondata',
     kanOppretteRevurderingMedAarsakIverksetteKaVedtak = 'familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak',
     skalAlltidViseAlleVedtaksperioder = 'familie-ks-sak-frontend.alltid-vis-alle-vedtaksperioder',
+    bosattSvalbard = 'familie-ks-sak.bosatt-svalbard',
 }
 
 export const alleTogglerAv = (): IToggles => {

--- a/src/frontend/typer/vilkår.ts
+++ b/src/frontend/typer/vilkår.ts
@@ -214,6 +214,7 @@ export const annenVurderingConfig: Record<AnnenVurderingType, IAnnenVurderingCon
 
 export enum UtdypendeVilkårsvurderingGenerell {
     VURDERING_ANNET_GRUNNLAG = 'VURDERING_ANNET_GRUNNLAG',
+    BOSATT_PÅ_SVALBARD = 'BOSATT_PÅ_SVALBARD',
     ADOPSJON = 'ADOPSJON',
     SOMMERFERIE = 'SOMMERFERIE',
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25335

Legger til muligheten til å velge bosatt på svalbard som utdypende vilkårsvurdering i bosatt i riket vilkåret.

<img width="601" alt="bosatt_på_svalbard" src="https://github.com/user-attachments/assets/0a298c48-a81a-4cae-a118-8ae58e76fb48" />
<img width="519" alt="bosatt på svalbard" src="https://github.com/user-attachments/assets/2f4656ab-60db-44f1-81d5-853132010834" />

BackendPR: https://github.com/navikt/familie-ks-sak/pull/1357
