### PR TITLE
oppdater opprett behandling funksjoner til å invalidate hente queries

### DIFF
--- a/src/frontend/hooks/useHentKlagebehandlinger.ts
+++ b/src/frontend/hooks/useHentKlagebehandlinger.ts
@@ -5,13 +5,14 @@ import { useHttp } from '@navikt/familie-http';
 import { hentKlagebehandlinger } from '../api/hentKlagebehandlinger';
 
 export const HentKlagebehandlingerQueryKeyFactory = {
-    fagsak: (fagsakId: number | undefined) => ['klagebehandlinger', fagsakId],
+    // TODO : Fjern "undefined" når FagsakContext alltid inneholder en fagsak
+    klagebehandlinger: (fagsakId: number | undefined) => ['klagebehandlinger', fagsakId],
 };
 
 export function useHentKlagebehandlinger(fagsakId: number) {
     const { request } = useHttp();
     return useQuery({
-        queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId),
+        queryKey: HentKlagebehandlingerQueryKeyFactory.klagebehandlinger(fagsakId),
         queryFn: () => hentKlagebehandlinger(request, fagsakId),
     });
 }

--- a/src/frontend/hooks/useHentKontantstøttebehandlinger.ts
+++ b/src/frontend/hooks/useHentKontantstøttebehandlinger.ts
@@ -4,14 +4,15 @@ import { useHttp } from '@navikt/familie-http';
 
 import { hentKontantstøtteBehandlinger } from '../api/hentKontantstøtteBehandlinger';
 
