### PR TITLE
Bytte fra familieikonvelger til eget ikonvelger komponent

### DIFF
--- a/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -3,9 +3,9 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import type { ISøkeresultat } from '@navikt/familie-header';
-import { ikoner, Søk } from '@navikt/familie-header';
+import { Søk } from '@navikt/familie-header';
 import { useHttp } from '@navikt/familie-http';
-import type { Ressurs } from '@navikt/familie-typer';
+import { kjønnType, type Ressurs } from '@navikt/familie-typer';
 import {
     byggFeiletRessurs,
     byggFunksjonellFeilRessurs,
@@ -17,9 +17,30 @@ import { idnr } from '@navikt/fnrvalidator';
 
 import OpprettFagsakModal from './OpprettFagsakModal';
 import { useAppContext } from '../../context/AppContext';
-import IkkeTilgang from '../../ikoner/IkkeTilgang';
-import type { IFagsakDeltager, ISøkParam } from '../../typer/fagsakdeltager';
+import {
+    FagsakDeltagerRolle,
+    type IFagsakDeltager,
+    type ISøkParam,
+} from '../../typer/fagsakdeltager';
+import { Adressebeskyttelsegradering } from '../../typer/person';
 import { obfuskerFagsakDeltager } from '../../utils/obfuskerData';
+import { PersonIkon } from '../PersonIkon';
+
+function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): React.ReactNode {
+    return (
+        <PersonIkon
+            kjønn={fagsakDeltager.kjønn || kjønnType.UKJENT}
+            erBarn={fagsakDeltager.rolle === FagsakDeltagerRolle.Barn}
+            erAdresseBeskyttet={
+                fagsakDeltager.adressebeskyttelseGradering !== undefined &&
+                fagsakDeltager.adressebeskyttelseGradering !== null &&
+                fagsakDeltager.adressebeskyttelseGradering !== Adressebeskyttelsegradering.UGRADERT
+            }
+            harTilgang={fagsakDeltager.harTilgang}
+            størrelse={'m'}
+        />
+    );
+}
 
 const FagsakDeltagerSøk: React.FC = () => {
     const { request } = useHttp();
@@ -87,11 +108,7 @@ const FagsakDeltagerSøk: React.FC = () => {
                           harTilgang: fagsakDeltager.harTilgang,
                           navn: fagsakDeltager.navn,
                           ident: fagsakDeltager.ident,
-                          ikon: fagsakDeltager.harTilgang ? (
-                              ikoner[`${fagsakDeltager.rolle}_${fagsakDeltager.kjønn}`]
-                          ) : (
-                              <IkkeTilgang height={30} width={30} />
-                          ),
+                          ikon: mapFagsakDeltagerTilIkon(fagsakDeltager),
                       };
                   }),
               }

--- a/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -22,8 +22,8 @@ import {
     type IFagsakDeltager,
     type ISøkParam,
 } from '../../typer/fagsakdeltager';
-import { Adressebeskyttelsegradering } from '../../typer/person';
 import { obfuskerFagsakDeltager } from '../../utils/obfuskerData';
+import { erAdresseBeskyttet } from '../../utils/validators';
 import { PersonIkon } from '../PersonIkon';
 
 function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): React.ReactNode {
@@ -31,11 +31,7 @@ function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): React.ReactN
         <PersonIkon
             kjønn={fagsakDeltager.kjønn || kjønnType.UKJENT}
             erBarn={fagsakDeltager.rolle === FagsakDeltagerRolle.Barn}
-            erAdresseBeskyttet={
-                fagsakDeltager.adressebeskyttelseGradering !== undefined &&
-                fagsakDeltager.adressebeskyttelseGradering !== null &&
-                fagsakDeltager.adressebeskyttelseGradering !== Adressebeskyttelsegradering.UGRADERT
-            }
+            erAdresseBeskyttet={erAdresseBeskyttet(fagsakDeltager.adressebeskyttelseGradering)}
             harTilgang={fagsakDeltager.harTilgang}
             størrelse={'m'}
         />

