### PR TITLE
Fikser styling på høyremeny toggle pil

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { ChevronLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
+import { ASurfaceDefault } from '@navikt/ds-tokens/dist/tokens';
 import { hentDataFraRessursMedFallback, RessursStatus } from '@navikt/familie-typer';
 
 import Behandlingskort from './Behandlingskort';
@@ -28,6 +29,7 @@ const ToggleVisningHøyremeny = styled(Button)<{ $åpenhøyremeny: boolean }>`
     padding: 0;
     border-radius: 50%;
     filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+    background-color: ${ASurfaceDefault};
 `;
 
 const HøyremenyContainer = styled.div`
@@ -63,13 +65,14 @@ const Høyremeny: React.FunctionComponent<Props> = ({ bruker }) => {
                     aria-label="Skjul høyremeny"
                     $åpenhøyremeny={åpenHøyremeny ? 1 : 0}
                     title={åpenHøyremeny ? 'Skjul høyremeny' : 'Vis høyremeny'}
-                >
-                    {åpenHøyremeny ? (
-                        <ChevronRightIcon aria-label="Skjul høyremeny" />
-                    ) : (
-                        <ChevronLeftIcon aria-label="Vis høyremeny" />
-                    )}
-                </ToggleVisningHøyremeny>
+                    icon={
+                        åpenHøyremeny ? (
+                            <ChevronRightIcon aria-label="Skjul høyremeny" />
+                        ) : (
+                            <ChevronLeftIcon aria-label="Vis høyremeny" />
+                        )
+                    }
+                />
                 {åpenHøyremeny && (
                     <>
                         <Behandlingskort åpenBehandling={åpenBehandling.data} />


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favrokort NAV-25736 Rar pil navigasjons ikon](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25736)

Høyrepil knappen hadde et rart utseende og var ikke konsistent med venstrepil eller design i ba.

### 👀 Screen shots
FØR
<img width="1150" height="859" alt="image" src="https://github.com/user-attachments/assets/a18a1738-4f66-4412-90d8-709fffd90244" />

ETTER
<img width="738" height="515" alt="image" src="https://github.com/user-attachments/assets/b6ddd5d6-315c-49ef-941c-b04954c74786" />