-export const HentBehandlingerQueryKeyFactory = {
-    fagsak: (fagsakId: number | undefined) => ['visningsBehandlinger', fagsakId],
+export const HentKontantstøttebehandlingerQueryKeyFactory = {
+    // TODO : Fjern "undefined" når FagsakContext alltid inneholder en fagsak
+    kontantstøttebehandlinger: (fagsakId: number | undefined) => ['kontantstøttebehandlinger', fagsakId],
 };
 
-export function useHentKontantstøtteBehandlinger(fagsakId: number | undefined, påvirkerSystemLaster: boolean = true) {
+export function useHentKontantstøttebehandlinger(fagsakId: number | undefined, påvirkerSystemLaster: boolean = true) {
     const { request } = useHttp();
     return useQuery({
-        queryKey: HentBehandlingerQueryKeyFactory.fagsak(fagsakId),
+        queryKey: HentKontantstøttebehandlingerQueryKeyFactory.kontantstøttebehandlinger(fagsakId),
         queryFn: () => {
             if (fagsakId === undefined) {
                 return Promise.reject(new Error('Kan ikke hente fagsak uten fagsakId.'));

--- a/src/frontend/hooks/useHentTilbakekrevingsbehandlinger.ts
+++ b/src/frontend/hooks/useHentTilbakekrevingsbehandlinger.ts
@@ -5,7 +5,7 @@ import { useHttp } from '@navikt/familie-http';
 import { hentTilbakekrevingsbehandlinger } from '../api/hentTilbakekrevingsbehandlinger';
 
 export const HentTilbakekrevingsbehandlingerQueryKeyFactory = {
-    fagsak: (fagsakId: number) => ['tilbakekrevingsbehandlinger', fagsakId],
+    fagsak: (fagsakId: number | undefined) => ['tilbakekrevingsbehandlinger', fagsakId],
 };
 
 export function useHentTilbakekrevingsbehandlinger(fagsakId: number) {

--- a/src/frontend/hooks/useHentTilbakekrevingsbehandlinger.ts
+++ b/src/frontend/hooks/useHentTilbakekrevingsbehandlinger.ts
@@ -5,13 +5,14 @@ import { useHttp } from '@navikt/familie-http';
 import { hentTilbakekrevingsbehandlinger } from '../api/hentTilbakekrevingsbehandlinger';
 
 export const HentTilbakekrevingsbehandlingerQueryKeyFactory = {
-    fagsak: (fagsakId: number | undefined) => ['tilbakekrevingsbehandlinger', fagsakId],
+    // TODO : Fjern "undefined" når FagsakContext alltid inneholder en fagsak
+    tilbakekrevingsbehandlinger: (fagsakId: number | undefined) => ['tilbakekrevingsbehandlinger', fagsakId],
 };
 
 export function useHentTilbakekrevingsbehandlinger(fagsakId: number) {
     const { request } = useHttp();
     return useQuery({
-        queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakId),
+        queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.tilbakekrevingsbehandlinger(fagsakId),
         queryFn: () => hentTilbakekrevingsbehandlinger(request, fagsakId),
     });
 }

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -11,7 +11,7 @@ import { useAppContext } from '../../../../../context/AppContext';
 import { useFagsakContext } from '../../../../../context/fagsak/FagsakContext';
 import { HentFagsakQueryKeyFactory } from '../../../../../hooks/useHentFagsak';
 import { HentKlagebehandlingerQueryKeyFactory } from '../../../../../hooks/useHentKlagebehandlinger';
-import { HentBehandlingerQueryKeyFactory } from '../../../../../hooks/useHentKontantstøtteBehandlinger';
+import { HentKontantstøttebehandlingerQueryKeyFactory } from '../../../../../hooks/useHentKontantstøttebehandlinger';
 import { HentTilbakekrevingsbehandlingerQueryKeyFactory } from '../../../../../hooks/useHentTilbakekrevingsbehandlinger';
 import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling, IRestNyBehandling } from '../../../../../typer/behandling';
@@ -40,14 +40,11 @@ const useOpprettBehandling = ({
 }) => {
     const { fagsakId } = useSakOgBehandlingParams();
     const { settÅpenBehandling } = useBehandlingContext();
-    const { bruker: brukerRessurs } = useFagsakContext();
+    const { minimalFagsak, bruker: brukerRessurs } = useFagsakContext();
     const { innloggetSaksbehandler } = useAppContext();
     const { oppdaterKlagebehandlingerPåFagsak } = useFagsakContext();
     const queryClient = useQueryClient();
     const navigate = useNavigate();
-
-    const erFagsakIdTall = fagsakId !== undefined && !isNaN(Number(fagsakId));
-    const fagsakIdTall = erFagsakIdTall ? Number(fagsakId) : undefined;
 
     const bruker = brukerRessurs.status === RessursStatus.SUKSESS ? brukerRessurs.data : undefined;
 
@@ -144,7 +141,7 @@ const useOpprettBehandling = ({
                     lukkModal();
                     nullstillSkjema();
                     queryClient.invalidateQueries({
-                        queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakIdTall),
+                        queryKey: HentKlagebehandlingerQueryKeyFactory.klagebehandlinger(minimalFagsak?.id),
                     });
                 }
             }
@@ -163,7 +160,9 @@ const useOpprettBehandling = ({
                     nullstillSkjemaStatus();
                     onOpprettTilbakekrevingSuccess();
                     queryClient.invalidateQueries({
-                        queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakIdTall),
+                        queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.tilbakekrevingsbehandlinger(
+                            minimalFagsak?.id
+                        ),
                     });
                 }
             }
@@ -188,11 +187,15 @@ const useOpprettBehandling = ({
                 if (response.status === RessursStatus.SUKSESS) {
                     lukkModal();
                     nullstillSkjema();
+
                     queryClient.invalidateQueries({
-                        queryKey: HentBehandlingerQueryKeyFactory.fagsak(fagsakIdTall),
+                        queryKey: HentKontantstøttebehandlingerQueryKeyFactory.kontantstøttebehandlinger(
+                            minimalFagsak?.id
+                        ),
                     });
+
                     queryClient.invalidateQueries({
-                        queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakIdTall),
+                        queryKey: HentFagsakQueryKeyFactory.fagsak(minimalFagsak?.id),
                     });
 
                     settÅpenBehandling(response);

--- a/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -9,7 +9,7 @@ import styles from './Behandlinger.module.css';
 import type { Saksoversiktsbehandling } from './utils';
 import { hentBehandlingerTilSaksoversikten, hentBehandlingId, hentTidspunktForSortering, skalRadVises } from './utils';
 import { useHentKlagebehandlinger } from '../../../hooks/useHentKlagebehandlinger';
-import { useHentKontantstøtteBehandlinger } from '../../../hooks/useHentKontantstøtteBehandlinger';
+import { useHentKontantstøttebehandlinger } from '../../../hooks/useHentKontantstøttebehandlinger';
 import { useHentTilbakekrevingsbehandlinger } from '../../../hooks/useHentTilbakekrevingsbehandlinger';
 import { isoStringTilDate } from '../../../utils/dato';
 
@@ -37,10 +37,10 @@ export function Behandlinger({ fagsakId }: Props) {
     const [visHenlagteBehandlinger, setVisHenlagteBehandlinger] = useState(false);
 
     const {
-        data: kontantstøtteBehandlinger,
-        isPending: hentKontantstøtteBehandlingerLaster,
-        error: hentKontantstøtteBehandlingerError,
-    } = useHentKontantstøtteBehandlinger(fagsakId);
+        data: kontantstøttebehandlinger,
+        isPending: hentKontantstøttebehandlingerLaster,
+        error: hentKontantstøttebehandlingerError,
+    } = useHentKontantstøttebehandlinger(fagsakId);
 
     const {
         data: klagebehandlinger,
@@ -55,7 +55,7 @@ export function Behandlinger({ fagsakId }: Props) {
     } = useHentTilbakekrevingsbehandlinger(fagsakId);
 
     const behandlingerLaster =
-        hentKlagebehandlingLaster || hentTilbakekrevingsbehandlingerLaster || hentKontantstøtteBehandlingerLaster;
+        hentKlagebehandlingLaster || hentTilbakekrevingsbehandlingerLaster || hentKontantstøttebehandlingerLaster;
 
     if (behandlingerLaster) {
         return (
@@ -74,7 +74,7 @@ export function Behandlinger({ fagsakId }: Props) {
         );
     }
     const saksoversiktbehandlinger = hentBehandlingerTilSaksoversikten(
-        kontantstøtteBehandlinger ?? [],
+        kontantstøttebehandlinger ?? [],
         klagebehandlinger ?? [],
         tilbakekrevingsbehandlinger ?? []
     );
@@ -85,34 +85,46 @@ export function Behandlinger({ fagsakId }: Props) {
 
     return (
         <VStack gap="6">
-            {hentKontantstøtteBehandlingerError !== null && (
+            {hentKontantstøttebehandlingerError !== null && (
                 <Alert variant="warning">
-                    <BodyShort>Fagsaken er ikke tilgjengelig for øyeblikket.</BodyShort>
+                    <VStack gap={'4'}>
+                        <BodyShort>Kontantstøttebehandlinger er ikke tilgjengelig for øyeblikket.</BodyShort>
+                        {hentKontantstøttebehandlingerError.message && (
+                            <BodyShort>Feilmelding: {hentKontantstøttebehandlingerError.message}</BodyShort>
+                        )}
+                    </VStack>
                 </Alert>
             )}
             {hentKlagebehandlingError !== null && (
                 <Alert variant="warning">
-                    <BodyShort>Klagebehandlinger er ikke tilgjengelig for øyeblikket.</BodyShort>
+                    <VStack gap={'4'}>
+                        <BodyShort>Klagebehandlinger er ikke tilgjengelig for øyeblikket.</BodyShort>
+                        {hentKlagebehandlingError.message && (
+                            <BodyShort>Feilmelding: {hentKlagebehandlingError.message}</BodyShort>
+                        )}
+                    </VStack>
                 </Alert>
             )}
             {hentTilbakekrevingsbehandlingerError !== null && (
                 <Alert variant="warning">
-                    <BodyShort>Tilbakekreving er ikke tilgjengelig for øyeblikket.</BodyShort>
+                    <VStack gap={'4'}>
+                        <BodyShort>Tilbakekrevingsbehandlinger er ikke tilgjengelig for øyeblikket.</BodyShort>
+                        {hentTilbakekrevingsbehandlingerError.message && (
+                            <BodyShort>Feilmelding: {hentTilbakekrevingsbehandlingerError.message}</BodyShort>
+                        )}
+                    </VStack>
                 </Alert>
             )}
             <div>
-                <Heading level="2" size={'medium'} spacing>
+                <Heading level="2" size={'medium'} spacing={true}>
                     Behandlinger
                     {finnesRadSomKanFiltreresBort && (
                         <Switch
-                            size="small"
+                            size={'small'}
                             className={styles.switchHøyre}
-                            position="left"
-                            id={'vis-henlagte-behandlinger'}
+                            position={'left'}
                             checked={visHenlagteBehandlinger}
-                            onChange={() => {
-                                setVisHenlagteBehandlinger(!visHenlagteBehandlinger);
-                            }}
+                            onChange={() => setVisHenlagteBehandlinger(!visHenlagteBehandlinger)}
                         >
                             Vis henlagte behandlinger
                         </Switch>
@@ -140,11 +152,9 @@ export function Behandlinger({ fagsakId }: Props) {
                         </Table.Body>
                     </Table>
                 ) : (
-                    <BodyShort children={'Ingen tidligere behandlinger'} />
+                    <BodyShort>Ingen tidligere behandlinger</BodyShort>
                 )}
             </div>
         </VStack>
     );
 }
-
-export default Behandlinger;

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -6,7 +6,7 @@ import { Link as ReactRouterLink } from 'react-router';
 import { Alert, Box, Heading, Link, VStack } from '@navikt/ds-react';
 import { byggTomRessurs } from '@navikt/familie-typer';
 
-import Behandlinger from './Behandlinger';
+import { Behandlinger } from './Behandlinger';
 import BehandlingerOld from './BehandlingerOld';
 import FagsakLenkepanel, { SaksoversiktPanelBredde } from './FagsakLenkepanel';
 import Utbetalinger from './Utbetalinger';


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26347

Invalidere queries ved oppretting av behandlinger slik at de automatisk dukker opp i tabellen/listen over behandlinger. Uten invalidering må man manuelt refreshe nettsiden for at de skal dukke opp.

Rydder også opp i noe relatert kode for å gjøre det lik kode i ba-sak-frontend.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
<img width="932" height="300" alt="image" src="https://github.com/user-attachments/assets/15473888-2c7d-4286-8b14-d76a69d6420a" />