### PR TITLE
NAV-26281: Legger til egen error-klasse some inneholder hvilken type ressursfeil man fikk

### DIFF
--- a/src/frontend/api/error/apiError.ts
+++ b/src/frontend/api/error/apiError.ts
@@ -1,0 +1,27 @@
+import type { RessursStatus } from '@navikt/familie-typer';
+
+enum Type {
+    IKKE_HENTET = 'IKKE_HENTET',
+    HENTER = 'HENTER',
+    IKKE_TILGANG = 'IKKE_TILGANG',
+    FEILET = 'FEILET',
+    FUNKSJONELL_FEIL = 'FUNKSJONELL_FEIL',
+}
+
+export class ApiError extends Error {
+    static readonly Type = Type;
+    public readonly type: Type;
+
+    static opprettFraRessurs(message: string, status: Exclude<RessursStatus, RessursStatus.SUKSESS>) {
+        return this.opprettFra(message, Type[status]);
+    }
+
+    static opprettFra(message: string, type: Type) {
+        return new ApiError(message, type);
+    }
+
+    constructor(message: string, type: Type) {
+        super(message);
+        this.type = type;
+    }
+}

--- a/src/frontend/utils/ressursResolver.test.ts
+++ b/src/frontend/utils/ressursResolver.test.ts
@@ -1,0 +1,93 @@
+import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
+
+import { RessursResolver } from './ressursResolver';
+import { ApiError } from '../api/error/apiError';
+
+describe('RessursResolver', () => {
+    test('skal kaste error hvis man prøver å resolve HENTER ressurs', () => {
+        // Arrange
+        const henterRessurs: Ressurs<void> = {
+            status: RessursStatus.HENTER,
+        };
+
+        // Act & expect
+        RessursResolver.resolveToPromise(henterRessurs).catch((error: ApiError) => {
+            expect(error).toBeInstanceOf(ApiError);
+            expect(error.message).toBe(`Uforventet status ${henterRessurs.status}.`);
+            expect(error.type).toBe(ApiError.Type.HENTER);
+        });
+    });
+
+    test('skal kaste error hvis man prøver å resolve IKKE_HENTET ressurs', () => {
+        // Arrange
+        const ikkeHentetRessurs: Ressurs<void> = {
+            status: RessursStatus.IKKE_HENTET,
+        };
+
+        // Act & expect
+        RessursResolver.resolveToPromise(ikkeHentetRessurs).catch((error: ApiError) => {
+            expect(error).toBeInstanceOf(ApiError);
+            expect(error.message).toBe(`Uforventet status ${ikkeHentetRessurs.status}.`);
+            expect(error.type).toBe(ApiError.Type.IKKE_HENTET);
+        });
+    });
+
+    test('skal resolve suksess ressurs til promise', () => {
+        // Arrange
+        const suksessRessurs: Ressurs<string> = {
+            status: RessursStatus.SUKSESS,
+            data: 'bla bla bla',
+        };
+
+        // Act
+        const promise = RessursResolver.resolveToPromise(suksessRessurs);
+
+        // Expect
+        promise.then(data => expect(data).toBe('bla bla bla'));
+    });
+
+    test('skal kaste error hvis man prøver å resolve IKKE_TILGANG ressurs', () => {
+        // Arrange
+        const ikkeTilgangRessurs: Ressurs<void> = {
+            status: RessursStatus.IKKE_TILGANG,
+            frontendFeilmelding: 'Du har ikke tilgang.',
+        };
+
+        // Act & expect
+        RessursResolver.resolveToPromise(ikkeTilgangRessurs).catch((error: ApiError) => {
+            expect(error).toBeInstanceOf(ApiError);
+            expect(error.message).toBe('Du har ikke tilgang.');
+            expect(error.type).toBe(ApiError.Type.IKKE_TILGANG);
+        });
+    });
+
+    test('skal kaste error hvis man prøver å resolve FEILET ressurs', () => {
+        // Arrange
+        const feiletRessurs: Ressurs<void> = {
+            status: RessursStatus.FEILET,
+            frontendFeilmelding: 'Ops! En feil oppstod.',
+        };
+
+        // Act & expect
+        RessursResolver.resolveToPromise(feiletRessurs).catch((error: ApiError) => {
+            expect(error).toBeInstanceOf(ApiError);
+            expect(error.message).toBe('Ops! En feil oppstod.');
+            expect(error.type).toBe(ApiError.Type.FEILET);
+        });
+    });
+
+    test('skal kaste error hvis man prøver å resolve FUNKSJONELL_FEIL ressurs', () => {
+        // Arrange
+        const funksjonellFeilRessurs: Ressurs<void> = {
+            status: RessursStatus.FUNKSJONELL_FEIL,
+            frontendFeilmelding: 'Ops! En funksjonell feil oppstod.',
+        };
+
+        // Act & expect
+        RessursResolver.resolveToPromise(funksjonellFeilRessurs).catch((error: ApiError) => {
+            expect(error).toBeInstanceOf(ApiError);
+            expect(error.message).toBe('Ops! En funksjonell feil oppstod.');
+            expect(error.type).toBe(ApiError.Type.FUNKSJONELL_FEIL);
+        });
+    });
+});

--- a/src/frontend/utils/ressursResolver.ts
+++ b/src/frontend/utils/ressursResolver.ts
@@ -1,18 +1,20 @@
-import type { Ressurs } from '@navikt/familie-typer';
+import { type Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
 
-export function resolveToPromise<T>(ressurs: Ressurs<T>): Promise<Awaited<T>> {
+import { ApiError } from '../api/error/apiError';
+
+export function resolveToPromise<T>(ressurs: Ressurs<T>): Promise<T> {
     switch (ressurs.status) {
         case RessursStatus.IKKE_HENTET:
         case RessursStatus.HENTER:
             // Dette burde egentlig aldri skje da ressursen burde allerede være hentet på dette tidspunktet.
-            return Promise.reject(new Error(`Uforventet ressurs status ${ressurs.status}.`));
+            return Promise.reject(ApiError.opprettFraRessurs(`Uforventet status ${ressurs.status}.`, ressurs.status));
         case RessursStatus.SUKSESS:
             return Promise.resolve(ressurs.data);
         case RessursStatus.IKKE_TILGANG:
         case RessursStatus.FEILET:
         case RessursStatus.FUNKSJONELL_FEIL:
-            return Promise.reject(new Error(ressurs.frontendFeilmelding));
+            return Promise.reject(ApiError.opprettFraRessurs(ressurs.frontendFeilmelding, ressurs.status));
     }
 }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro:  https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26281

I forbindelse med refaktoreringen av "Registrer Søknad" skjemaet er det behov for å vite hvilken type feil som oppstod ved HTTP requester.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer.
