### PR TITLE
NAV-26034: Flytter manuelle brevmottakere på fagsak ut fra FagsakContext til ManuelleBrevmottakerePåFagsakContext

### DIFF
--- a/src/frontend/context/fagsak/FagsakContext.tsx
+++ b/src/frontend/context/fagsak/FagsakContext.tsx
@@ -17,7 +17,6 @@ import {
 import { useOppdaterBrukerOgEksterneBehandlingerNårFagsakEndrerSeg } from './useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg';
 import useFagsakApi from '../../api/useFagsakApi';
 import { useTilbakekrevingApi } from '../../api/useTilbakekrevingApi';
-import type { SkjemaBrevmottaker } from '../../sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import type { IMinimalFagsak } from '../../typer/fagsak';
 import type { IKlagebehandling } from '../../typer/klage';
 import type { IPersonInfo } from '../../typer/person';
@@ -38,8 +37,6 @@ interface IFagsakContext {
     oppdaterKlagebehandlingerPåFagsak: () => void;
     tilbakekrevingsbehandlinger: ITilbakekrevingsbehandling[];
     tilbakekrevingStatus: RessursStatus;
-    manuelleBrevmottakerePåFagsak: SkjemaBrevmottaker[];
-    settManuelleBrevmottakerePåFagsak: (brevmottakere: SkjemaBrevmottaker[]) => void;
 }
 
 const FagsakContext = createContext<IFagsakContext | undefined>(undefined);
@@ -55,10 +52,6 @@ export const FagsakProvider = (props: PropsWithChildren) => {
 
     const [tilbakekrevingsbehandlinger, settTilbakekrevingsbehandlinger] =
         useState<Ressurs<ITilbakekrevingsbehandling[]>>(byggTomRessurs());
-
-    const [manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak] = useState<
-        SkjemaBrevmottaker[]
-    >([]);
 
     const { request } = useHttp();
     const { skalObfuskereData } = useAppContext();
@@ -159,7 +152,6 @@ export const FagsakProvider = (props: PropsWithChildren) => {
         bruker,
         oppdaterKlagebehandlingerPåFagsak,
         oppdaterTilbakekrevingsbehandlingerPåFagsak,
-        settManuelleBrevmottakerePåFagsak,
     });
 
     return (
@@ -176,8 +168,6 @@ export const FagsakProvider = (props: PropsWithChildren) => {
                 oppdaterKlagebehandlingerPåFagsak,
                 tilbakekrevingsbehandlinger: hentDataFraRessurs(tilbakekrevingsbehandlinger) ?? [],
                 tilbakekrevingStatus: tilbakekrevingsbehandlinger.status,
-                manuelleBrevmottakerePåFagsak,
-                settManuelleBrevmottakerePåFagsak,
             }}
         >
             {props.children}

--- a/src/frontend/context/fagsak/useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg.ts
+++ b/src/frontend/context/fagsak/useOppdaterBrukerOgKlagebehandlingerNårFagsakEndrerSeg.ts
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
 
-import type { SkjemaBrevmottaker } from '../../sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import type { IMinimalFagsak } from '../../typer/fagsak';
 import type { IPersonInfo } from '../../typer/person';
 
@@ -17,7 +16,6 @@ interface Props {
     bruker: Ressurs<IPersonInfo>;
     oppdaterKlagebehandlingerPåFagsak: () => void;
     oppdaterTilbakekrevingsbehandlingerPåFagsak: () => void;
-    settManuelleBrevmottakerePåFagsak: (manuelleBrevmottakere: SkjemaBrevmottaker[]) => void;
 }
 
 export const useOppdaterBrukerOgEksterneBehandlingerNårFagsakEndrerSeg = ({
@@ -27,7 +25,6 @@ export const useOppdaterBrukerOgEksterneBehandlingerNårFagsakEndrerSeg = ({
     bruker,
     oppdaterKlagebehandlingerPåFagsak,
     oppdaterTilbakekrevingsbehandlingerPåFagsak,
-    settManuelleBrevmottakerePåFagsak,
 }: Props) =>
     useEffect(() => {
         if (
@@ -43,5 +40,4 @@ export const useOppdaterBrukerOgEksterneBehandlingerNårFagsakEndrerSeg = ({
         }
         oppdaterKlagebehandlingerPåFagsak();
         oppdaterTilbakekrevingsbehandlingerPåFagsak();
-        settManuelleBrevmottakerePåFagsak([]);
     }, [minimalFagsakRessurs]);

--- a/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnIBrevSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnIBrevSkjema.tsx
@@ -6,10 +6,10 @@ import { CheckboxGroup } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import BarnCheckbox from './BarnCheckbox';
-import { useFagsakContext } from '../../../../context/fagsak/FagsakContext';
 import LeggTilBarn from '../../../../komponenter/LeggTilBarn';
 import type { IBarnMedOpplysninger } from '../../../../typer/søknad';
 import { isoStringTilDate } from '../../../../utils/dato';
+import { useManuelleBrevmottakerePåFagsakContext } from '../../ManuelleBrevmottakerePåFagsakContext';
 
 interface IProps {
     barnIBrevFelt: Felt<IBarnMedOpplysninger[]>;
@@ -19,7 +19,7 @@ interface IProps {
 }
 
 const BarnIBrevSkjema = (props: IProps) => {
-    const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
+    const { manuelleBrevmottakerePåFagsak } = useManuelleBrevmottakerePåFagsakContext();
 
     const { barnIBrevFelt, visFeilmeldinger, settVisFeilmeldinger } = props;
 

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingContext.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingContext.tsx
@@ -15,6 +15,7 @@ import { ForelderBarnRelasjonRolle, type IForelderBarnRelasjon } from '../../../
 import { Målform, type IBarnMedOpplysninger } from '../../../typer/søknad';
 import { Datoformat, isoStringTilFormatertString } from '../../../utils/dato';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
+import { useManuelleBrevmottakerePåFagsakContext } from '../ManuelleBrevmottakerePåFagsakContext';
 
 export enum DokumentÅrsak {
     KAN_SØKE_EØS = 'KAN_SØKE_EØS',
@@ -94,8 +95,9 @@ const DokumentutsendingContext = createContext<DokumentutsendingContextValue | u
 );
 
 export const DokumentutsendingProvider = ({ fagsakId, children }: Props) => {
-    const { bruker, manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } =
-        useFagsakContext();
+    const { bruker } = useFagsakContext();
+    const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } =
+        useManuelleBrevmottakerePåFagsakContext();
     const [visInnsendtBrevModal, settVisInnsendtBrevModal] = useState(false);
     const { hentForhåndsvisning, hentetDokument } = useDokument();
 

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -12,11 +12,11 @@ import {
     DokumentÅrsak,
     useDokumentutsendingContext,
 } from './DokumentutsendingContext';
-import { useFagsakContext } from '../../../context/fagsak/FagsakContext';
 import { BrevmottakereAlert } from '../../../komponenter/BrevmottakereAlert';
 import FritekstAvsnitt from '../../../komponenter/FritekstAvsnitt';
 import MålformVelger from '../../../komponenter/MålformVelger';
 import type { IPersonInfo } from '../../../typer/person';
+import { useManuelleBrevmottakerePåFagsakContext } from '../ManuelleBrevmottakerePåFagsakContext';
 
 interface Props {
     bruker: IPersonInfo;
@@ -73,7 +73,7 @@ const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
         visForhåndsvisningBeskjed,
     } = useDokumentutsendingContext();
 
-    const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
+    const { manuelleBrevmottakerePåFagsak } = useManuelleBrevmottakerePåFagsakContext();
 
     const årsakVerdi = skjema.felter.årsak.verdi;
 

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -11,6 +11,7 @@ import Dokumentutsending from './Dokumentutsending/Dokumentutsending';
 import { DokumentutsendingProvider } from './Dokumentutsending/DokumentutsendingContext';
 import { Fagsaklinje } from './Fagsaklinje/Fagsaklinje';
 import JournalpostListe from './journalposter/JournalpostListe';
+import { ManuelleBrevmottakerePåFagsakProvider } from './ManuelleBrevmottakerePåFagsakContext';
 import Personlinje from './Personlinje/Personlinje';
 import { Saksoversikt } from './Saksoversikt/Saksoversikt';
 import { useFagsakContext } from '../../context/fagsak/FagsakContext';
@@ -34,60 +35,62 @@ const FagsakContainerInnhold = ({ minimalFagsak }: { minimalFagsak: IMinimalFags
     switch (bruker.status) {
         case RessursStatus.SUKSESS:
             return (
-                <Innhold>
-                    <Hovedinnhold id={'fagsak-main'}>
-                        <Personlinje bruker={bruker.data} />
-                        <Routes>
-                            <Route
-                                path="/saksoversikt"
-                                element={
-                                    <>
-                                        <Fagsaklinje minimalFagsak={minimalFagsak} />
-                                        <Saksoversikt minimalFagsak={minimalFagsak} />
-                                    </>
-                                }
-                            />
+                <ManuelleBrevmottakerePåFagsakProvider key={minimalFagsak.id}>
+                    <Innhold>
+                        <Hovedinnhold id={'fagsak-main'}>
+                            <Personlinje bruker={bruker.data} />
+                            <Routes>
+                                <Route
+                                    path="/saksoversikt"
+                                    element={
+                                        <>
+                                            <Fagsaklinje minimalFagsak={minimalFagsak} />
+                                            <Saksoversikt minimalFagsak={minimalFagsak} />
+                                        </>
+                                    }
+                                />
 
-                            <Route
-                                path="/dokumentutsending"
-                                element={
-                                    <>
-                                        <Fagsaklinje minimalFagsak={minimalFagsak} />
-                                        <DokumentutsendingProvider fagsakId={minimalFagsak.id}>
-                                            <Dokumentutsending bruker={bruker.data} />
-                                        </DokumentutsendingProvider>
-                                    </>
-                                }
-                            />
+                                <Route
+                                    path="/dokumentutsending"
+                                    element={
+                                        <>
+                                            <Fagsaklinje minimalFagsak={minimalFagsak} />
+                                            <DokumentutsendingProvider fagsakId={minimalFagsak.id}>
+                                                <Dokumentutsending bruker={bruker.data} />
+                                            </DokumentutsendingProvider>
+                                        </>
+                                    }
+                                />
 
-                            <Route
-                                path="/dokumenter"
-                                element={
-                                    <>
-                                        <Fagsaklinje minimalFagsak={minimalFagsak} />
-                                        <JournalpostListe bruker={bruker.data} />
-                                    </>
-                                }
-                            />
+                                <Route
+                                    path="/dokumenter"
+                                    element={
+                                        <>
+                                            <Fagsaklinje minimalFagsak={minimalFagsak} />
+                                            <JournalpostListe bruker={bruker.data} />
+                                        </>
+                                    }
+                                />
 
-                            <Route
-                                path="/:behandlingId/*"
-                                element={
-                                    <BehandlingContainer
-                                        bruker={bruker.data}
-                                        minimalFagsak={minimalFagsak}
-                                    />
-                                }
-                            />
-                            <Route
-                                path="/"
-                                element={
-                                    <Navigate to={`/fagsak/${minimalFagsak.id}/saksoversikt`} />
-                                }
-                            />
-                        </Routes>
-                    </Hovedinnhold>
-                </Innhold>
+                                <Route
+                                    path="/:behandlingId/*"
+                                    element={
+                                        <BehandlingContainer
+                                            bruker={bruker.data}
+                                            minimalFagsak={minimalFagsak}
+                                        />
+                                    }
+                                />
+                                <Route
+                                    path="/"
+                                    element={
+                                        <Navigate to={`/fagsak/${minimalFagsak.id}/saksoversikt`} />
+                                    }
+                                />
+                            </Routes>
+                        </Hovedinnhold>
+                    </Innhold>
+                </ManuelleBrevmottakerePåFagsakProvider>
             );
         case RessursStatus.FEILET:
         case RessursStatus.FUNKSJONELL_FEIL:

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 import { LeggTilBrevmottakerModal } from './LeggTilBrevmottakerModal';
 import type { BrevmottakerUseSkjema, SkjemaBrevmottaker } from './useBrevmottakerSkjema';
 import { felterTilSkjemaBrevmottaker } from './useBrevmottakerSkjema';
-import { useFagsakContext } from '../../../../../context/fagsak/FagsakContext';
+import { useManuelleBrevmottakerePåFagsakContext } from '../../../ManuelleBrevmottakerePåFagsakContext';
 
 interface IFagsakModalProps {
     lukkModal: () => void;
 }
+
 export const LeggTilBrevmottakerModalFagsak: React.FC<IFagsakModalProps> = ({ lukkModal }) => {
-    const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } = useFagsakContext();
+    const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } =
+        useManuelleBrevmottakerePåFagsakContext();
 
     const lagreMottaker = (useSkjema: BrevmottakerUseSkjema) => {
         if (useSkjema.kanSendeSkjema()) {

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/MenyvalgFagsak.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/MenyvalgFagsak.tsx
@@ -6,8 +6,8 @@ import { Dropdown } from '@navikt/ds-react';
 
 import { LeggTilEllerFjernBrevmottakere } from './LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere';
 import OpprettBehandling from './OpprettBehandling/OpprettBehandling';
-import { useFagsakContext } from '../../../../context/fagsak/FagsakContext';
 import type { IMinimalFagsak } from '../../../../typer/fagsak';
+import { useManuelleBrevmottakerePåFagsakContext } from '../../ManuelleBrevmottakerePåFagsakContext';
 
 interface IProps {
     minimalFagsak: IMinimalFagsak;
@@ -17,7 +17,7 @@ const MenyvalgFagsak = ({ minimalFagsak }: IProps) => {
     const navigate = useNavigate();
 
     const erPåDokumentutsending = useLocation().pathname.includes('dokumentutsending');
-    const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
+    const { manuelleBrevmottakerePåFagsak } = useManuelleBrevmottakerePåFagsakContext();
 
     return (
         <>

--- a/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.test.tsx
+++ b/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.test.tsx
@@ -1,0 +1,50 @@
+import React, { type PropsWithChildren } from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+
+import {
+    ManuelleBrevmottakerePåFagsakProvider,
+    useManuelleBrevmottakerePåFagsakContext,
+} from './ManuelleBrevmottakerePåFagsakContext';
+import { lagBrevmottaker } from '../../testdata/brevmottakerTestdata';
+
+function Provider({ children }: PropsWithChildren) {
+    return (
+        <ManuelleBrevmottakerePåFagsakProvider>{children}</ManuelleBrevmottakerePåFagsakProvider>
+    );
+}
+
+describe('ManuelleBrevmottakerePåFagsakContext', () => {
+    test('skal kaste feil om context hooken brukes uten en provider', () => {
+        // Act & expect
+        expect(() => {
+            renderHook(() => useManuelleBrevmottakerePåFagsakContext());
+        }).toThrow(
+            'useManuelleBrevmottakerePåFagsakContext må brukes innenfor en ManuelleBrevmottakerePåFagsakProvider'
+        );
+    });
+
+    test('skal ha en tom liste med brevmottakere om ingen er satt manuelt', () => {
+        // Act
+        const { result } = renderHook(() => useManuelleBrevmottakerePåFagsakContext(), {
+            wrapper: Provider,
+        });
+
+        // Expect
+        expect(result.current.manuelleBrevmottakerePåFagsak).toHaveLength(0);
+    });
+
+    test('skal kunne sette brevmottakere på fagsak', () => {
+        // Arrange
+        const brevmottakere = [lagBrevmottaker()];
+        const { result } = renderHook(() => useManuelleBrevmottakerePåFagsakContext(), {
+            wrapper: Provider,
+        });
+
+        // Act
+        act(() => result.current.settManuelleBrevmottakerePåFagsak(brevmottakere));
+
+        // Expect
+        expect(result.current.manuelleBrevmottakerePåFagsak).toBe(brevmottakere);
+    });
+});

--- a/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.tsx
+++ b/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, type PropsWithChildren, useContext, useMemo, useState } from 'react';
+
+import type { SkjemaBrevmottaker } from './Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
+
+interface ManuelleBrevmottakerePåFagsakContext {
+    manuelleBrevmottakerePåFagsak: SkjemaBrevmottaker[];
+    settManuelleBrevmottakerePåFagsak: (brevmottakere: SkjemaBrevmottaker[]) => void;
+}
+
+const ManuelleBrevmottakerePåFagsakContext = createContext<
+    ManuelleBrevmottakerePåFagsakContext | undefined
+>(undefined);
+
+export function ManuelleBrevmottakerePåFagsakProvider({ children }: PropsWithChildren) {
+    const [manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak] = useState<
+        SkjemaBrevmottaker[]
+    >([]);
+
+    const value = useMemo(
+        () => ({
+            manuelleBrevmottakerePåFagsak,
+            settManuelleBrevmottakerePåFagsak,
+        }),
+        [manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak]
+    );
+
+    return (
+        <ManuelleBrevmottakerePåFagsakContext.Provider value={value}>
+            {children}
+        </ManuelleBrevmottakerePåFagsakContext.Provider>
+    );
+}
+
+export function useManuelleBrevmottakerePåFagsakContext() {
+    const context = useContext(ManuelleBrevmottakerePåFagsakContext);
+    if (context === undefined) {
+        throw new Error(
+            'useManuelleBrevmottakerePåFagsakContext må brukes innenfor en ManuelleBrevmottakerePåFagsakProvider'
+        );
+    }
+    return context;
+}

--- a/src/frontend/testdata/brevmottakerTestdata.ts
+++ b/src/frontend/testdata/brevmottakerTestdata.ts
@@ -1,0 +1,19 @@
+import {
+    Mottaker,
+    type SkjemaBrevmottaker,
+} from '../sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
+
+export function lagBrevmottaker(brevmottaker?: Partial<SkjemaBrevmottaker>): SkjemaBrevmottaker {
+    return {
+        type: Mottaker.FULLMEKTIG,
+        navn: 'Navn Navnesen',
+        adresselinje1: 'Adresselinje 1',
+        adresselinje2: undefined,
+        postnummer: '0001',
+        poststed: 'Oslo',
+        landkode: 'NO',
+        ...(brevmottaker ?? {}),
+    };
+}
+
+export * as BrevmottakerTestdata from './brevmottakerTestdata';


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26034

Flytter ut manuelle brevmottakere fra `FagsakContext` til sin egen context kalt `ManuelleBrevmottakerePåFagsakContext`

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan ta ved behov. 

### 👀 Screen shots
Ingen visuelle endringer. 
