### PR TITLE
Flytt BehandlingProvider til BehandlingContainer

### DIFF
--- a/src/frontend/Container.tsx
+++ b/src/frontend/Container.tsx
@@ -12,7 +12,6 @@ import SystemetLaster from './komponenter/SystemetLaster/SystemetLaster';
 import { TidslinjeProvider } from './komponenter/Tidslinje/TidslinjeContext';
 import Toasts from './komponenter/Toast/Toasts';
 import Barnehagelister from './sider/Barnehagelister/Barnehagelister';
-import { BehandlingProvider } from './sider/Fagsak/Behandling/context/BehandlingContext';
 import { FagsakContainer } from './sider/Fagsak/FagsakContainer';
 import Internstatistikk from './sider/Internstatistikk/Internstatistikk';
 import ManuellJournalføring from './sider/ManuellJournalføring/ManuellJournalføring';
@@ -52,24 +51,22 @@ const Container = () => {
                                 brukerNavn={innloggetSaksbehandler?.displayName}
                                 brukerEnhet={innloggetSaksbehandler?.enhet}
                             />
-                            <BehandlingProvider>
-                                <Routes>
-                                    <Route path="/fagsak/:fagsakId/*" element={<FagsakContainer />} />
-                                    <Route path="/oppgaver/journalfor/:oppgaveId" element={<ManuellJournalføring />} />
-                                    <Route
-                                        path="/tidslinjer/:behandlingId"
-                                        element={
-                                            <TidslinjeProvider>
-                                                <TidslinjeVisualisering />
-                                            </TidslinjeProvider>
-                                        }
-                                    />
-                                    <Route path="/internstatistikk" element={<Internstatistikk />} />
-                                    <Route path="/barnehagelister" element={<Barnehagelister />} />
-                                    <Route path="/oppgaver" element={<Oppgavebenk />} />
-                                    <Route path="/" element={<Navigate to="/oppgaver" />} />
-                                </Routes>
-                            </BehandlingProvider>
+                            <Routes>
+                                <Route path="/fagsak/:fagsakId/*" element={<FagsakContainer />} />
+                                <Route path="/oppgaver/journalfor/:oppgaveId" element={<ManuellJournalføring />} />
+                                <Route
+                                    path="/tidslinjer/:behandlingId"
+                                    element={
+                                        <TidslinjeProvider>
+                                            <TidslinjeVisualisering />
+                                        </TidslinjeProvider>
+                                    }
+                                />
+                                <Route path="/internstatistikk" element={<Internstatistikk />} />
+                                <Route path="/barnehagelister" element={<Barnehagelister />} />
+                                <Route path="/oppgaver" element={<Oppgavebenk />} />
+                                <Route path="/" element={<Navigate to="/oppgaver" />} />
+                            </Routes>
                         </Main>
                     </>
                 )

