### PR TITLE
Fikser trippel scroll på behandlingsvisningen

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
@@ -27,7 +27,7 @@ const VenstremenyContainer = styled.div`
 `;
 
 const HovedinnholdContainer = styled.div`
-    height: calc(100vh - 6rem);
+    height: calc(100vh - 146px);
     flex: 1;
     overflow: auto;
 `;
@@ -36,6 +36,7 @@ const HøyremenyContainer = styled.div`
     border-left: 1px solid ${ABorderDivider};
     overflow-x: hidden;
     overflow-y: scroll;
+    height: calc(100vh - 146px);
 `;
 
 interface Props {

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
@@ -37,7 +37,6 @@ const HøyremenyContainer = styled.div`
         display: flex;
         flex-direction: column;
         width: 25rem;
-        height: calc(100vh - 8rem);
     }
 `;
 

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -19,7 +19,7 @@ import { useScrollTilAnker } from '../../hooks/useScrollTilAnker';
 import type { IMinimalFagsak } from '../../typer/fagsak';
 
 const Innhold = styled.div`
-    height: calc(100vh - 6rem);
+    height: calc(100vh - 3rem);
     display: flex;
 `;
 


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26134

### 💰 Hva forsøker du å løse i denne PR'en
Fjernet en tredje scrollbar som gjorde slik at personlinjen med fnr og kommune på søker samt menylinjen under forsvant hvis saksbehandler scrollet seg helt ned på siden.

Problemet er at vi eksplisitt setter høyde på hovedinnhold og høyremenyen basert på at det kun fantes én header (den sorte) og én personlinje. Nå har vi en ytterligere linje under personlinjen med lenker til saken. Dermed måtte kalkulasjonen av høyde basert på enheten `vh` bli litt annerledes. Jeg legger også begge høydestilene på samme sted slik at verdiene blir like. Før lå høyremenyen sin høyde lenger inn i hierarkiet og på et element som lå lenger nede visuelt, som gjorde at disse to høydeverdiene ble litt forskjellige og veldig forvirrende. Har også fikset generell høyde på alle scrollbarene, før sluttet de litt før bunnen på siden, nå slutter de på bunnen.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingen bekymringer

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før (merk tre scrollbarer som stoppet litt før bunnen på siden):
<img width="1810" height="1208" alt="image" src="https://github.com/user-attachments/assets/4ccc0a16-4d01-4228-bed3-dc4a509cd4e2" />


Når vi scrollet oss helt ned vil den ytterste scrollbaren også scrolles helt ned, og personlinja + den nye linja under vil da skjules:
<img width="1810" height="1207" alt="image" src="https://github.com/user-attachments/assets/f576f9c0-f286-4cec-829a-52a7af13c1b1" />



Etter (kun to scrollbarer og scrollbarene går ned til bunnen av siden):
<img width="1807" height="1206" alt="image" src="https://github.com/user-attachments/assets/eb70cb26-d14e-4c33-849d-8af83badec53" />


Og når vi scroller helt ned er alt fremdeles A-OK:
<img width="1806" height="1206" alt="image" src="https://github.com/user-attachments/assets/3c06599f-400f-479e-86f7-062661771d5c" />