--- a/src/frontend/komponenter/PersonIkon.tsx
+++ b/src/frontend/komponenter/PersonIkon.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import {
+    GuttIkon,
+    JenteIkon,
+    KvinneIkon,
+    MannIkon,
+    NøytralPersonIkon,
+} from '@navikt/familie-ikoner';
+import { kjønnType } from '@navikt/familie-typer';
+
+import IkkeTilgang from '../ikoner/IkkeTilgang';
+
+const StyledJenteIkon = styled(JenteIkon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet) {
+            return `
+            g {
+                fill: var(--a-orange-600);
+            }
+        `;
+        } else {
+            return `
+                g {
+                    fill: var(--a-purple-400);
+                }
+        `;
+        }
+    }};
+`;
+
+const StyledKvinneIkon = styled(KvinneIkon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet) {
+            return `
+            g {
+                fill: var(--a-orange-600);
+            }
+        `;
+        } else {
+            return `
+                g {
+                    fill: var(--a-purple-400);
+                }
+        `;
+        }
+    }};
+`;
+
+const StyledGuttIkon = styled(GuttIkon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet) {
+            return `
+            g {
+                fill: var(--a-orange-600);
+            }
+        `;
+        } else {
+            return `
+                g {
+                    fill: var(--a-blue-400);
+                }
+        `;
+        }
+    }};
+`;
+
+const StyledMannIkon = styled(MannIkon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet) {
+            return `
+            g {
+                fill: var(--a-orange-600);
+            }
+        `;
+        } else {
+            return `
+                g {
+                    fill: var(--a-blue-400);
+                }
+        `;
+        }
+    }};
+`;
+
+const StyledNøytralIkon = styled(NøytralPersonIkon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet) {
+            return `
+                path:first-of-type {
+                    fill: var(--a-orange-600);
+                }
+            `;
+        }
+    }};
+`;
+
+interface PersonIkonProps {
+    kjønn: kjønnType;
+    erBarn: boolean;
+    størrelse?: 's' | 'm';
+    erAdresseBeskyttet?: boolean;
+    harTilgang?: boolean;
+}
+
+export const PersonIkon = ({
+    kjønn,
+    erBarn,
+    størrelse = 's',
+    erAdresseBeskyttet = false,
+    harTilgang = true,
+}: PersonIkonProps) => {
+    if (!harTilgang) {
+        return <IkkeTilgang height={30} width={30} />;
+    }
+
+    const ikonProps = størrelse === 's' ? { height: 24, width: 24 } : { height: 32, width: 32 };
+    if (kjønn === kjønnType.KVINNE) {
+        return erBarn ? (
+            <StyledJenteIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
+        ) : (
+            <StyledKvinneIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
+        );
+    }
+    if (kjønn === kjønnType.MANN) {
+        return erBarn ? (
+            <StyledGuttIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
+        ) : (
+            <StyledMannIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
+        );
+    }
+
+    return <StyledNøytralIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />;
+};

--- a/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -3,12 +3,18 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import { BodyShort, CopyButton, Heading, HStack } from '@navikt/ds-react';
-import { FamilieIkonVelger } from '@navikt/familie-ikoner';
+import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
-import type { IGrunnlagPerson } from '../../typer/person';
-import { personTypeMap } from '../../typer/person';
-import { hentAlder, formaterIdent } from '../../utils/formatter';
+import { useFagsakContext } from '../../context/fagsak/FagsakContext';
+import {
+    Adressebeskyttelsegradering,
+    type IGrunnlagPerson,
+    type IPersonInfo,
+    personTypeMap,
+} from '../../typer/person';
+import { formaterIdent, hentAlder } from '../../utils/formatter';
 import DødsfallTag from '../DødsfallTag';
+import { PersonIkon } from '../PersonIkon';
 
 interface IProps {
     person: IGrunnlagPerson;
@@ -21,6 +27,33 @@ const HeadingUtenOverflow = styled(Heading)`
     overflow: hidden;
     text-overflow: ellipsis;
 `;
+
+const hentAdresseBeskyttelseGradering = (
+    brukerRessurs: Ressurs<IPersonInfo>,
+    personIdent: string
+): boolean | undefined => {
+    if (brukerRessurs.status === RessursStatus.SUKSESS) {
+        const bruker = brukerRessurs.data;
+        const forelderBarnRelasjoner = brukerRessurs.data.forelderBarnRelasjon;
+        const forelderBarnRelasjon = forelderBarnRelasjoner.find(
+            rel => rel.personIdent === personIdent
+        );
+
+        if (bruker.personIdent === personIdent) {
+            return (
+                bruker.adressebeskyttelseGradering !== null &&
+                bruker.adressebeskyttelseGradering !== Adressebeskyttelsegradering.UGRADERT
+            );
+        } else if (forelderBarnRelasjon?.personIdent === personIdent) {
+            return (
+                forelderBarnRelasjon.adressebeskyttelseGradering !== undefined &&
+                forelderBarnRelasjon.adressebeskyttelseGradering !== null &&
+                forelderBarnRelasjon.adressebeskyttelseGradering !==
+                    Adressebeskyttelsegradering.UGRADERT
+            );
+        }
+    }
+};
 
 const Skillelinje: React.FC<{ erHeading?: boolean }> = ({ erHeading = false }) => {
     if (erHeading) {
@@ -37,11 +70,19 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({ person, somOverskr
     const alder = hentAlder(person.fødselsdato);
     const navnOgAlder = `${person.navn} (${alder} år)`;
     const formatertIdent = formaterIdent(person.personIdent);
+    const { bruker: brukerRessurs } = useFagsakContext();
+
+    const erAdresseBeskyttet = hentAdresseBeskyttelseGradering(brukerRessurs, person.personIdent);
 
     if (somOverskrift) {
         return (
             <HStack gap="6" wrap={false} align="center">
-                <FamilieIkonVelger className={'familie-ikon'} alder={alder} kjønn={person.kjønn} />
+                <PersonIkon
+                    erBarn={alder < 18}
+                    kjønn={person.kjønn}
+                    størrelse={'m'}
+                    erAdresseBeskyttet={erAdresseBeskyttet}
+                />
                 <HStack gap="4" align="center" wrap={false}>
                     <HeadingUtenOverflow level="2" size="medium" title={navnOgAlder}>
                         {navnOgAlder}
@@ -67,12 +108,11 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({ person, somOverskr
 
     return (
         <HStack gap="2" align="center" wrap={false}>
-            <FamilieIkonVelger
-                className={'familie-ikon--for-normaltekst'}
-                width={24}
-                height={24}
-                alder={alder}
+            <PersonIkon
+                erBarn={alder < 18}
                 kjønn={person.kjønn}
+                størrelse={'m'}
+                erAdresseBeskyttet={erAdresseBeskyttet}
             />
             <BodyShort className={'navn'} title={navnOgAlder}>
                 {navnOgAlder}

--- a/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -6,13 +6,9 @@ import { BodyShort, CopyButton, Heading, HStack } from '@navikt/ds-react';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useFagsakContext } from '../../context/fagsak/FagsakContext';
-import {
-    Adressebeskyttelsegradering,
-    type IGrunnlagPerson,
-    type IPersonInfo,
-    personTypeMap,
-} from '../../typer/person';
+import { type IGrunnlagPerson, type IPersonInfo, personTypeMap } from '../../typer/person';
 import { formaterIdent, hentAlder } from '../../utils/formatter';
+import { erAdresseBeskyttet } from '../../utils/validators';
 import DødsfallTag from '../DødsfallTag';
 import { PersonIkon } from '../PersonIkon';
 
@@ -40,17 +36,9 @@ const hentAdresseBeskyttelseGradering = (
         );
 
         if (bruker.personIdent === personIdent) {
-            return (
-                bruker.adressebeskyttelseGradering !== null &&
-                bruker.adressebeskyttelseGradering !== Adressebeskyttelsegradering.UGRADERT
-            );
+            return erAdresseBeskyttet(bruker.adressebeskyttelseGradering);
         } else if (forelderBarnRelasjon?.personIdent === personIdent) {
-            return (
-                forelderBarnRelasjon.adressebeskyttelseGradering !== undefined &&
-                forelderBarnRelasjon.adressebeskyttelseGradering !== null &&
-                forelderBarnRelasjon.adressebeskyttelseGradering !==
-                    Adressebeskyttelsegradering.UGRADERT
-            );
+            return erAdresseBeskyttet(forelderBarnRelasjon.adressebeskyttelseGradering);
         }
     }
 };

--- a/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
@@ -7,8 +7,9 @@ import Visittkort from '@navikt/familie-visittkort';
 import Behandlingsmeny from './Behandlingsmeny/Behandlingsmeny';
 import { useAppContext } from '../../../context/AppContext';
 import DødsfallTag from '../../../komponenter/DødsfallTag';
+import { PersonIkon } from '../../../komponenter/PersonIkon';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
-import type { IPersonInfo } from '../../../typer/person';
+import { Adressebeskyttelsegradering, type IPersonInfo } from '../../../typer/person';
 import { formaterIdent, hentAlder } from '../../../utils/formatter';
 
 interface IProps {
@@ -26,6 +27,18 @@ const Personlinje: React.FC<IProps> = ({ bruker, minimalFagsak }) => {
             kjønn={bruker?.kjønn ?? kjønnType.UKJENT}
             dempetKantlinje
             padding
+            ikon={
+                <PersonIkon
+                    kjønn={bruker?.kjønn ?? kjønnType.UKJENT}
+                    erBarn={hentAlder(bruker?.fødselsdato ?? '') < 18}
+                    erAdresseBeskyttet={
+                        bruker?.adressebeskyttelseGradering !== undefined &&
+                        bruker?.adressebeskyttelseGradering !== null &&
+                        bruker?.adressebeskyttelseGradering !== Adressebeskyttelsegradering.UGRADERT
+                    }
+                    harTilgang={bruker?.harTilgang}
+                />
+            }
         >
             <div>|</div>
             <BodyShort>{`Kommunenr: ${bruker?.kommunenummer ?? 'ukjent'}`}</BodyShort>

--- a/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
@@ -9,8 +9,9 @@ import { useAppContext } from '../../../context/AppContext';
 import DødsfallTag from '../../../komponenter/DødsfallTag';
 import { PersonIkon } from '../../../komponenter/PersonIkon';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
-import { Adressebeskyttelsegradering, type IPersonInfo } from '../../../typer/person';
+import { type IPersonInfo } from '../../../typer/person';
 import { formaterIdent, hentAlder } from '../../../utils/formatter';
+import { erAdresseBeskyttet } from '../../../utils/validators';
 
 interface IProps {
     bruker?: IPersonInfo;
@@ -31,11 +32,7 @@ const Personlinje: React.FC<IProps> = ({ bruker, minimalFagsak }) => {
                 <PersonIkon
                     kjønn={bruker?.kjønn ?? kjønnType.UKJENT}
                     erBarn={hentAlder(bruker?.fødselsdato ?? '') < 18}
-                    erAdresseBeskyttet={
-                        bruker?.adressebeskyttelseGradering !== undefined &&
-                        bruker?.adressebeskyttelseGradering !== null &&
-                        bruker?.adressebeskyttelseGradering !== Adressebeskyttelsegradering.UGRADERT
-                    }
+                    erAdresseBeskyttet={erAdresseBeskyttet(bruker?.adressebeskyttelseGradering)}
                     harTilgang={bruker?.harTilgang}
                 />
             }

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -18,12 +18,12 @@ import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { FagsakStatus } from '../../../typer/fagsak';
 import { Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
 import {
-    hentDagensDato,
     dateTilFormatertString,
     Datoformat,
+    hentDagensDato,
     isoStringTilDate,
+    periodeOverlapperMedValgtDato,
 } from '../../../utils/dato';
-import { periodeOverlapperMedValgtDato } from '../../../utils/dato';
 import { hentAktivBehandlingPåMinimalFagsak } from '../../../utils/fagsak';
 
 interface IProps {

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -7,8 +7,7 @@ import { idnr } from '@navikt/fnrvalidator';
 import { hentDagensDato, type IIsoDatoPeriode, isoStringTilDate } from './dato';
 import { validerPeriodePåBarnetsAlder } from '../sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering';
 import { erBegrunnelsePåkrevd } from '../sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema';
-import type { IGrunnlagPerson } from '../typer/person';
-import { PersonType } from '../typer/person';
+import { Adressebeskyttelsegradering, type IGrunnlagPerson, PersonType } from '../typer/person';
 import { IEndretUtbetalingAndelÅrsak } from '../typer/utbetalingAndel';
 import type { Begrunnelse } from '../typer/vedtak';
 import type { UtdypendeVilkårsvurdering } from '../typer/vilkår';
@@ -233,4 +232,14 @@ export const erBegrunnelseGyldig = (
     } else {
         return ok(felt);
     }
+};
+
+export const erAdresseBeskyttet = (
+    adresseBeskyttelsesGradering: Adressebeskyttelsegradering | undefined | null
+) => {
+    return (
+        adresseBeskyttelsesGradering !== undefined &&
+        adresseBeskyttelsesGradering !== null &&
+        adresseBeskyttelsesGradering !== Adressebeskyttelsegradering.UGRADERT
+    );
 };


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25191

### 💰 Hva forsøker du å løse i denne PR'en
- Gå bort fra FamilieIkonVelger til eget ikon-komponent. Oppdatert for bruk i personsøk, personlinje, saksoversikt utbetaling og vilkårsbehandling.
- Oppdaterer noen farger på kvinne-ikoner og for skjerming.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

### 👀 Screen shots

Alle ikon-variantene
<img width="408" height="67" alt="image" src="https://github.com/user-attachments/assets/a64b55a8-84cc-480e-9127-dd41b083cec2" />
Diverse usecase
<img width="366" height="319" alt="image" src="https://github.com/user-attachments/assets/74ec9306-9acf-4525-9bf2-db37e2c2203d" />
<img width="574" height="539" alt="image" src="https://github.com/user-attachments/assets/b894a8b2-da3d-4948-b05a-0c4fc522134f" />

Ikoner for skjerming virker ikke i søk pga. manglende informasjon i søket (Det er laget eget Favro-kort for dette): 
<img width="801" height="421" alt="image" src="https://github.com/user-attachments/assets/3f2cc098-b9f1-43a9-8cde-0182a29b00e5" />
