### PR TITLE
NAV-26616: Flytter tilstand til venstre og høyremeny til session storage

### DIFF
--- a/src/frontend/hooks/useSessionStorage.ts
+++ b/src/frontend/hooks/useSessionStorage.ts
@@ -1,0 +1,64 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useEffect, useState } from 'react';
+
+export enum Key {
+    ER_HØYREMENY_ÅPEN = 'erHøyremenyÅpen',
+    ER_VENSTREMENY_ÅPEN = 'erVenstremenyÅpen',
+}
+
+type SessionStorageItem = string | null;
+
+function deserialize<T>(value: SessionStorageItem, fallbackValue: T): T {
+    if (value === null) {
+        return fallbackValue;
+    }
+    try {
+        return JSON.parse(value) as T;
+    } catch (error) {
+        console.error('Error parsing JSON:', error);
+        return fallbackValue;
+    }
+}
+
+export function useSessionStorage<T>(key: Key, initialValue: T): [T, Dispatch<SetStateAction<T>>] {
+    const [storedValue, setStoredValue] = useState(() => readValue());
+
+    function readValue(): T {
+        try {
+            const item = window.sessionStorage.getItem(key) as SessionStorageItem;
+            return deserialize(item, initialValue);
+        } catch (error) {
+            console.error(`Error reading sessionStorage key “${key}”:`, error);
+            return initialValue;
+        }
+    }
+
+    function setValue(value: T | ((previousValue: T) => T)) {
+        try {
+            const previousValue = readValue();
+            const newValue = value instanceof Function ? value(previousValue) : value;
+            window.sessionStorage.setItem(key, JSON.stringify(newValue));
+            setStoredValue(newValue);
+            // We dispatch a custom event so every similar useSessionStorage hook is notified
+            window.dispatchEvent(new StorageEvent('storage', { key }));
+        } catch (error) {
+            console.error(`Error setting sessionStorage key “${key}”:`, error);
+        }
+    }
+
+    useEffect(() => {
+        function handleStorageChange(event: StorageEvent) {
+            if (event.key !== key) {
+                return;
+            }
+            setStoredValue(readValue());
+        }
+
+        window.addEventListener('storage', handleStorageChange);
+        return () => {
+            window.removeEventListener('storage', handleStorageChange);
+        };
+    }, []);
+
+    return [storedValue, setValue];
+}

--- a/src/frontend/komponenter/Hendelsesoversikt/Header/Header.module.css
+++ b/src/frontend/komponenter/Hendelsesoversikt/Header/Header.module.css
@@ -1,6 +1,8 @@
 .tabsListe {
     width: 100%;
-
+    justify-content: space-between;
+    padding-right: 0.25rem;
+    padding-left: 0.25rem;
     > button {
         flex: 1;
     }

--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
@@ -6,11 +6,11 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { BehandlingRouter } from './BehandlingRouter';
 import { useBehandlingContext } from './context/BehandlingContext';
-import Høyremeny from './Høyremeny/Høyremeny';
+import { Høyremeny } from './Høyremeny/Høyremeny';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 import type { IPersonInfo } from '../../../typer/person';
 import { Fagsaklinje } from '../Fagsaklinje/Fagsaklinje';
-import Venstremeny from './Venstremeny/Venstremeny';
+import { Venstremeny } from './Venstremeny/Venstremeny';
 import { HenleggBehandlingModal } from '../Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal';
 import { HenleggBehandlingVeivalgModal } from '../Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingVeivalgModal';
 import { KorrigerEtterbetalingModal } from './sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal';
@@ -22,7 +22,9 @@ const FlexContainer = styled.div`
 const VenstremenyContainer = styled.div`
     min-width: 1rem;
     border-right: 1px solid ${ABorderDivider};
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    height: calc(100vh - 146px);
 `;
 
 const HovedinnholdContainer = styled.div`
@@ -32,6 +34,7 @@ const HovedinnholdContainer = styled.div`
 `;
 
 const HøyremenyContainer = styled.div`
+    min-width: 1rem;
     border-left: 1px solid ${ABorderDivider};
     overflow-x: hidden;
     overflow-y: scroll;

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/useHøyremeny.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/useHøyremeny.ts
@@ -1,0 +1,9 @@
+import type { Dispatch, SetStateAction } from 'react';
+
+import { Key, useSessionStorage } from '../../../../hooks/useSessionStorage';
+
+export function useHøyremeny(): [boolean, Dispatch<SetStateAction<boolean>>] {
+    const [erÅpen, settErÅpen] = useSessionStorage(Key.ER_HØYREMENY_ÅPEN, true);
+
+    return [erÅpen, settErÅpen];
+}

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/useVenstremeny.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/useVenstremeny.ts
@@ -1,0 +1,9 @@
+import type { Dispatch, SetStateAction } from 'react';
+
+import { Key, useSessionStorage } from '../../../../hooks/useSessionStorage';
+
+export function useVenstremeny(): [boolean, Dispatch<SetStateAction<boolean>>] {
+    const [erÅpen, settErÅpen] = useSessionStorage(Key.ER_VENSTREMENY_ÅPEN, true);
+
+    return [erÅpen, settErÅpen];
+}

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -63,10 +63,6 @@ interface BehandlingContextValue {
     ) => void;
     behandlingPåVent: IBehandlingPåVent | undefined;
     erBehandleneEnhetMidlertidig?: boolean;
-    åpenHøyremeny: boolean;
-    settÅpenHøyremeny: (åpenHøyremeny: boolean) => void;
-    åpenVenstremeny: boolean;
-    settÅpenVenstremeny: (åpenVenstremeny: boolean) => void;
     erBehandlingAvsluttet: boolean;
 }
 
@@ -76,8 +72,6 @@ export const BehandlingProvider = ({ children }: PropsWithChildren) => {
     const { fagsakId } = useSakOgBehandlingParams();
     const queryClient = useQueryClient();
     const [åpenBehandling, privatSettÅpenBehandling] = useState<Ressurs<IBehandling>>(byggTomRessurs());
-    const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
-    const [åpenVenstremeny, settÅpenVenstremeny] = useState(true);
 
     const settÅpenBehandling = (behandling: Ressurs<IBehandling>, oppdaterMinimalFagsak = true) => {
         if (oppdaterMinimalFagsak && fagsakId) {
@@ -267,10 +261,6 @@ export const BehandlingProvider = ({ children }: PropsWithChildren) => {
                 foreslåVedtakNesteOnClick,
                 behandlingPåVent: hentDataFraRessurs(åpenBehandling)?.behandlingPåVent,
                 erBehandleneEnhetMidlertidig,
-                åpenHøyremeny,
-                settÅpenHøyremeny,
-                åpenVenstremeny,
-                settÅpenVenstremeny,
                 erBehandlingAvsluttet,
             }}
         >


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26616

Flytter tilstanden for å håndtere hvorvidt venstre og høyremenyen er åpen til session storage. Dette gjør slik at man husker tilstand på tvers av refresh.

Tar også i bruk den nye react komponenten `<Activity />` for å vise/skjule innhold uten å trenge å rerendere på nytt hver gang venstre/høyremenyen åpnes. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei
### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ser stort sett likt ut som før, noen små visuelle forbedringer på høyremeny knappen (den blir ikke lengre skvist inn i høyremargen).

<img width="67" height="462" alt="image" src="https://github.com/user-attachments/assets/e5b18165-133c-4c3d-89d1-098a01520a7c" />
