### PR TITLE
NAV-26611: Legger till fallback komponent i ErrorBoundary for å forhindre en "crash-loop"

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -12,7 +12,7 @@ import Container from './Container';
 import { AppProvider } from './context/AppContext';
 import { AuthOgHttpProvider } from './context/AuthContext';
 import { ModalProvider } from './context/ModalContext';
-import ErrorBoundary from './komponenter/ErrorBoundary/ErrorBoundary';
+import { ErrorBoundary } from './komponenter/ErrorBoundary/ErrorBoundary';
 import { initGrafanaFaro } from './utils/grafanaFaro';
 
 const queryClient = new QueryClient({

--- a/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.module.css
+++ b/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.module.css
@@ -1,0 +1,6 @@
+.container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+}

--- a/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.tsx
@@ -3,38 +3,54 @@ import { Component } from 'react';
 
 import * as Sentry from '@sentry/browser';
 
+import { XMarkOctagonIcon } from '@navikt/aksel-icons';
+import { BodyShort, Button, ErrorMessage, Heading, HStack, VStack } from '@navikt/ds-react';
 import type { ISaksbehandler } from '@navikt/familie-typer';
 
-import { erLokal } from '../../utils/miljø';
+import Styles from './ErrorBoundary.module.css';
 
-interface IProps extends PropsWithChildren {
+interface Props extends PropsWithChildren {
     autentisertSaksbehandler?: ISaksbehandler;
 }
 
-class ErrorBoundary extends Component<IProps> {
-    public constructor(props: IProps) {
+interface State {
+    hasError: boolean;
+    error?: Error;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+    public constructor(props: Props) {
         super(props);
+        this.state = { hasError: false };
+        this.visSentryDialog = this.visSentryDialog.bind(this);
+    }
+
+    static getDerivedStateFromError(error: Error) {
+        return { hasError: true, error };
     }
 
     // eslint-disable-next-line
     public componentDidCatch(error: any, info: any): void {
-        // eslint-disable-next-line: no-console
-        console.log(error, info);
-        if (!erLokal()) {
+        console.error(error, info);
+        if (Sentry.isEnabled()) {
             Sentry.setUser({
                 username: this.props.autentisertSaksbehandler
                     ? this.props.autentisertSaksbehandler.displayName
                     : 'Ukjent bruker',
                 email: this.props.autentisertSaksbehandler ? this.props.autentisertSaksbehandler.email : 'Ukjent email',
             });
-
             Sentry.withScope(scope => {
                 Object.keys(info).forEach(key => {
                     scope.setExtra(key, info[key]);
                     Sentry.captureException(error);
                 });
             });
+            this.visSentryDialog();
+        }
+    }
 
+    private visSentryDialog() {
+        if (Sentry.isEnabled()) {
             Sentry.showReportDialog({
                 title: 'En feil har oppstått i vedtaksløsningen',
                 subtitle: '',
@@ -53,8 +69,38 @@ class ErrorBoundary extends Component<IProps> {
     }
 
     render(): ReactNode {
+        if (this.state.hasError) {
+            return (
+                <div className={Styles.container}>
+                    <VStack gap={'space-32'}>
+                        <VStack gap={'space-8'}>
+                            <Heading size={'medium'} level={'1'}>
+                                <HStack gap={'space-8'} align={'center'} justify={'start'}>
+                                    <XMarkOctagonIcon fontSize={'1.5rem'} />
+                                    En feil har oppstått i vedtaksløsningen
+                                </HStack>
+                            </Heading>
+                            <BodyShort>Teamet har fått beskjed.</BodyShort>
+                        </VStack>
+                        {this.state.error?.message && (
+                            <VStack gap={'space-8'}>
+                                <BodyShort>Feilmelding:</BodyShort>
+                                <ErrorMessage>{this.state.error?.message}</ErrorMessage>
+                            </VStack>
+                        )}
+                        {Sentry.isEnabled() && (
+                            <HStack justify={'end'}>
+                                <div>
+                                    <Button variant={'tertiary'} onClick={this.visSentryDialog}>
+                                        Gi en mer utfyllende beskjed
+                                    </Button>
+                                </div>
+                            </HStack>
+                        )}
+                    </VStack>
+                </div>
+            );
+        }
         return this.props.children;
     }
 }
-
-export default ErrorBoundary;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26611

Legger til en fallback komponent i `<ErrorBoundary />` for å forhindre en "crash-loop" hvor feil oppstår i "children" som rendrer `<ErrorBoundary />` som igjen rendrer "children", osv.

Se mer hvordan `<ErrorBoundary />` fungerer her https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary

Sentry dialogen er ikke ny. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Fallback error komponent:
<img width="663" height="246" alt="image" src="https://github.com/user-attachments/assets/c9fd1ad7-74d6-4df2-ac4d-9602198de7a0" />

Sentry dialog:
<img width="587" height="462" alt="image" src="https://github.com/user-attachments/assets/f5f3115b-d1e1-4487-adc1-766268fc6392" />
