### PR TITLE
NAV-26033: Tar i bruk ny PDF modal for tilbakekreving brev

### DIFF
--- a/src/frontend/api/opprettForhåndsvisbarTilbakekrevingVarselbrev.ts
+++ b/src/frontend/api/opprettForhåndsvisbarTilbakekrevingVarselbrev.ts
@@ -1,0 +1,21 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import { RessursResolver } from '../utils/ressursResolver';
+
+export interface OpprettForhåndsvisTilbakekrevingVarselbrevRequest {
+    fritekst: string;
+}
+
+export async function opprettForhåndsvisbarTilbakekrevingVarselbrev(
+    request: FamilieRequest,
+    behandlingId: number,
+    payload: OpprettForhåndsvisTilbakekrevingVarselbrevRequest
+) {
+    const ressurs = await request<OpprettForhåndsvisTilbakekrevingVarselbrevRequest, string>({
+        method: 'POST',
+        url: `/familie-ks-sak/api/tilbakekreving/${behandlingId}/forhaandsvis-tilbakekreving-varselbrev`,
+        data: { fritekst: payload.fritekst },
+        påvirkerSystemLaster: false,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/hooks/useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf.ts
+++ b/src/frontend/hooks/useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf.ts
@@ -1,0 +1,37 @@
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import {
+    opprettForhåndsvisbarTilbakekrevingVarselbrev,
+    type OpprettForhåndsvisTilbakekrevingVarselbrevRequest,
+} from '../api/opprettForhåndsvisbarTilbakekrevingVarselbrev';
+import { opprettPdfBlob } from '../utils/blob';
+
+interface MutationParameters {
+    behandlingId: number;
+    payload: OpprettForhåndsvisTilbakekrevingVarselbrevRequest;
+}
+
+type Options = Omit<UseMutationOptions<Blob, DefaultError, MutationParameters>, 'mutationFn'>;
+
+export function useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf(options: Options) {
+    const { request } = useHttp();
+    return useMutation({
+        mutationFn: async ({ behandlingId, payload }: MutationParameters) => {
+            try {
+                const bytes = await opprettForhåndsvisbarTilbakekrevingVarselbrev(
+                    request,
+                    behandlingId,
+                    payload
+                );
+                const blob = opprettPdfBlob(bytes);
+                return Promise.resolve(blob);
+            } catch (e) {
+                const error = e instanceof Error ? e : Error('En ukjent feil oppstod.');
+                return Promise.reject(error);
+            }
+        },
+        ...options,
+    });
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Simulering/Simulering.tsx
@@ -11,11 +11,14 @@ import { useSimuleringContext } from './SimuleringContext';
 import SimuleringPanel from './SimuleringPanel';
 import SimuleringTabell from './SimuleringTabell';
 import TilbakekrevingSkjema from './TilbakekrevingSkjema';
+import TilbakekrevingSkjemaGammel from './TilbakekrevingSkjemaGammel';
+import { useAppContext } from '../../../../../context/AppContext';
 import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
 import Skjemasteg from '../../../../../komponenter/Skjemasteg/Skjemasteg';
 import type { IBehandling } from '../../../../../typer/behandling';
 import { BehandlingResultat, BehandlingSteg } from '../../../../../typer/behandling';
 import type { ITilbakekreving } from '../../../../../typer/simulering';
+import { ToggleNavn } from '../../../../../typer/toggles';
 import { hentSøkersMålform } from '../../../../../utils/behandling';
 import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
 
@@ -28,6 +31,7 @@ const StyledAlert = styled(Alert)`
 `;
 
 const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling }) => {
+    const { toggles } = useAppContext();
     const { fagsakId } = useSakOgBehandlingParams();
     const navigate = useNavigate();
     const {
@@ -90,12 +94,18 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                     <>
                         <SimuleringPanel simulering={simuleringsresultat.data} />
                         <SimuleringTabell simulering={simuleringsresultat.data} />
-                        {erFeilutbetaling && (
-                            <TilbakekrevingSkjema
-                                søkerMålform={hentSøkersMålform(åpenBehandling)}
-                                harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
-                            />
-                        )}
+                        {erFeilutbetaling &&
+                            (toggles[ToggleNavn.brukNyPdfModal] ? (
+                                <TilbakekrevingSkjema
+                                    søkerMålform={hentSøkersMålform(åpenBehandling)}
+                                    harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
+                                />
+                            ) : (
+                                <TilbakekrevingSkjemaGammel
+                                    søkerMålform={hentSøkersMålform(åpenBehandling)}
+                                    harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
+                                />
+                            ))}
                     </>
                 )
             ) : (


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26033

Tar i bruk den nye PDF visning modalen for tilbakekrevingsbrev.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Knapp for å forhåndsvise brev er endret litt, ellers skal det se likt ut.
<img width="184" height="69" alt="image" src="https://github.com/user-attachments/assets/4b7e126b-3f8b-4fd2-ba9b-3ab4170560a2" />