### PR TITLE
Legg til oppholdsadresse i registeropplysninger

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
@@ -14,8 +14,10 @@ import { Alert, Detail, Heading } from '@navikt/ds-react';
 import { AFontWeightRegular, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 
 import RegisteropplysningerTabell from './RegisteropplysningerTabell';
+import { useAppContext } from '../../../../../../context/AppContext';
 import type { IRestRegisterhistorikk } from '../../../../../../typer/person';
 import { Registeropplysning } from '../../../../../../typer/registeropplysning';
+import { ToggleNavn } from '../../../../../../typer/toggles';
 import { Datoformat, isoStringTilFormatertString } from '../../../../../../utils/dato';
 
 const Container = styled.div`
@@ -35,6 +37,7 @@ const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({
     opplysninger,
     fødselsdato,
 }) => {
+    const { toggles } = useAppContext();
     const manglerRegisteropplysninger = opplysninger.statsborgerskap.length === 0;
 
     const personErDød = opplysninger.dødsboadresse.length > 0;
@@ -118,11 +121,19 @@ const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({
                         ikon={<HouseIcon fontSize={'1.5rem'} title="Hjem-ikon" focusable="false" />}
                         historikk={opplysninger.bostedsadresse}
                     />
-                    <RegisteropplysningerTabell
-                        opplysningstype={Registeropplysning.OPPHOLDSADRESSE}
-                        ikon={<HouseIcon fontSize={'1.5rem'} title="Hjem-ikon" focusable="false" />}
-                        historikk={opplysninger.oppholdsadresse}
-                    />
+                    {toggles[ToggleNavn.skalViseOppholdsadresse] && (
+                        <RegisteropplysningerTabell
+                            opplysningstype={Registeropplysning.OPPHOLDSADRESSE}
+                            ikon={
+                                <HouseIcon
+                                    fontSize={'1.5rem'}
+                                    title="Hjem-ikon"
+                                    focusable="false"
+                                />
+                            }
+                            historikk={opplysninger.oppholdsadresse}
+                        />
+                    )}
                 </Container>
             )}
         </>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
@@ -118,6 +118,11 @@ const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({
                         ikon={<HouseIcon fontSize={'1.5rem'} title="Hjem-ikon" focusable="false" />}
                         historikk={opplysninger.bostedsadresse}
                     />
+                    <RegisteropplysningerTabell
+                        opplysningstype={Registeropplysning.OPPHOLDSADRESSE}
+                        ikon={<HouseIcon fontSize={'1.5rem'} title="Hjem-ikon" focusable="false" />}
+                        historikk={opplysninger.oppholdsadresse}
+                    />
                 </Container>
             )}
         </>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.tsx
@@ -80,7 +80,8 @@ const RegisteropplysningerTabell: React.FC<IRegisteropplysningerTabellProps> = (
     const skalVæreEkspanderbar =
         !manglerOpplysninger &&
         historikk.length > GRENSE_FOR_EKSPANDERBAR_HISTORIKK &&
-        opplysningstype === Registeropplysning.BOSTEDSADRESSE;
+        (opplysningstype === Registeropplysning.BOSTEDSADRESSE ||
+            opplysningstype === Registeropplysning.OPPHOLDSADRESSE);
 
     const synligHistorikk =
         !skalVæreEkspanderbar || erEkspandert

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -89,6 +89,7 @@ export interface IRestRegisterhistorikk {
     oppholdstillatelse: IRestRegisteropplysning[];
     statsborgerskap: IRestRegisteropplysning[];
     bostedsadresse: IRestRegisteropplysning[];
+    oppholdsadresse: IRestRegisteropplysning[];
     dødsboadresse: IRestRegisteropplysning[];
 }
 

--- a/src/frontend/typer/registeropplysning.ts
+++ b/src/frontend/typer/registeropplysning.ts
@@ -3,6 +3,7 @@ export enum Registeropplysning {
     OPPHOLD = 'OPPHOLD',
     STATSBORGERSKAP = 'STATSBORGERSKAP',
     BOSTEDSADRESSE = 'BOSTEDSADRESSE',
+    OPPHOLDSADRESSE = 'OPPHOLDSADRESSE',
     DØDSBOADRESSE = 'DØDSBOADRESSE',
     FØDSELSDATO = 'FØDSELSDATO',
 }
@@ -12,6 +13,7 @@ export const registeropplysning: Record<Registeropplysning, string> = {
     OPPHOLD: 'Oppholdstillatelse',
     STATSBORGERSKAP: 'Statsborgerskap',
     BOSTEDSADRESSE: 'Adresse',
+    OPPHOLDSADRESSE: 'Oppholdsadresse',
     DØDSBOADRESSE: 'Dødsboadresse',
     FØDSELSDATO: 'Fødselsdato',
 };

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -12,6 +12,7 @@ export enum ToggleNavn {
     skalAlltidViseAlleVedtaksperioder = 'familie-ks-sak-frontend.alltid-vis-alle-vedtaksperioder',
     bosattSvalbard = 'familie-ks-sak.bosatt-svalbard',
     brukNyHenleggModal = 'familie-ks-sak.bruk-ny-henlegg-modal',
+    skalViseOppholdsadresse = 'familie-ks-sak.skal-vise-oppholdsadresse',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-26037

Samme som i [ba-sak-frontend](https://github.com/navikt/familie-ba-sak-frontend/pull/3982)

Henter oppholdsadresse per person sammen med behandlingen, og viser i registeropplysningene

### 👀 Screen shots
<img width="517" height="194" alt="image" src="https://github.com/user-attachments/assets/6dfd48f7-089c-474b-804b-ec3732faa86e" />
