### PR TITLE
håndter udefinerte personer i personlinje

### DIFF
--- a/src/frontend/komponenter/PersonIkon.tsx
+++ b/src/frontend/komponenter/PersonIkon.tsx
@@ -15,16 +15,16 @@ import styles from './PersonIkon.module.css';
 import IkkeTilgang from '../ikoner/IkkeTilgang';
 
 interface PersonIkonProps {
-    kjønn: kjønnType;
-    erBarn: boolean;
+    kjønn?: kjønnType;
+    erBarn?: boolean;
     størrelse?: 's' | 'm';
     erAdresseBeskyttet?: boolean;
     harTilgang?: boolean;
 }
 
 export const PersonIkon = ({
-    kjønn,
-    erBarn,
+    kjønn = kjønnType.UKJENT,
+    erBarn = false,
     størrelse = 's',
     erAdresseBeskyttet = false,
     harTilgang = true,

--- a/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
@@ -25,6 +25,21 @@ const Divider = () => {
 };
 
 const Personlinje: React.FC<IProps> = ({ bruker }) => {
+    if (bruker === undefined) {
+        return (
+            <InnholdContainer>
+                <HStack align="center" gap="3 4">
+                    <HStack align="center" gap="3 4">
+                        <PersonIkon kjønn={kjønnType.UKJENT} erBarn={false} />
+                        <Divider />
+                        <HStack align="center" gap="1">
+                            Personen er ikke identifisert
+                        </HStack>
+                    </HStack>
+                </HStack>
+            </InnholdContainer>
+        );
+    }
     return (
         <InnholdContainer>
             <HStack align="center" gap="3 4">


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Under ManuellJournalføring bruker personlinje person fra IDataForManuellJournalføring som har person?: IPersonInfo. Dette kan skape en udefinert person så vi legger til mer forklarende tekst. 

Samtidig gjør jeg feltene for PersonIkon til optional slik at det blir lettere for dette caset, og alt blir håndtert uansett til ukjent ikon.

Screenshot for teksts/design er bekreftet av Anna Herborg Førland

### 👀 Screen shots
FØR
<img width="741" height="190" alt="image" src="https://github.com/user-attachments/assets/82b8ef36-4507-49db-a715-c684923ad74b" />

ETTER
<img width="1007" height="267" alt="image" src="https://github.com/user-attachments/assets/4cd3f7c3-1853-49c7-9585-f5c61af02007" />

