### PR TITLE
NAV-26033: Tar i bruk lokal modal state da det bedre håndterer laster, error, og data tilstanden på samme måte som tidligere.

### DIFF
--- a/src/frontend/Container.tsx
+++ b/src/frontend/Container.tsx
@@ -9,7 +9,6 @@ import { HeaderMedSøk } from './komponenter/HeaderMedSøk/HeaderMedSøk';
 import AppInfoModal from './komponenter/Modal/AppInfoModal';
 import { FeilmeldingModal } from './komponenter/Modal/FeilmeldingModal';
 import UgyldigSesjon from './komponenter/Modal/SesjonUtløpt';
-import { ForhåndsvisPdfModal } from './komponenter/PdfVisningModal/ForhåndsvisPdfModal';
 import SystemetLaster from './komponenter/SystemetLaster/SystemetLaster';
 import { TidslinjeProvider } from './komponenter/Tidslinje/TidslinjeContext';
 import Toasts from './komponenter/Toast/Toasts';
@@ -49,7 +48,6 @@ const Container: React.FC = () => {
 
                         <Main $systemetLaster={systemetLaster()}>
                             <FeilmeldingModal />
-                            <ForhåndsvisPdfModal />
                             <HeaderMedSøk
                                 brukerNavn={innloggetSaksbehandler?.displayName}
                                 brukerEnhet={innloggetSaksbehandler?.enhet}

--- a/src/frontend/hooks/useOpprettForhåndsvisbarBehandlingBrevPdf.ts
+++ b/src/frontend/hooks/useOpprettForhåndsvisbarBehandlingBrevPdf.ts
@@ -13,7 +13,7 @@ interface MutationParameters {
 
 type Options = Omit<UseMutationOptions<Blob, DefaultError, MutationParameters>, 'mutationFn'>;
 
-export function useOpprettForhåndsvisbarBehandlingBrevPdf(options: Options) {
+export function useOpprettForhåndsvisbarBehandlingBrevPdf(options?: Options) {
     const { request } = useHttp();
     return useMutation({
         mutationFn: async ({ behandlingId, payload }: MutationParameters) => {

--- a/src/frontend/hooks/useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf.ts
+++ b/src/frontend/hooks/useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf.ts
@@ -15,7 +15,7 @@ interface MutationParameters {
 
 type Options = Omit<UseMutationOptions<Blob, DefaultError, MutationParameters>, 'mutationFn'>;
 
-export function useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf(options: Options) {
+export function useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf(options?: Options) {
     const { request } = useHttp();
     return useMutation({
         mutationFn: async ({ behandlingId, payload }: MutationParameters) => {

--- a/src/frontend/komponenter/PdfVisningModal/ForhåndsvisPdfModal.tsx
+++ b/src/frontend/komponenter/PdfVisningModal/ForhåndsvisPdfModal.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, Modal } from '@navikt/ds-react';
-
-import { ModalType } from '../../context/ModalContext';
-import { useModal } from '../../hooks/useModal';
+import { Alert, Heading, HStack, Loader, Modal, VStack } from '@navikt/ds-react';
 
 const StyledModal = styled(Modal)`
     width: 80%;
@@ -19,35 +16,63 @@ const StyledModal = styled(Modal)`
     }
 `;
 
-export function ForhåndsvisPdfModal() {
-    const { args, erModalÅpen, lukkModal, tittel, bredde } = useModal(ModalType.FORHÅNDSVIS_PDF);
+interface Props {
+    pdf?: Blob;
+    laster?: boolean;
+    error?: Error | null;
+    lukk: () => void;
+}
+
+export function ForhåndsvisPdfModal({ pdf, laster, error, lukk }: Props) {
+    if (laster) {
+        return (
+            <StyledModal
+                open={true}
+                onClose={lukk}
+                header={{ heading: 'Forhåndsvis PDF', closeButton: true }}
+                width={'1000rem'}
+                portal={true}
+            >
+                <HStack justify={'center'} height={'100%'} align={'center'}>
+                    <VStack align={'center'}>
+                        <Heading size={'small'} level={'2'}>
+                            Innhenter dokument
+                        </Heading>
+                        <Loader size={'xlarge'} title={'Innhenter dokument'} />
+                    </VStack>
+                </HStack>
+            </StyledModal>
+        );
+    }
+
+    if (error || pdf === undefined) {
+        return (
+            <StyledModal
+                open={true}
+                onClose={lukk}
+                header={{ heading: 'Forhåndsvis PDF', closeButton: true }}
+                width={'1000rem'}
+                portal={true}
+            >
+                <Alert variant={'error'}>{error?.message ?? 'En ukjent feil oppstod.'}</Alert>
+            </StyledModal>
+        );
+    }
+
     return (
         <StyledModal
-            open={erModalÅpen}
-            onClose={lukkModal}
-            header={{ heading: tittel, closeButton: true }}
-            width={bredde}
+            open={true}
+            onClose={lukk}
+            header={{ heading: 'Forhåndsvis PDF', closeButton: true }}
+            width={'1000rem'}
             portal={true}
         >
-            {erModalÅpen && (
-                <>
-                    {args === undefined && (
-                        <Modal.Body>
-                            <Alert variant={'error'}>
-                                En feil oppstod ved innlasting av modal.
-                            </Alert>
-                        </Modal.Body>
-                    )}
-                    {args !== undefined && (
-                        <iframe
-                            title={'Dokument'}
-                            height={'100%'}
-                            width={'100%'}
-                            src={window.URL.createObjectURL(args.blob)}
-                        />
-                    )}
-                </>
-            )}
+            <iframe
+                title={'Dokument'}
+                height={'100%'}
+                width={'100%'}
+                src={window.URL.createObjectURL(pdf)}
+            />
         </StyledModal>
     );
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26033

Bytter tilbake til lokal state for disse modalene da ModalContext ikke håndtere oppdatering av state. Her ønsker man å vise en modal før man har generert en PDF med en "Innhenter dokument" spinner, det fungerer ikke så bra med ModalContext per nå. Jeg tror også det er greit å bruke lokal state da det er en mer "declarative approach", som minner mer om hvordan react fungerer. 


### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Skal se likt ut som i prod.