### PR TITLE
fikser console feil på nested p tag

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/BarnMedOpplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/BarnMedOpplysninger.tsx
@@ -22,6 +22,7 @@ const CheckboxOgSlettknapp = styled.div`
 
 const StyledCheckbox = styled(Checkbox)`
     margin-left: 1rem;
+
     > label {
         width: 100%;
     }
@@ -57,12 +58,9 @@ const BarnMedOpplysninger: React.FunctionComponent<IProps> = ({ barn }) => {
             {erLesevisning ? (
                 barn.merket ? (
                     <BodyShort
+                        title={navnOgIdentTekst}
                         className={classNames('skjemaelement', 'lese-felt')}
-                        children={
-                            <LabelContent>
-                                <LabelTekst title={navnOgIdentTekst}>{navnOgIdentTekst}</LabelTekst>
-                            </LabelContent>
-                        }
+                        children={navnOgIdentTekst}
                     />
                 ) : null
             ) : (


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Jeg kom over noen feil som dukket opp i console og tenkte jeg bare kunne fikse det raskt. Man kan ikke ha p tag eller div tag inni en p tag, jeg fjernet all styling og syns at wrapping ble mye bedre enn det det var.
Her er feilmeldingen jeg prøver å løse.
<img width="1161" height="883" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/1dfed5f8-f27e-493f-bbb7-421bcb1c4013" />

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Jeg vet ikke om det var noen spesifikk grunn til å ikke vill ha wrapping på det. Ser ut som at intensjonen var å ellipse overflow, men det så ikke helt ut til å ha virket ordentlig heller.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

### 👀 Screen shots
FØR
<img width="683" height="550" alt="Kontantstette" src="https://github.com/user-attachments/assets/70746f29-ba53-45fa-9cc9-10da5f7b5296" />
På veldig smal skjerm ser vi at teksten forblir:
<img width="194" height="181" alt="image" src="https://github.com/user-attachments/assets/0b6c77ff-cd94-4098-94bc-dea703742635" />

ETTER
Vanlig side ingen visuelle endringer
<img width="418" height="452" alt="Kontantstette" src="https://github.com/user-attachments/assets/eeb19d57-dd96-4d62-a8b6-8d75c9696d4c" />
På veldig liten skjerm, får vi nå wrapping.
<img width="238" height="278" alt="Registrer" src="https://github.com/user-attachments/assets/d351bf8b-5016-4171-91b4-f0f0d0cc7262" />