--- a/src/frontend/komponenter/Alert/BehandlingPåVentAlert.tsx
+++ b/src/frontend/komponenter/Alert/BehandlingPåVentAlert.tsx
@@ -1,16 +1,13 @@
 import { Alert } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandlingContext } from '../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { SettPåVentÅrsak, settPåVentÅrsaker } from '../../typer/behandling';
 import { Datoformat, isoStringTilFormatertString } from '../../utils/dato';
 
 export function BehandlingPåVentAlert() {
-    const { åpenBehandling } = useBehandlingContext();
+    const { behandling } = useBehandlingContext();
 
-    const behandling = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data : undefined;
-
-    if (!behandling || !behandling.behandlingPåVent) {
+    if (!behandling.behandlingPåVent) {
         return null;
     }
 

--- a/src/frontend/komponenter/Alert/MidlertidigEnhetAlert.tsx
+++ b/src/frontend/komponenter/Alert/MidlertidigEnhetAlert.tsx
@@ -1,18 +1,11 @@
 import { Alert } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandlingContext } from '../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { BehandlingStatus } from '../../typer/behandling';
 import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../../utils/behandling';
 
 export function MidlertidigEnhetAlert() {
-    const { åpenBehandling } = useBehandlingContext();
-
-    const behandling = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data : undefined;
-
-    if (!behandling) {
-        return null;
-    }
+    const { behandling } = useBehandlingContext();
 
     const erBehandleneEnhetMidlertidig =
         behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId === MIDLERTIDIG_BEHANDLENDE_ENHET_ID;

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -76,7 +76,7 @@ const FritekstWrapper = styled.div`
 `;
 
 const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
-    const { åpenBehandling, settÅpenBehandling, vurderErLesevisning, hentLogg } = useBehandlingContext();
+    const { behandling, settÅpenBehandling, vurderErLesevisning, hentLogg } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 
     const {
@@ -98,8 +98,6 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
         settVisFritekstAvsnittTekstboks,
     } = useBrevModul();
 
-    const behandlingId = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.behandlingId : undefined;
-
     const { åpneModal: åpneForhåndsvisOpprettingAvPdfModal } = useModal(ModalType.FORHÅNDSVIS_OPPRETTING_AV_PDF);
 
     const { mutate: opprettForhåndsvisbarBrevPdf, isPending: isOpprettForhåndsvisbarBrevPdfPending } =
@@ -112,8 +110,6 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
 
     const fieldsetId = 'Fritekster-brev';
     const erMaksAntallKulepunkter = skjema.felter.friteksterKulepunkter.verdi.length >= maksAntallKulepunkter;
-
-    const behandlingSteg = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.steg : undefined;
 
     const onChangeFritekst = (event: ChangeEvent<HTMLTextAreaElement>, fritekstId: number) =>
         skjema.felter.friteksterKulepunkter.validerOgSettFelt([
@@ -330,7 +326,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                 {skjema.felter.barnBrevetGjelder.erSynlig && (
                     <BarnBrevetGjelder
                         barnBrevetGjelderFelt={skjema.felter.barnBrevetGjelder}
-                        behandlingsSteg={behandlingSteg}
+                        behandlingsSteg={behandling.steg}
                         visFeilmeldinger={skjema.visFeilmeldinger}
                         settVisFeilmeldinger={settVisfeilmeldinger}
                     />
@@ -350,12 +346,12 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                     size={'medium'}
                     disabled={skjemaErLåst}
                     onClick={() => {
-                        if (behandlingId === undefined) {
+                        if (behandling.behandlingId === undefined) {
                             return; // Dette skal aldri skje
                         }
                         if (kanSendeSkjema()) {
                             opprettForhåndsvisbarBrevPdf({
-                                behandlingId: behandlingId,
+                                behandlingId: behandling.behandlingId,
                                 payload: hentSkjemaData(),
                             });
                         }
@@ -370,20 +366,18 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                     loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                     disabled={skjemaErLåst}
                     onClick={() => {
-                        if (åpenBehandling.status === RessursStatus.SUKSESS) {
-                            onSubmit<IManueltBrevRequestPåBehandling>(
-                                {
-                                    method: 'POST',
-                                    data: hentSkjemaData(),
-                                    url: `/familie-ks-sak/api/brev/send-brev/${åpenBehandling.data.behandlingId}`,
-                                },
-                                (ressurs: Ressurs<IBehandling>) => {
-                                    onSubmitSuccess();
-                                    settÅpenBehandling(ressurs);
-                                    hentLogg();
-                                }
-                            );
-                        }
+                        onSubmit<IManueltBrevRequestPåBehandling>(
+                            {
+                                method: 'POST',
+                                data: hentSkjemaData(),
+                                url: `/familie-ks-sak/api/brev/send-brev/${behandling.behandlingId}`,
+                            },
+                            (ressurs: Ressurs<IBehandling>) => {
+                                onSubmitSuccess();
+                                settÅpenBehandling(ressurs);
+                                hentLogg();
+                            }
+                        );
                     }}
                 >
                     Send brev

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/useBrevModul.test.ts
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/useBrevModul.test.ts
@@ -1,10 +1,7 @@
 import { Valideringsstatus } from '@navikt/familie-skjema';
-import type { Ressurs } from '@navikt/familie-typer';
-import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
 
 import { Brevmal } from './typer';
 import { hentMuligeBrevmalerImplementering, mottakersMålformImplementering } from './useBrevModul';
-import type { IBehandling } from '../../../typer/behandling';
 import { Behandlingstype, BehandlingÅrsak } from '../../../typer/behandling';
 import { Målform } from '../../../typer/søknad';
 import { mockBehandling } from '../../../utils/test/behandling/behandling.mock';
@@ -12,17 +9,12 @@ import { mockBarn, mockSøker } from '../../../utils/test/person/person.mock';
 
 describe('useBrevModul', () => {
     describe('hentMuligeBrevmalerImplementering', () => {
-        const lagBehandlignRessursSuksess = (behandling: IBehandling): Ressurs<IBehandling> => ({
-            status: RessursStatus.SUKSESS,
-            data: behandling,
-        });
-
         const behandlingSøknad = mockBehandling({
             årsak: BehandlingÅrsak.SØKNAD,
             type: Behandlingstype.FØRSTEGANGSBEHANDLING,
         });
         test('Skal returnere liste med gyldige brev for når behandlingsårsaken er SØKNAD og behandlingstypen er FØRSTEGANGSBEHANDLING', () => {
-            expect(hentMuligeBrevmalerImplementering(lagBehandlignRessursSuksess(behandlingSøknad)).sort()).toEqual(
+            expect(hentMuligeBrevmalerImplementering(behandlingSøknad).sort()).toEqual(
                 [
                     Brevmal.INNHENTE_OPPLYSNINGER,
                     Brevmal.INNHENTE_OPPLYSNINGER_OG_INFORMASJON_OM_AT_ANNEN_FORELDER_MED_SELVSTENDIG_RETT_HAR_SØKT,
@@ -47,12 +39,10 @@ describe('useBrevModul', () => {
                     .map(årsak =>
                         expect(
                             hentMuligeBrevmalerImplementering(
-                                lagBehandlignRessursSuksess(
-                                    mockBehandling({
-                                        årsak: årsak,
-                                        type: Behandlingstype.REVURDERING,
-                                    })
-                                )
+                                mockBehandling({
+                                    årsak: årsak,
+                                    type: Behandlingstype.REVURDERING,
+                                })
                             )
                         ).toContain(Brevmal.VARSEL_OM_REVURDERING)
                     );

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/useBrevModul.ts
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/useBrevModul.ts
@@ -2,8 +2,6 @@ import { useEffect, useState } from 'react';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
-import type { Ressurs } from '@navikt/familie-typer';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import type { ISelectOptionMedBrevtekst } from './typer';
 import { Brevmal } from './typer';
@@ -18,13 +16,9 @@ import { Målform } from '../../../typer/søknad';
 import type { IFritekstFelt } from '../../../utils/fritekstfelter';
 import { genererIdBasertPåAndreFritekster, lagInitiellFritekst } from '../../../utils/fritekstfelter';
 
-export const hentMuligeBrevmalerImplementering = (åpenBehandling: Ressurs<IBehandling>): Brevmal[] => {
-    if (åpenBehandling.status !== RessursStatus.SUKSESS) {
-        return [];
-    }
-
+export const hentMuligeBrevmalerImplementering = (behandling: IBehandling): Brevmal[] => {
     const brevmaler: Brevmal[] = Object.keys(Brevmal) as Brevmal[];
-    return brevmaler.filter(brevmal => brevmalKanVelgesForBehandling(brevmal, åpenBehandling.data));
+    return brevmaler.filter(brevmal => brevmalKanVelgesForBehandling(brevmal, behandling));
 };
 
 const brevmalKanVelgesForBehandling = (brevmal: Brevmal, åpenBehandling: IBehandling): boolean => {
@@ -85,7 +79,7 @@ export const mottakersMålformImplementering = (
     })?.målform ?? Målform.NB;
 
 export const useBrevModul = () => {
-    const { åpenBehandling } = useBehandlingContext();
+    const { behandling } = useBehandlingContext();
 
     const maksAntallKulepunkter = 20;
     const makslengdeFritekstHvertKulepunkt = 220;
@@ -93,10 +87,9 @@ export const useBrevModul = () => {
 
     const [visFritekstAvsnittTekstboks, settVisFritekstAvsnittTekstboks] = useState(false);
 
-    const behandlingKategori =
-        åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.kategori : undefined;
+    const behandlingKategori = behandling.kategori;
 
-    const brevmottakere = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.brevmottakere : [];
+    const brevmottakere = behandling.brevmottakere;
 
     const mottakerIdent = useFelt({
         verdi: '',
@@ -269,13 +262,13 @@ export const useBrevModul = () => {
     useEffect(() => {
         skjema.felter.dokumenter.nullstill();
         nullstillBarnBrevetGjelder();
-    }, [åpenBehandling]);
+    }, [behandling]);
 
     useEffect(() => {
         nullstillBarnBrevetGjelder();
     }, [skjema.felter.brevmal.verdi]);
 
-    const personer = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.personer : [];
+    const personer = behandling.personer;
 
     const mottakersMålform = (): Målform =>
         mottakersMålformImplementering(
@@ -284,7 +277,7 @@ export const useBrevModul = () => {
             skjema.felter.mottakerIdent.verdi
         );
 
-    const hentMuligeBrevMaler = (): Brevmal[] => hentMuligeBrevmalerImplementering(åpenBehandling);
+    const hentMuligeBrevMaler = (): Brevmal[] => hentMuligeBrevmalerImplementering(behandling);
 
     const leggTilFritekst = (valideringsmelding?: string) => {
         skjema.felter.friteksterKulepunkter.validerOgSettFelt([

--- a/src/frontend/komponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Skjemasteg/Skjemasteg.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 
 import { Box, Button, ErrorMessage, Heading, VStack } from '@navikt/ds-react';
 import { ASpacing24, ASpacing4, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
-import { hentDataFraRessurs } from '@navikt/familie-typer';
 
 import { useBehandlingContext } from '../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { BehandlingSteg } from '../../typer/behandling';
@@ -57,7 +56,7 @@ const Skjemasteg = ({
     skalViseForrigeKnapp = true,
     feilmelding = '',
 }: IProps) => {
-    const { åpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling, vurderErLesevisning } = useBehandlingContext();
 
     useEffect(() => {
         const skjema = document.getElementById('skjemasteg');
@@ -66,10 +65,7 @@ const Skjemasteg = ({
         }
     }, []);
 
-    const kanGåVidereILesevisning = behandlingErEtterSteg(
-        BehandlingSteg.SIMULERING,
-        hentDataFraRessurs(åpenBehandling)
-    );
+    const kanGåVidereILesevisning = behandlingErEtterSteg(BehandlingSteg.SIMULERING, behandling);
 
     function onNesteClicked() {
         if (!senderInn && nesteOnClick) {

--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
@@ -5,11 +5,12 @@ import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { BehandlingRouter } from './BehandlingRouter';
-import { useBehandlingContext } from './context/BehandlingContext';
+import { BehandlingProvider } from './context/BehandlingContext';
 import { Høyremeny } from './Høyremeny/Høyremeny';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 import type { IPersonInfo } from '../../../typer/person';
 import { Fagsaklinje } from '../Fagsaklinje/Fagsaklinje';
+import { useHentOgSettBehandlingContext } from './context/HentOgSettBehandlingContext';
 import { Venstremeny } from './Venstremeny/Venstremeny';
 import { HenleggBehandlingModal } from '../Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal';
 import { HenleggBehandlingVeivalgModal } from '../Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingVeivalgModal';
@@ -47,34 +48,34 @@ interface Props {
 }
 
 const BehandlingContainer = ({ bruker, minimalFagsak }: Props) => {
-    const { åpenBehandling } = useBehandlingContext();
+    const { behandlingRessurs } = useHentOgSettBehandlingContext();
 
-    switch (åpenBehandling.status) {
+    switch (behandlingRessurs.status) {
         case RessursStatus.SUKSESS:
             return (
-                <>
+                <BehandlingProvider behandling={behandlingRessurs.data}>
                     <HenleggBehandlingModal />
                     <HenleggBehandlingVeivalgModal />
-                    <KorrigerEtterbetalingModal behandling={åpenBehandling.data} />
-                    <Fagsaklinje minimalFagsak={minimalFagsak} />
+                    <KorrigerEtterbetalingModal behandling={behandlingRessurs.data} />
+                    <Fagsaklinje minimalFagsak={minimalFagsak} behandling={behandlingRessurs.data} />
                     <FlexContainer>
                         <VenstremenyContainer>
                             <Venstremeny />
                         </VenstremenyContainer>
                         <HovedinnholdContainer>
-                            <BehandlingRouter åpenBehandling={åpenBehandling.data} bruker={bruker} />
+                            <BehandlingRouter åpenBehandling={behandlingRessurs.data} bruker={bruker} />
                         </HovedinnholdContainer>
                         <HøyremenyContainer>
                             <Høyremeny bruker={bruker} />
                         </HøyremenyContainer>
                     </FlexContainer>
-                </>
+                </BehandlingProvider>
             );
         case RessursStatus.IKKE_TILGANG:
             return <Alert variant="warning" children={`Du har ikke tilgang til å se denne behandlingen.`} />;
         case RessursStatus.FEILET:
         case RessursStatus.FUNKSJONELL_FEIL:
-            return <Alert children={åpenBehandling.frontendFeilmelding} variant="error" />;
+            return <Alert children={behandlingRessurs.frontendFeilmelding} variant="error" />;
         default:
             return <div />;
     }

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { ChevronLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons';
 import { Button, Stack, VStack } from '@navikt/ds-react';
 import { ASurfaceDefault } from '@navikt/ds-tokens/dist/tokens';
-import { hentDataFraRessursMedFallback, RessursStatus } from '@navikt/familie-typer';
+import { hentDataFraRessursMedFallback } from '@navikt/familie-typer';
 
 import Behandlingskort from './Behandlingskort';
 import { useHøyremeny } from './useHøyremeny';
@@ -34,19 +34,13 @@ const ToggleVisningHøyremeny = styled(Button)`
 `;
 
 export function Høyremeny({ bruker }: Props) {
-    const { åpenBehandling, logg, hentLogg } = useBehandlingContext();
+    const { behandling, logg, hentLogg } = useBehandlingContext();
 
     const [erÅpen, settErÅpen] = useHøyremeny();
 
     useEffect(() => {
-        if (åpenBehandling && åpenBehandling.status === RessursStatus.SUKSESS) {
-            hentLogg();
-        }
-    }, [åpenBehandling]);
-
-    if (åpenBehandling.status !== RessursStatus.SUKSESS) {
-        return null;
-    }
+        hentLogg();
+    }, [behandling]);
 
     const icon = erÅpen ? (
         <ChevronRightIcon aria-label={'Skjul høyremeny'} />
@@ -67,7 +61,7 @@ export function Høyremeny({ bruker }: Props) {
             />
             <Activity mode={erÅpen ? 'visible' : 'hidden'}>
                 <VStack width={'25rem'}>
-                    <Behandlingskort åpenBehandling={åpenBehandling.data} />
+                    <Behandlingskort åpenBehandling={behandling} />
                     <Hendelsesoversikt
                         hendelser={hentDataFraRessursMedFallback(logg, []).map((loggElement: ILogg): Hendelse => {
                             return {
@@ -82,7 +76,7 @@ export function Høyremeny({ bruker }: Props) {
                                 beskrivelse: loggElement.tekst,
                             };
                         })}
-                        åpenBehandling={åpenBehandling.data}
+                        åpenBehandling={behandling}
                         bruker={bruker}
                     />
                 </VStack>

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
@@ -19,7 +19,6 @@ import {
     ASurfaceWarning,
     ATextDefault,
 } from '@navikt/ds-tokens/dist/tokens';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import { useVenstremeny } from './useVenstremeny';
 import { useFagsakId } from '../../../../hooks/useFagsakId';
@@ -77,7 +76,7 @@ const UndersideSirkel = styled.span`
 `;
 
 export function Venstremeny() {
-    const { åpenBehandling, trinnPåBehandling } = useBehandlingContext();
+    const { behandling, trinnPåBehandling } = useBehandlingContext();
 
     const fagsakId = useFagsakId();
     const [erÅpen, settErÅpen] = useVenstremeny();
@@ -94,10 +93,6 @@ export function Venstremeny() {
         <ChevronRightIcon aria-label={'Skjul venstremeny'} />
     );
 
-    if (åpenBehandling.status !== RessursStatus.SUKSESS) {
-        return null;
-    }
-
     return (
         <Stack direction={'row-reverse'}>
             <ToggleVisningVenstremeny
@@ -112,9 +107,9 @@ export function Venstremeny() {
             <Activity mode={erÅpen ? 'visible' : 'hidden'}>
                 <Box as={'nav'} paddingBlock={'space-8'}>
                     {Object.entries(trinnPåBehandling).map(([sideId, side], index) => {
-                        const tilPath = `/fagsak/${fagsakId}/${åpenBehandling.data.behandlingId}/${side.href}`;
-                        const undersider = side.undersider ? side.undersider(åpenBehandling.data) : [];
-                        const sidenErAktiv = erSidenAktiv(side, åpenBehandling.data);
+                        const tilPath = `/fagsak/${fagsakId}/${behandling.behandlingId}/${side.href}`;
+                        const undersider = side.undersider ? side.undersider(behandling) : [];
+                        const sidenErAktiv = erSidenAktiv(side, behandling);
                         return (
                             <VStack key={sideId}>
                                 <MenyLenke

--- a/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
@@ -39,12 +39,14 @@ export function HentOgSettBehandlingProvider({ fagsak, children }: Props) {
         behandling => behandling.behandlingId.toString() === behandlingId
     );
 
-    if (behandlingId !== undefined && !erBehandlingDelAvFagsak) {
-        navigate(`/fagsak/${fagsak.id}`);
-    }
+    useEffect(() => {
+        if (behandlingId !== undefined && !erBehandlingDelAvFagsak) {
+            navigate(`/fagsak/${fagsak.id}`);
+        }
+    }, [behandlingId, erBehandlingDelAvFagsak]);
 
     const settBehandlingRessurs = async (behandling: Ressurs<IBehandling>) => {
-        queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id) });
+        await queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id) });
         if (skalObfuskereData) {
             obfuskerBehandling(behandling);
         }
@@ -59,15 +61,10 @@ export function HentOgSettBehandlingProvider({ fagsak, children }: Props) {
                 url: `/familie-ks-sak/api/behandlinger/${behandlingId}`,
                 påvirkerSystemLaster: true,
             })
-                .then((response: Ressurs<IBehandling>) => {
-                    if (skalObfuskereData) {
-                        obfuskerBehandling(response);
-                    }
-                    privatSettBehandlingRessurs(response);
-                })
-                .catch((_error: AxiosError) => {
-                    privatSettBehandlingRessurs(byggFeiletRessurs('Ukjent ved innhenting av behandling'));
-                });
+                .then(response => settBehandlingRessurs(response))
+                .catch((_error: AxiosError) =>
+                    privatSettBehandlingRessurs(byggFeiletRessurs('Ukjent ved innhenting av behandling'))
+                );
         }
     }, [behandlingId]);
 

--- a/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
@@ -1,0 +1,83 @@
+import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import { useNavigate } from 'react-router';
+
+import { useHttp } from '@navikt/familie-http';
+import { byggFeiletRessurs, byggTomRessurs, type Ressurs } from '@navikt/familie-typer';
+
+import { useAppContext } from '../../../../context/AppContext';
+import { HentFagsakQueryKeyFactory } from '../../../../hooks/useHentFagsak';
+import useSakOgBehandlingParams from '../../../../hooks/useSakOgBehandlingParams';
+import type { IBehandling } from '../../../../typer/behandling';
+import type { IMinimalFagsak } from '../../../../typer/fagsak';
+import { obfuskerBehandling } from '../../../../utils/obfuskerData';
+
+interface Props extends PropsWithChildren {
+    fagsak: IMinimalFagsak;
+}
+
+interface Context {
+    behandlingRessurs: Ressurs<IBehandling>;
+    settBehandlingRessurs: (behandling: Ressurs<IBehandling>) => void;
+}
+
+const Context = createContext<Context | undefined>(undefined);
+
+export function HentOgSettBehandlingProvider({ fagsak, children }: Props) {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+
+    const { request } = useHttp();
+    const { behandlingId } = useSakOgBehandlingParams();
+    const { skalObfuskereData } = useAppContext();
+
+    const [behandlingRessurs, privatSettBehandlingRessurs] = useState<Ressurs<IBehandling>>(byggTomRessurs());
+
+    const erBehandlingDelAvFagsak = fagsak.behandlinger.some(
+        behandling => behandling.behandlingId.toString() === behandlingId
+    );
+
+    if (behandlingId !== undefined && !erBehandlingDelAvFagsak) {
+        navigate(`/fagsak/${fagsak.id}`);
+    }
+
+    const settBehandlingRessurs = async (behandling: Ressurs<IBehandling>) => {
+        queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id) });
+        if (skalObfuskereData) {
+            obfuskerBehandling(behandling);
+        }
+        privatSettBehandlingRessurs(behandling);
+    };
+
+    useEffect(() => {
+        privatSettBehandlingRessurs(byggTomRessurs());
+        if (behandlingId) {
+            request<void, IBehandling>({
+                method: 'GET',
+                url: `/familie-ks-sak/api/behandlinger/${behandlingId}`,
+                påvirkerSystemLaster: true,
+            })
+                .then((response: Ressurs<IBehandling>) => {
+                    if (skalObfuskereData) {
+                        obfuskerBehandling(response);
+                    }
+                    privatSettBehandlingRessurs(response);
+                })
+                .catch((_error: AxiosError) => {
+                    privatSettBehandlingRessurs(byggFeiletRessurs('Ukjent ved innhenting av behandling'));
+                });
+        }
+    }, [behandlingId]);
+
+    return <Context.Provider value={{ behandlingRessurs, settBehandlingRessurs }}>{children}</Context.Provider>;
+}
+
+export function useHentOgSettBehandlingContext() {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useHentOgSettBehandlingContext må brukes innenfor HentOgSettBehandlingProvider');
+    }
+    return context;
+}

--- a/src/frontend/sider/Fagsak/Behandling/context/useBehandlingApi.ts
+++ b/src/frontend/sider/Fagsak/Behandling/context/useBehandlingApi.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import type { AxiosError } from 'axios';
 import { useNavigate } from 'react-router';
@@ -11,10 +11,9 @@ import { useAppContext } from '../../../../context/AppContext';
 import useSakOgBehandlingParams from '../../../../hooks/useSakOgBehandlingParams';
 import { BehandlingÅrsak, type IBehandling, type IOpprettBehandlingData } from '../../../../typer/behandling';
 import type { ILogg } from '../../../../typer/logg';
-import { obfuskerBehandling, obfuskerLogg } from '../../../../utils/obfuskerData';
+import { obfuskerLogg } from '../../../../utils/obfuskerData';
 
 const useBehandlingApi = (
-    behandling: Ressurs<IBehandling>,
     oppdaterBehandling: (behandling: Ressurs<IBehandling>, oppdaterMinimalFagsak?: boolean) => void
 ) => {
     const { request } = useHttp();
@@ -23,19 +22,6 @@ const useBehandlingApi = (
     const navigate = useNavigate();
     const [logg, settLogg] = useState<Ressurs<ILogg[]>>(byggTomRessurs());
     const { skalObfuskereData } = useAppContext();
-
-    useEffect(() => {
-        if (behandlingId !== undefined) {
-            if (behandling.status !== RessursStatus.SUKSESS) {
-                hentBehandling();
-            } else if (
-                behandling.status === RessursStatus.SUKSESS &&
-                behandling.data.behandlingId !== parseInt(behandlingId, 10)
-            ) {
-                hentBehandling();
-            }
-        }
-    }, [behandlingId]);
 
     const opprettBehandling = (data: IOpprettBehandlingData): Promise<void | Ressurs<IBehandling>> => {
         return request<IOpprettBehandlingData, IBehandling>({
@@ -59,19 +45,6 @@ const useBehandlingApi = (
             .catch(() => {
                 return byggFeiletRessurs('Opprettelse av behandling feilet');
             });
-    };
-
-    const hentBehandling = () => {
-        request<void, IBehandling>({
-            method: 'GET',
-            url: `/familie-ks-sak/api/behandlinger/${behandlingId}`,
-            påvirkerSystemLaster: true,
-        }).then((response: Ressurs<IBehandling>) => {
-            if (skalObfuskereData) {
-                obfuskerBehandling(response);
-            }
-            oppdaterBehandling(response, false);
-        });
     };
 
     const hentLogg = (): void => {

--- a/src/frontend/sider/Fagsak/Behandling/context/useBehandlingApi.ts
+++ b/src/frontend/sider/Fagsak/Behandling/context/useBehandlingApi.ts
@@ -36,9 +36,9 @@ const useBehandlingApi = (
                     const behandling = response.data;
 
                     if (behandling.årsak === BehandlingÅrsak.SØKNAD) {
-                        navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-soknad`);
+                        navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/registrer-soknad`);
                     } else {
-                        navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`);
+                        navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/vilkaarsvurdering`);
                     }
                 }
             })

--- a/src/frontend/sider/Fagsak/Behandling/context/useBehandlingssteg.ts
+++ b/src/frontend/sider/Fagsak/Behandling/context/useBehandlingssteg.ts
@@ -133,7 +133,6 @@ const useBehandlingssteg = (
         vilkårsvurderingNesteOnClick,
         behandlingresultatNesteOnClick,
         foreslåVedtakNesteOnClick: foreslåVedtakNesteOnClick,
-        settSubmitRessurs,
     };
 };
 

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/useKompetansePeriodeSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/useKompetansePeriodeSkjema.ts
@@ -36,12 +36,9 @@ interface IProps {
 
 const useKompetansePeriodeSkjema = ({ barnIKompetanse, kompetanse }: IProps) => {
     const [erKompetanseEkspandert, settErKompetanseEkspandert] = useState<boolean>(false);
-    const { åpenBehandling, settÅpenBehandling } = useBehandlingContext();
-    const behandlingId = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.behandlingId : null;
-    const behandlingsÅrsakErOvergangsordning =
-        åpenBehandling.status === RessursStatus.SUKSESS
-            ? åpenBehandling.data.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024
-            : false;
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
+    const behandlingId = behandling.behandlingId;
+    const behandlingsÅrsakErOvergangsordning = behandling.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024;
     const { request } = useHttp();
 
     const initelFom = useFelt<string>({ verdi: kompetanse.fom });

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/useUtenlandskPeriodeBeløpSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/useUtenlandskPeriodeBeløpSkjema.ts
@@ -53,12 +53,9 @@ interface IProps {
 
 const useUtenlandskPeriodeBeløpSkjema = ({ barnIUtenlandskPeriodeBeløp, utenlandskPeriodeBeløp }: IProps) => {
     const [erUtenlandskPeriodeBeløpEkspandert, settErUtenlandskPeriodeBeløpEkspandert] = useState<boolean>(false);
-    const { åpenBehandling, settÅpenBehandling } = useBehandlingContext();
-    const behandlingId = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.behandlingId : null;
-    const behandlingsÅrsakErOvergangsordning =
-        åpenBehandling.status === RessursStatus.SUKSESS
-            ? åpenBehandling.data.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024
-            : false;
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
+    const behandlingId = behandling.behandlingId;
+    const behandlingsÅrsakErOvergangsordning = behandling.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024;
     const initelFom = useFelt<string>({ verdi: utenlandskPeriodeBeløp.fom });
     const { request } = useHttp();
 

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
@@ -67,12 +67,9 @@ interface IProps {
 const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
     const [erValutakursEkspandert, settErValutakursEkspandert] = useState<boolean>(false);
     const [sletterValutakurs, settSletterValutakurs] = useState<boolean>(false);
-    const { åpenBehandling, settÅpenBehandling } = useBehandlingContext();
-    const behandlingId = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.behandlingId : null;
-    const behandlingsÅrsakErOvergangsordning =
-        åpenBehandling.status === RessursStatus.SUKSESS
-            ? åpenBehandling.data.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024
-            : false;
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
+    const behandlingId = behandling.behandlingId;
+    const behandlingsÅrsakErOvergangsordning = behandling.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024;
     const initelFom = useFelt<string>({ verdi: valutakurs.fom });
     const { request } = useHttp();
 

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/OvergangsordningAndel/OvergangsordningAndelContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/OvergangsordningAndel/OvergangsordningAndelContext.tsx
@@ -33,9 +33,9 @@ const OvergangsordningAndelContext = createContext<OvergangsordningAndelContextV
 
 export const OvergangsordningAndelProvider = ({ overgangsordningAndel, children }: Props) => {
     const { request } = useHttp();
-    const { åpenBehandling, settÅpenBehandling } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
 
-    const behandlingId = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.behandlingId : null;
+    const behandlingId = behandling.behandlingId;
 
     const { skjema, kanSendeSkjema, onSubmit, nullstillSkjema } = useSkjema<IOvergangsordningAndelSkjema, IBehandling>({
         felter: {

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/RegistrerSøknad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/RegistrerSøknad.tsx
@@ -14,13 +14,12 @@ import type { IBarnMedOpplysninger } from '../../../../../typer/søknad';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
 const RegistrerSøknad = () => {
-    const { åpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling, vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 
     const { hentFeilTilOppsummering, nesteAction, skjema, søknadErLastetFraBackend } = useSøknadContext();
 
-    const harBrevmottaker =
-        åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.brevmottakere.length > 0 : false;
+    const harBrevmottaker = behandling.brevmottakere.length > 0;
 
     function onLeggTilBarn(barn: IBarnMedOpplysninger) {
         skjema.felter.barnaMedOpplysninger.validerOgSettFelt([...skjema.felter.barnaMedOpplysninger.verdi, barn]);

--- a/src/frontend/sider/Fagsak/Behandling/sider/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Simulering/TilbakekrevingSkjema.tsx
@@ -80,7 +80,7 @@ const TilbakekrevingSkjema = ({
     søkerMålform: Målform;
     harÅpenTilbakekrevingRessurs: Ressurs<boolean>;
 }) => {
-    const { vurderErLesevisning, åpenBehandling } = useBehandlingContext();
+    const { vurderErLesevisning, behandling } = useBehandlingContext();
     const { tilbakekrevingSkjema, hentFeilTilOppsummering, maksLengdeTekst } = useSimuleringContext();
     const { fritekstVarsel, begrunnelse, tilbakekrevingsvalg } = tilbakekrevingSkjema.felter;
 
@@ -231,17 +231,16 @@ const TilbakekrevingSkjema = ({
                                 >
                                     Opprett tilbakekreving, send varsel
                                 </Radio>
-                                {åpenBehandling.status === RessursStatus.SUKSESS &&
-                                    tilbakekrevingsvalg.verdi ===
-                                        Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL && (
-                                        <StyledBrevmottakereAlert
-                                            bruker={bruker}
-                                            erPåBehandling={true}
-                                            erLesevisning={erLesevisning}
-                                            åpenBehandling={åpenBehandling.data}
-                                            brevmottakere={åpenBehandling.data.brevmottakere}
-                                        />
-                                    )}
+                                {tilbakekrevingsvalg.verdi ===
+                                    Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL && (
+                                    <StyledBrevmottakereAlert
+                                        bruker={bruker}
+                                        erPåBehandling={true}
+                                        erLesevisning={erLesevisning}
+                                        åpenBehandling={behandling}
+                                        brevmottakere={behandling.brevmottakere}
+                                    />
+                                )}
                                 {fritekstVarsel.erSynlig && (
                                     <FritekstVarsel>
                                         <Textarea
@@ -297,12 +296,8 @@ const TilbakekrevingSkjema = ({
                                                 variant={'tertiary'}
                                                 id={'forhandsvis-varsel'}
                                                 onClick={() => {
-                                                    if (åpenBehandling.status !== RessursStatus.SUKSESS) {
-                                                        // TODO: Fjern når BehanldingContext alltid har en behandling. Dette burde aldri skje.
-                                                        return;
-                                                    }
                                                     opprettTilbakekrevingVarselBrevPdf({
-                                                        behandlingId: åpenBehandling.data.behandlingId,
+                                                        behandlingId: behandling.behandlingId,
                                                         payload: { fritekst: fritekstVarsel.verdi },
                                                     });
                                                 }}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
@@ -4,7 +4,6 @@ import deepEqual from 'deep-equal';
 import styled from 'styled-components';
 
 import { BodyShort, HStack, Table } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import { AnnenVurderingSkjema } from './AnnenVurderingSkjema';
 import { annenVurderingFeilmeldingId } from './AnnenVurderingTabell';
@@ -28,7 +27,7 @@ const BeskrivelseCelle = styled(BodyShort)`
 `;
 
 const AnnenVurderingTabellRad = ({ person, annenVurderingConfig, annenVurdering }: IProps) => {
-    const { vurderErLesevisning, åpenBehandling } = useBehandlingContext();
+    const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 
     const [ekspandertAnnenVurdering, settEkspandertAnnenVurdering] = useState(
@@ -73,11 +72,7 @@ const AnnenVurderingTabellRad = ({ person, annenVurderingConfig, annenVurdering 
             <Table.DataCell>
                 <ManuellVurdering />
             </Table.DataCell>
-            <Table.DataCell>
-                {åpenBehandling.status === RessursStatus.SUKSESS && annenVurdering.erVurdert
-                    ? 'Vurdert i denne behandlingen'
-                    : ''}
-            </Table.DataCell>
+            <Table.DataCell>{annenVurdering.erVurdert ? 'Vurdert i denne behandlingen' : ''}</Table.DataCell>
         </Table.ExpandableRow>
     );
 };

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårEkspanderbarRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårEkspanderbarRad.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import { CogIcon, CogRotationIcon, PersonIcon } from '@navikt/aksel-icons';
 import { BodyShort, Table } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import { vilkårFeilmeldingId } from './VilkårTabell';
 import VilkårResultatIkon from '../../../../../../ikoner/VilkårResultatIkon';
@@ -34,6 +33,7 @@ const BeskrivelseCelle = styled(BodyShort)`
 
 const VurderingCelle = styled.div`
     display: flex;
+
     svg {
         margin-right: 1rem;
     }
@@ -44,6 +44,7 @@ const FlexDiv = styled.div`
     flex-wrap: nowrap;
     justify-content: flex-start;
     align-items: center;
+
     > div:nth-child(n + 2) {
         padding-left: 0.5rem;
     }
@@ -65,7 +66,7 @@ const StyledPersonIcon = styled(PersonIcon)`
 `;
 
 export const VilkårEkspanderbarRad = ({ toggleForm, children, lagretVilkårResultat, erVilkårEkspandert }: IProps) => {
-    const { åpenBehandling } = useBehandlingContext();
+    const { behandling } = useBehandlingContext();
 
     const periodeErTom = !lagretVilkårResultat.periode.fom && !lagretVilkårResultat.periode.tom;
 
@@ -112,8 +113,8 @@ export const VilkårEkspanderbarRad = ({ toggleForm, children, lagretVilkårResu
                         <StyledPersonIcon title={'Manuell vurdering'} />
                     )}
                     <div>
-                        {åpenBehandling.status === RessursStatus.SUKSESS && lagretVilkårResultat.erVurdert
-                            ? lagretVilkårResultat.behandlingId === åpenBehandling.data.behandlingId
+                        {lagretVilkårResultat.erVurdert
+                            ? lagretVilkårResultat.behandlingId === behandling.behandlingId
                                 ? 'Vurdert i denne behandlingen'
                                 : `Vurdert ${isoStringTilFormatertString({
                                       isoString: lagretVilkårResultat.endretTidspunkt,

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Fieldset, Label, Radio, RadioGroup, Select, Textarea } from '@navikt/ds-react';
 import { ABorderDefault, ASurfaceAction } from '@navikt/ds-tokens/dist/tokens';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import AvslagSkjema from './AvslagSkjema';
 import { UtdypendeVilkårsvurderingMultiselect } from './UtdypendeVilkårsvurderingMultiselect';
@@ -76,9 +75,8 @@ export const VilkårSkjema = <T extends IVilkårSkjemaContext>({
     oppdaterMuligeUtdypendeVilkårsvurderinger,
     settFokusPåLeggTilPeriodeKnapp,
 }: IVilkårSkjema<T>) => {
-    const { åpenBehandling } = useBehandlingContext();
-    const årsakErSøknad =
-        åpenBehandling.status !== RessursStatus.SUKSESS || åpenBehandling.data.årsak === BehandlingÅrsak.SØKNAD;
+    const { behandling } = useBehandlingContext();
+    const årsakErSøknad = behandling.årsak === BehandlingÅrsak.SØKNAD;
     const { skjema, lagreVilkår, lagrerVilkår, slettVilkår, sletterVilkår, feilmelding, nullstillSkjema } =
         vilkårSkjemaContext;
 

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/useVilkårsvurderingApi.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/useVilkårsvurderingApi.ts
@@ -11,14 +11,14 @@ import type {
     IRestNyttVilkår,
     VilkårType,
 } from '../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+import { useBehandlingContext } from '../../context/BehandlingContext';
 
 export const useVilkårsvurderingApi = () => {
     const { request } = useHttp();
 
-    const { åpenBehandling, settÅpenBehandling } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
 
-    const behandlingId = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.behandlingId : null;
+    const behandlingId = behandling.behandlingId;
 
     const [lagrerVilkår, settLagrerVilkår] = useState<boolean>(false);
     const [lagreVilkårFeilmelding, settLagreVilkårFeilmelding] = useState<string>('');

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -17,6 +17,7 @@ import { useFagsakId } from '../../hooks/useFagsakId';
 import { useHentFagsak } from '../../hooks/useHentFagsak';
 import { useScrollTilAnker } from '../../hooks/useScrollTilAnker';
 import type { IMinimalFagsak } from '../../typer/fagsak';
+import { HentOgSettBehandlingProvider } from './Behandling/context/HentOgSettBehandlingContext';
 
 const Innhold = styled.div`
     height: calc(100vh - 3rem);
@@ -73,7 +74,11 @@ const FagsakContainerInnhold = ({ minimalFagsak }: { minimalFagsak: IMinimalFags
 
                                 <Route
                                     path="/:behandlingId/*"
-                                    element={<BehandlingContainer bruker={bruker.data} minimalFagsak={minimalFagsak} />}
+                                    element={
+                                        <HentOgSettBehandlingProvider fagsak={minimalFagsak}>
+                                            <BehandlingContainer bruker={bruker.data} minimalFagsak={minimalFagsak} />
+                                        </HentOgSettBehandlingProvider>
+                                    }
                                 />
                                 <Route
                                     path="/"

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/Behandlingsmeny.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/Behandlingsmeny.tsx
@@ -2,16 +2,15 @@ import styled from 'styled-components';
 
 import { ChevronDownIcon } from '@navikt/aksel-icons';
 import { Button, Dropdown } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import MenyvalgFagsak from './MenyvalgFagsak';
 import MenyvalgBehandling from './OpprettFagsak/MenyvalgBehandling';
-import { BehandlingStatus } from '../../../../typer/behandling';
+import { BehandlingStatus, type IBehandling } from '../../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../../typer/fagsak';
-import { useBehandlingContext } from '../../Behandling/context/BehandlingContext';
 
 interface IProps {
     minimalFagsak: IMinimalFagsak;
+    behandling?: IBehandling;
 }
 
 const PosisjonertMenyknapp = styled(Button)`
@@ -22,11 +21,8 @@ const StyledDropdownMenu = styled(Dropdown.Menu)`
     width: 30ch;
 `;
 
-const Behandlingsmeny = ({ minimalFagsak }: IProps) => {
-    const { åpenBehandling } = useBehandlingContext();
-
-    const skalViseMenyvalgForBehandling =
-        åpenBehandling.status === RessursStatus.SUKSESS && åpenBehandling.data.status !== BehandlingStatus.AVSLUTTET;
+const Behandlingsmeny = ({ minimalFagsak, behandling }: IProps) => {
+    const skalViseMenyvalgForBehandling = behandling && behandling.status !== BehandlingStatus.AVSLUTTET;
 
     return (
         <Dropdown>
@@ -44,7 +40,7 @@ const Behandlingsmeny = ({ minimalFagsak }: IProps) => {
                     <MenyvalgFagsak minimalFagsak={minimalFagsak} />
                     {skalViseMenyvalgForBehandling && <Dropdown.Menu.Divider />}
                     {skalViseMenyvalgForBehandling && (
-                        <MenyvalgBehandling minimalFagsak={minimalFagsak} åpenBehandling={åpenBehandling.data} />
+                        <MenyvalgBehandling minimalFagsak={minimalFagsak} behandling={behandling} />
                     )}
                 </Dropdown.Menu.List>
             </StyledDropdownMenu>

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -1,7 +1,7 @@
 import { type ChangeEvent, useState } from 'react';
 
 import { Button, Dropdown, Fieldset, Modal, Select, Textarea } from '@navikt/ds-react';
-import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
+import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
 import useEndreBehandlendeEnhet from './useEndreBehandlendeEnhet';
 import { useAppContext } from '../../../../../context/AppContext';
@@ -12,7 +12,7 @@ import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
 import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
 
 const EndreBehandlendeEnhet = () => {
-    const { åpenBehandling, vurderErLesevisning, erBehandleneEnhetMidlertidig } = useBehandlingContext();
+    const { behandling, vurderErLesevisning, erBehandleneEnhetMidlertidig } = useBehandlingContext();
     const [visModal, settVisModal] = useState(erBehandleneEnhetMidlertidig);
     const { innloggetSaksbehandler } = useAppContext();
 
@@ -33,12 +33,11 @@ const EndreBehandlendeEnhet = () => {
     };
 
     const erLesevisningPåBehandling = () => {
-        const åpenBehandlingData = hentDataFraRessurs(åpenBehandling);
-        const steg = åpenBehandlingData?.steg;
+        const steg = behandling.steg;
         if (
             steg &&
             hentStegNummer(steg) === hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK) &&
-            innloggetSaksbehandler?.navIdent !== åpenBehandlingData?.totrinnskontroll?.saksbehandlerId
+            innloggetSaksbehandler?.navIdent !== behandling.totrinnskontroll?.saksbehandlerId
         ) {
             return false;
         } else {
@@ -81,8 +80,8 @@ const EndreBehandlendeEnhet = () => {
                                             key={enhet.enhetId}
                                             value={enhet.enhetId}
                                             disabled={
-                                                hentDataFraRessurs(åpenBehandling)?.arbeidsfordelingPåBehandling
-                                                    .behandlendeEnhetId === enhet.enhetId
+                                                behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId ===
+                                                enhet.enhetId
                                             }
                                         >
                                             {`${enhet.enhetId} ${enhet.enhetNavn}`}
@@ -110,11 +109,7 @@ const EndreBehandlendeEnhet = () => {
                             variant="primary"
                             size="small"
                             disabled={submitRessurs.status === RessursStatus.HENTER}
-                            onClick={() => {
-                                if (åpenBehandling.status === RessursStatus.SUKSESS) {
-                                    endreEnhet(åpenBehandling.data.behandlingId);
-                                }
-                            }}
+                            onClick={() => endreEnhet(behandling.behandlingId)}
                             children={'Bekreft'}
                             loading={submitRessurs.status === RessursStatus.HENTER}
                         />

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandlendeEnhet/useEndreBehandlendeEnhet.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandlendeEnhet/useEndreBehandlendeEnhet.ts
@@ -10,7 +10,7 @@ import { useBehandlingContext } from '../../../Behandling/context/BehandlingCont
 
 const useEndreBehandlendeEnhet = (lukkModal: () => void) => {
     const { request } = useHttp();
-    const { åpenBehandling, settÅpenBehandling } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
 
     const [enhetId, settEnhetId] = useState<string | undefined>(undefined);
     const [begrunnelse, settBegrunnelse] = useState('');
@@ -18,12 +18,10 @@ const useEndreBehandlendeEnhet = (lukkModal: () => void) => {
     const [submitRessurs, settSubmitRessurs] = useState(byggTomRessurs());
 
     useEffect(() => {
-        if (åpenBehandling.status === RessursStatus.SUKSESS) {
-            settEnhetId(åpenBehandling.data.arbeidsfordelingPåBehandling.behandlendeEnhetId);
-            settBegrunnelse('');
-            settSubmitRessurs(byggTomRessurs());
-        }
-    }, [åpenBehandling]);
+        settEnhetId(behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId);
+        settBegrunnelse('');
+        settSubmitRessurs(byggTomRessurs());
+    }, [behandling]);
 
     const endreEnhet = (behandlingId: number) => {
         if (begrunnelse === '') {
@@ -56,11 +54,7 @@ const useEndreBehandlendeEnhet = (lukkModal: () => void) => {
     };
 
     const fjernState = () => {
-        settEnhetId(
-            åpenBehandling.status === RessursStatus.SUKSESS
-                ? åpenBehandling.data.arbeidsfordelingPåBehandling.behandlendeEnhetId
-                : undefined
-        );
+        settEnhetId(behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId);
         settBegrunnelse('');
         settSubmitRessurs(byggTomRessurs());
     };

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstema.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstema.tsx
@@ -14,7 +14,7 @@ const EndreBehandlingstema = () => {
         settVisModal(false)
     );
 
-    const { vurderErLesevisning, åpenBehandling } = useBehandlingContext();
+    const { vurderErLesevisning, behandling } = useBehandlingContext();
 
     const lukkEndreBehandlingModal = () => {
         nullstillSkjema();
@@ -52,11 +52,7 @@ const EndreBehandlingstema = () => {
                             key={'bekreft'}
                             variant="primary"
                             size="small"
-                            onClick={() => {
-                                if (åpenBehandling.status === RessursStatus.SUKSESS) {
-                                    endreBehandlingstema(åpenBehandling.data.behandlingId);
-                                }
-                            }}
+                            onClick={() => endreBehandlingstema(behandling.behandlingId)}
                             children={'Bekreft'}
                             loading={ressurs.status === RessursStatus.HENTER}
                         />

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/useEndreBehandlingstema.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/useEndreBehandlingstema.ts
@@ -13,7 +13,7 @@ import { useBehandlingContext } from '../../../Behandling/context/BehandlingCont
 
 const useEndreBehandling = (lukkModal: () => void) => {
     const { request } = useHttp();
-    const { åpenBehandling, settÅpenBehandling } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
 
     const [ressurs, settRessurs] = useState(byggTomRessurs());
 
@@ -30,7 +30,7 @@ const useEndreBehandling = (lukkModal: () => void) => {
 
     useEffect(() => {
         nullstillSkjema();
-    }, [åpenBehandling]);
+    }, [behandling]);
 
     const endreBehandlingstema = (behandlingId: number) => {
         const { behandlingstema } = skjema.felter;
@@ -53,10 +53,8 @@ const useEndreBehandling = (lukkModal: () => void) => {
     };
 
     const nullstillSkjema = () => {
-        if (åpenBehandling.status === RessursStatus.SUKSESS) {
-            const { kategori } = åpenBehandling.data;
-            skjema.felter.behandlingstema.validerOgSettFelt(tilBehandlingstema(kategori));
-        }
+        const { kategori } = behandling;
+        skjema.felter.behandlingstema.validerOgSettFelt(tilBehandlingstema(kategori));
     };
 
     return {

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/ForhåndsvisBrevLenke.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/ForhåndsvisBrevLenke.tsx
@@ -1,5 +1,4 @@
 import { Link } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import { ModalType } from '../../../../../context/ModalContext';
 import { useModal } from '../../../../../hooks/useModal';
@@ -23,7 +22,7 @@ function lagRequestPayload(mottakerIdent: string): IManueltBrevRequestPåBehandl
 
 export function ForhåndsvisBrevLenke() {
     const { fagsak } = useFagsakContext();
-    const { åpenBehandling } = useBehandlingContext();
+    const { behandling } = useBehandlingContext();
 
     const { åpneModal: åpneForhåndsvisOpprettingAvPdfModal } = useModal(ModalType.FORHÅNDSVIS_OPPRETTING_AV_PDF);
 
@@ -32,13 +31,9 @@ export function ForhåndsvisBrevLenke() {
     });
 
     function forhåndsvisBrev() {
-        if (åpenBehandling.status !== RessursStatus.SUKSESS) {
-            // TODO : Fjern når BehandlingContext får innsendt en behandling fra react-query. Dette skal aldri skje
-            return;
-        }
         if (!isPending) {
             mutate({
-                behandlingId: åpenBehandling.data.behandlingId,
+                behandlingId: behandling.behandlingId,
                 payload: lagRequestPayload(fagsak.søkerFødselsnummer),
             });
         }

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
@@ -1,5 +1,4 @@
 import { Dropdown } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import { useAppContext } from '../../../../../context/AppContext';
 import { ModalType } from '../../../../../context/ModalContext';
@@ -10,10 +9,8 @@ import { useBehandlingContext } from '../../../Behandling/context/BehandlingCont
 
 export function HenleggBehandling() {
     const { toggles } = useAppContext();
-    const { åpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling, vurderErLesevisning } = useBehandlingContext();
     const { åpneModal } = useModal(ModalType.HENLEGG_BEHANDLING);
-
-    const behandling = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data : undefined;
 
     const harTilgangTilTekniskVedlikeholdHenleggelse = toggles[ToggleNavn.tekniskVedlikeholdHenleggelse];
 

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/useHenleggBehandlingForm.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/useHenleggBehandlingForm.ts
@@ -1,6 +1,6 @@
 import { type FieldErrors, useForm } from 'react-hook-form';
 
-import { byggSuksessRessurs, RessursStatus } from '@navikt/familie-typer';
+import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { ModalType } from '../../../../../context/ModalContext';
 import { useHenleggBehandling } from '../../../../../hooks/useHenleggBehandling';
@@ -34,7 +34,7 @@ export interface HenleggBehandlingFormValues {
 export const HENLEGG_BEHANDLING_FORM_ID = 'henlegg_behandling_modal_form';
 
 export function useHenleggBehandlingForm() {
-    const { åpenBehandling, settÅpenBehandling } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
 
     const { lukkModal } = useModal(ModalType.HENLEGG_BEHANDLING);
     const { åpneModal } = useModal(ModalType.HENLEGG_BEHANDLING_VEIVALG);
@@ -58,13 +58,6 @@ export function useHenleggBehandlingForm() {
             });
             return;
         }
-        if (åpenBehandling.status !== RessursStatus.SUKSESS) {
-            setError(HenleggBehandlingServerErrors.onSubmitError.id, {
-                message: 'Mangler behandling.',
-            });
-            return;
-        }
-        const behandling = åpenBehandling.data;
         return mutateAsync({ behandling, årsak, begrunnelse })
             .then(behandling => {
                 settÅpenBehandling(byggSuksessRessurs(behandling));

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/ÅrsakFelt.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/ÅrsakFelt.tsx
@@ -1,7 +1,6 @@
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Select } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import { HenleggBehandlingFormFields, type HenleggBehandlingFormValues } from './useHenleggBehandlingForm';
 import { useAppContext } from '../../../../../context/AppContext';
@@ -10,9 +9,7 @@ import { ToggleNavn } from '../../../../../typer/toggles';
 import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
 
 export function ÅrsakFelt() {
-    const { åpenBehandling } = useBehandlingContext();
-
-    const behandling = åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data : undefined;
+    const { behandling } = useBehandlingContext();
 
     const { toggles } = useAppContext();
 
@@ -26,22 +23,19 @@ export function ÅrsakFelt() {
 
     const harTilgangTilTekniskVedlikeholdHenleggelse = toggles[ToggleNavn.tekniskVedlikeholdHenleggelse];
 
-    const valgmuligheter =
-        behandling !== undefined
-            ? Object.values(HenleggÅrsak)
-                  .filter(
-                      årsak =>
-                          (årsak !== HenleggÅrsak.TEKNISK_VEDLIKEHOLD && erPåHenleggbartSteg(behandling.steg)) ||
-                          (årsak === HenleggÅrsak.TEKNISK_VEDLIKEHOLD && harTilgangTilTekniskVedlikeholdHenleggelse)
-                  )
-                  .map(årsak => {
-                      return (
-                          <option key={årsak} aria-selected={field.value === årsak} value={årsak}>
-                              {henleggÅrsak[årsak]}
-                          </option>
-                      );
-                  })
-            : [];
+    const valgmuligheter = Object.values(HenleggÅrsak)
+        .filter(
+            årsak =>
+                (årsak !== HenleggÅrsak.TEKNISK_VEDLIKEHOLD && erPåHenleggbartSteg(behandling.steg)) ||
+                (årsak === HenleggÅrsak.TEKNISK_VEDLIKEHOLD && harTilgangTilTekniskVedlikeholdHenleggelse)
+        )
+        .map(årsak => {
+            return (
+                <option key={årsak} aria-selected={field.value === årsak} value={årsak}>
+                    {henleggÅrsak[årsak]}
+                </option>
+            );
+        });
 
     return (
         <Select

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -20,7 +20,6 @@ import { Klagebehandlingstype } from '../../../../../typer/klage';
 import { Tilbakekrevingsbehandlingstype } from '../../../../../typer/tilbakekrevingsbehandling';
 import type { IsoDatoString } from '../../../../../utils/dato';
 import { dateTilIsoDatoString, dateTilIsoDatoStringEllerUndefined, validerGyldigDato } from '../../../../../utils/dato';
-import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
 import { useFagsakContext } from '../../../FagsakContext';
 
 interface IOpprettBehandlingSkjemaFelter {
@@ -39,7 +38,6 @@ const useOpprettBehandling = ({
     onOpprettTilbakekrevingSuccess: () => void;
 }) => {
     const { fagsakId } = useSakOgBehandlingParams();
-    const { settÅpenBehandling } = useBehandlingContext();
     const { fagsak, bruker: brukerRessurs } = useFagsakContext();
     const { innloggetSaksbehandler } = useAppContext();
     const queryClient = useQueryClient();
@@ -192,7 +190,6 @@ const useOpprettBehandling = ({
                         queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id),
                     });
 
-                    settÅpenBehandling(response);
                     const behandling: IBehandling | undefined = hentDataFraRessurs(response);
 
                     if (behandling && behandling.årsak === BehandlingÅrsak.SØKNAD) {

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -177,7 +177,7 @@ const useOpprettBehandling = ({
                 method: 'POST',
                 url: '/familie-ks-sak/api/behandlinger',
             },
-            response => {
+            async response => {
                 if (response.status === RessursStatus.SUKSESS) {
                     lukkModal();
                     nullstillSkjema();
@@ -186,9 +186,7 @@ const useOpprettBehandling = ({
                         queryKey: HentKontantstøttebehandlingerQueryKeyFactory.kontantstøttebehandlinger(fagsak.id),
                     });
 
-                    queryClient.invalidateQueries({
-                        queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id),
-                    });
+                    await queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id) });
 
                     const behandling = response.data;
 

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
+import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useAppContext } from '../../../../../context/AppContext';
 import { HentFagsakQueryKeyFactory } from '../../../../../hooks/useHentFagsak';
@@ -190,12 +190,12 @@ const useOpprettBehandling = ({
                         queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id),
                     });
 
-                    const behandling: IBehandling | undefined = hentDataFraRessurs(response);
+                    const behandling = response.data;
 
-                    if (behandling && behandling.årsak === BehandlingÅrsak.SØKNAD) {
-                        navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-soknad`);
+                    if (behandling.årsak === BehandlingÅrsak.SØKNAD) {
+                        navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/registrer-soknad`);
                     } else {
-                        navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`);
+                        navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/vilkaarsvurdering`);
                     }
                 }
             }

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettFagsak/MenyvalgBehandling.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettFagsak/MenyvalgBehandling.tsx
@@ -13,10 +13,10 @@ import { LeggTilEllerFjernBrevmottakere } from '../LeggTilEllerFjernBrevmottaker
 
 interface IProps {
     minimalFagsak: IMinimalFagsak;
-    åpenBehandling: IBehandling;
+    behandling: IBehandling;
 }
 
-const MenyvalgBehandling = ({ minimalFagsak, åpenBehandling }: IProps) => {
+const MenyvalgBehandling = ({ minimalFagsak, behandling }: IProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
 
     const erLesevisning = vurderErLesevisning();
@@ -27,23 +27,21 @@ const MenyvalgBehandling = ({ minimalFagsak, åpenBehandling }: IProps) => {
             <EndreBehandlingstema />
             <HenleggBehandling />
             {!erLesevisning &&
-                (åpenBehandling.årsak === BehandlingÅrsak.NYE_OPPLYSNINGER ||
-                    åpenBehandling.årsak === BehandlingÅrsak.KLAGE ||
-                    åpenBehandling.årsak === BehandlingÅrsak.IVERKSETTE_KA_VEDTAK ||
-                    åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV) && (
-                    <LeggTiLBarnPåBehandling behandling={åpenBehandling} />
+                (behandling.årsak === BehandlingÅrsak.NYE_OPPLYSNINGER ||
+                    behandling.årsak === BehandlingÅrsak.KLAGE ||
+                    behandling.årsak === BehandlingÅrsak.IVERKSETTE_KA_VEDTAK ||
+                    behandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV) && (
+                    <LeggTiLBarnPåBehandling behandling={behandling} />
                 )}
-            {åpenBehandling.status === BehandlingStatus.UTREDES && (
-                <SettEllerOppdaterVenting behandling={åpenBehandling} />
-            )}
-            {åpenBehandling.behandlingPåVent && <TaBehandlingAvVent behandling={åpenBehandling} />}
+            {behandling.status === BehandlingStatus.UTREDES && <SettEllerOppdaterVenting behandling={behandling} />}
+            {behandling.behandlingPåVent && <TaBehandlingAvVent behandling={behandling} />}
 
-            {(!erLesevisning || åpenBehandling.brevmottakere.length > 0) &&
-                (åpenBehandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING ||
-                    åpenBehandling.type === Behandlingstype.REVURDERING) && (
+            {(!erLesevisning || behandling.brevmottakere.length > 0) &&
+                (behandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING ||
+                    behandling.type === Behandlingstype.REVURDERING) && (
                     <LeggTilEllerFjernBrevmottakere
                         erPåBehandling={true}
-                        behandling={åpenBehandling}
+                        behandling={behandling}
                         erLesevisning={erLesevisning}
                     />
                 )}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Fagsaklinje.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Fagsaklinje.tsx
@@ -5,10 +5,12 @@ import { Box, Button, HStack } from '@navikt/ds-react';
 
 import Behandlingsmeny from './Behandlingsmeny/Behandlingsmeny';
 import { useAppContext } from '../../../context/AppContext';
+import type { IBehandling } from '../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 
 interface FagsaklinjeProps {
     minimalFagsak: IMinimalFagsak;
+    behandling?: IBehandling;
 }
 
 const aktivFaneStyle = (fanenavn: string, pathname: string) => {
@@ -17,7 +19,7 @@ const aktivFaneStyle = (fanenavn: string, pathname: string) => {
     return sluttenPåUrl === fanenavn ? { textDecoration: 'underline' } : {};
 };
 
-export const Fagsaklinje = ({ minimalFagsak }: FagsaklinjeProps) => {
+export const Fagsaklinje = ({ minimalFagsak, behandling }: FagsaklinjeProps) => {
     const { pathname } = useLocation();
     const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
     return (
@@ -48,7 +50,9 @@ export const Fagsaklinje = ({ minimalFagsak }: FagsaklinjeProps) => {
                             </Button>
                         </HStack>
                     )}
-                    {harInnloggetSaksbehandlerSkrivetilgang() && <Behandlingsmeny minimalFagsak={minimalFagsak} />}
+                    {harInnloggetSaksbehandlerSkrivetilgang() && (
+                        <Behandlingsmeny minimalFagsak={minimalFagsak} behandling={behandling} />
+                    )}
                 </HStack>
             </Box>
         </>

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -1,10 +1,7 @@
-import { useEffect } from 'react';
-
 import { addMonths, differenceInMilliseconds, startOfMonth } from 'date-fns';
 import { Link as ReactRouterLink } from 'react-router';
 
 import { Alert, Box, Heading, Link, VStack } from '@navikt/ds-react';
-import { byggTomRessurs } from '@navikt/familie-typer';
 
 import { Behandlinger } from './Behandlinger';
 import FagsakLenkepanel, { SaksoversiktPanelBredde } from './FagsakLenkepanel';
@@ -24,19 +21,12 @@ import {
     periodeOverlapperMedValgtDato,
 } from '../../../utils/dato';
 import { hentAktivBehandlingPåMinimalFagsak } from '../../../utils/fagsak';
-import { useBehandlingContext } from '../Behandling/context/BehandlingContext';
 
 interface IProps {
     minimalFagsak: IMinimalFagsak;
 }
 
 export function Saksoversikt({ minimalFagsak }: IProps) {
-    const { settÅpenBehandling } = useBehandlingContext();
-
-    useEffect(() => {
-        settÅpenBehandling(byggTomRessurs(), false);
-    }, [minimalFagsak.status]);
-
     const iverksatteBehandlinger = minimalFagsak.behandlinger.filter(
         (behandling: VisningBehandling) =>
             behandling.status === BehandlingStatus.AVSLUTTET && !erBehandlingHenlagt(behandling.resultat)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26159

- Flytter `BehandlingProvider` til `BehandlingContainer` for å gjøre det likere ba-sak-frontend.
- Introdusere `HentOgSettBehandlingProvider` for å hente og sette behandling, likt det som er gjort i ba-sak. 
- Omdøper `åpenBehandling` til `behandling`
- Fjerner en del logikk knyttet til at `åpenBehandling` tidligere var en `Ressurs<IBehandling>` mens nå kun er av typen `IBehandling`. 

På sikt burde `HentOgSettBehandlingProvider` ersattes med react-query, men det får bli i en annen PR. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Skal ikke være noen visuelle endringer.