### PR TITLE
Distroless-imaget heter slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Plukket opp på dagens Security Champion-møte. Akkurat for node så er ikke Chainguard-imaget distroless. Må bytte til slim

Testet i preprod