### PR TITLE
Fjerner gruppering av minor og patch 

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,14 +15,8 @@ updates:
     registries: "*"
     ignore:
       - dependency-name: "*"
-        update-types: [ "version-update:semver-patch" ]
+        update-types: ["version-update:semver-patch"]
     groups:
-      minor-and-patch:
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'
       react:
         patterns:
           - "react"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fjerner gruppering av minor og patch dependabot PRer slik at vi kan merge de separat. Dette er nyttig når noen av dependenciene feiler av ukjent grunn. Nå feiler oppgraderingen av webpack av ukjent grunn og i mellomtiden ønsker jeg å kunne bumpe alle de andre dependenciene. Dette har skjedd flere ganger, nok til at jeg nå ønsker å fjerne denne grupperingen. Configen blir da lik som på alle de andre frontend-appene våre.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingenting å fremheve

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Ingen visuelle endringer
