### PR TITLE
NAV-26412: Sett "replace" til "true" ved automatisk navigering slik at navigering ved tilbakeknappen i browsern ikke sender deg til en "tom" steg side

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -218,7 +218,9 @@ export const BehandlingProvider = ({ children }: React.PropsWithChildren) => {
                 (erViPåUdefinertFagsakSide(location.pathname) || erViPåUlovligSteg(location.pathname, sideForSteg)) &&
                 sideForSteg
             ) {
-                navigate(`/fagsak/${fagsakId}/${åpenBehandling.data.behandlingId}/${sideForSteg.href}`);
+                navigate(`/fagsak/${fagsakId}/${åpenBehandling.data.behandlingId}/${sideForSteg.href}`, {
+                    replace: true,
+                });
             }
         }
     };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26412

Sett "replace" til "true" ved automatisk navigering slik at navigering ved tilbakeknappen i browsern ikke sender deg til en "tom" steg side

Dette ble gjort i ba-sak-frontend for en stund tilbake siden, se her https://github.com/navikt/familie-ba-sak-frontend/pull/3943

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Ingen visuelle endringer.