### PR TITLE
Fjern rolle-tekst i fagsakdeltaker søk

### DIFF
--- a/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -11,7 +11,6 @@ import {
     byggFunksjonellFeilRessurs,
     byggHenterRessurs,
     byggTomRessurs,
-    kjønnType,
     RessursStatus,
 } from '@navikt/familie-typer';
 import { idnr } from '@navikt/fnrvalidator';
@@ -20,7 +19,6 @@ import OpprettFagsakModal from './OpprettFagsakModal';
 import { useAppContext } from '../../context/AppContext';
 import IkkeTilgang from '../../ikoner/IkkeTilgang';
 import type { IFagsakDeltager, ISøkParam } from '../../typer/fagsakdeltager';
-import { fagsakdeltagerRoller } from '../../typer/fagsakdeltager';
 import { obfuskerFagsakDeltager } from '../../utils/obfuskerData';
 
 const FagsakDeltagerSøk: React.FC = () => {
@@ -94,9 +92,6 @@ const FagsakDeltagerSøk: React.FC = () => {
                           ) : (
                               <IkkeTilgang height={30} width={30} />
                           ),
-                          rolle: fagsakdeltagerRoller[fagsakDeltager.rolle][
-                              fagsakDeltager.kjønn ?? kjønnType.UKJENT
-                          ],
                       };
                   }),
               }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fjerner rolle-tekst i fagsakdeltaker søke resultat liste.

De nye ikonene viser viser for det meste fagsaktype, kjønn og alder som er veldig beskrivende som vi tenker er nok informasjon.

### 👀 Screen shots
FØR
<img width="661" height="340" alt="image" src="https://github.com/user-attachments/assets/c8228f0e-e3dc-45a3-9297-3d9d9d82f142" />

<img width="690" height="228" alt="image" src="https://github.com/user-attachments/assets/a9bb5c58-48e1-4c33-a9a0-d52951d12393" />

ETTER
<img width="633" height="243" alt="image" src="https://github.com/user-attachments/assets/a482016a-42f2-489c-b614-aaa30173bbde" />
<img width="652" height="212" alt="image" src="https://github.com/user-attachments/assets/f4f17ac2-44c6-431d-bc4a-72c762818be3" />
