### PR TITLE
React query for barnehagelister

### DIFF
--- a/src/frontend/api/hentBarnehagebarn.ts
+++ b/src/frontend/api/hentBarnehagebarn.ts
@@ -1,0 +1,18 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import type { BarnehagebarnRequestParams, BarnehagebarnResponse } from '../typer/barnehagebarn';
+import { RessursResolver } from '../utils/ressursResolver';
+
+const BARNEHAGELISTE_URL = '/familie-ks-sak/api/barnehagebarn/barnehagebarnliste';
+
+export async function hentBarnehagebarn(
+    request: FamilieRequest,
+    barnehagebarnRequestParams: BarnehagebarnRequestParams
+): Promise<BarnehagebarnResponse> {
+    const ressurs = await request<BarnehagebarnRequestParams, BarnehagebarnResponse>({
+        data: barnehagebarnRequestParams,
+        method: 'POST',
+        url: `${BARNEHAGELISTE_URL}`,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/hooks/useHentBarnehagebarn.ts
+++ b/src/frontend/hooks/useHentBarnehagebarn.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { hentBarnehagebarn } from '../api/hentBarnehagebarn';
+import type { BarnehagebarnRequestParams } from '../typer/barnehagebarn';
+
+export const HentBarnehagebarnQueryKeyFactory = {
+    barnehagebarn: (barnehagebarnRequestParams: BarnehagebarnRequestParams) => [
+        'barnehagebarn',
+        barnehagebarnRequestParams,
+    ],
+};
+
+export function useHentBarnehagebarn(barnehagebarnRequestParams: BarnehagebarnRequestParams) {
+    const { request } = useHttp();
+    return useQuery({
+        queryKey: HentBarnehagebarnQueryKeyFactory.barnehagebarn(barnehagebarnRequestParams),
+        queryFn: () => hentBarnehagebarn(request, barnehagebarnRequestParams),
+    });
+}

--- a/src/frontend/sider/Barnehagelister/BarnehagebarnTabell.tsx
+++ b/src/frontend/sider/Barnehagelister/BarnehagebarnTabell.tsx
@@ -1,20 +1,20 @@
 import { Link as ReactRouterLink } from 'react-router';
 
-import { Alert, Box, Link, Table } from '@navikt/ds-react';
-import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
+import { Alert, Box, HStack, Link, Loader, Table } from '@navikt/ds-react';
 
-import type { Barnehagebarn, BarnehagebarnRequestParams, BarnehagebarnResponse } from '../../typer/barnehagebarn';
+import { useHentBarnehagebarn } from '../../hooks/useHentBarnehagebarn';
+import type { BarnehagebarnRequestParams } from '../../typer/barnehagebarn';
 import { Datoformat, isoStringTilFormatertString } from '../../utils/dato';
 
-interface BarnehagebarnTabellProps<T> {
+interface BarnehagebarnTabellProps {
     barnehagebarnRequestParams: BarnehagebarnRequestParams;
-    barnehagebarnResponse: Ressurs<BarnehagebarnResponse<T>>;
-    data: readonly T[];
     updateSortByAscDesc: (fieldName: string) => void;
 }
 
-export const BarnehagebarnTabell = (props: BarnehagebarnTabellProps<Barnehagebarn>) => {
-    const { barnehagebarnRequestParams, barnehagebarnResponse, data, updateSortByAscDesc } = props;
+export const BarnehagebarnTabell = (props: BarnehagebarnTabellProps) => {
+    const { barnehagebarnRequestParams, updateSortByAscDesc } = props;
+
+    const { data, isPending, error } = useHentBarnehagebarn(barnehagebarnRequestParams);
 
     function visAvvikstekst(avvik?: boolean) {
         if (avvik === true) {
@@ -70,71 +70,73 @@ export const BarnehagebarnTabell = (props: BarnehagebarnTabellProps<Barnehagebar
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>
-                    {data.map((barnehagebarn, i) => {
-                        return (
-                            <Table.Row key={i + barnehagebarn.ident}>
-                                <Table.DataCell>{barnehagebarn.ident}</Table.DataCell>
-                                <Table.DataCell>
-                                    {isoStringTilFormatertString({
-                                        isoString: barnehagebarn.endretTid,
-                                        tilFormat: Datoformat.DATO_TID,
-                                    })}
-                                </Table.DataCell>
-                                <Table.DataCell>
-                                    {isoStringTilFormatertString({
-                                        isoString: barnehagebarn.fom,
-                                        tilFormat: Datoformat.DATO_FORKORTTET,
-                                    })}
-                                </Table.DataCell>
-                                <Table.DataCell>
-                                    {isoStringTilFormatertString({
-                                        isoString: barnehagebarn.tom,
-                                        tilFormat: Datoformat.DATO_FORKORTTET,
-                                    })}
-                                </Table.DataCell>
-                                <Table.DataCell align="center">{barnehagebarn.antallTimerIBarnehage}</Table.DataCell>
-                                <Table.DataCell>{barnehagebarn.endringstype}</Table.DataCell>
-                                <Table.DataCell>{visAvvikstekst(barnehagebarn.avvik)}</Table.DataCell>
-                                <Table.DataCell>{barnehagebarn.kommuneNavn}</Table.DataCell>
-                                <Table.DataCell>{barnehagebarn.kommuneNr}</Table.DataCell>
-                                <Table.DataCell>
-                                    {barnehagebarn.fagsakstatus ? barnehagebarn.fagsakstatus : 'Ingen fagsak'}
-                                </Table.DataCell>
-                                <Table.DataCell>
-                                    {barnehagebarn.fagsakId ? (
-                                        <Link
-                                            as={ReactRouterLink}
-                                            title={`FagsakId: ${barnehagebarn.fagsakId}`}
-                                            to={`/fagsak/${barnehagebarn.fagsakId}/saksoversikt`}
-                                        >
-                                            Gå til saksoversikt
-                                        </Link>
-                                    ) : (
-                                        'Ingen fagsak'
-                                    )}
-                                </Table.DataCell>
-                            </Table.Row>
-                        );
-                    })}
+                    {!error &&
+                        data?.content.map((barnehagebarn, i) => {
+                            return (
+                                <Table.Row key={i + barnehagebarn.ident}>
+                                    <Table.DataCell>{barnehagebarn.ident}</Table.DataCell>
+                                    <Table.DataCell>
+                                        {isoStringTilFormatertString({
+                                            isoString: barnehagebarn.endretTid,
+                                            tilFormat: Datoformat.DATO_TID,
+                                        })}
+                                    </Table.DataCell>
+                                    <Table.DataCell>
+                                        {isoStringTilFormatertString({
+                                            isoString: barnehagebarn.fom,
+                                            tilFormat: Datoformat.DATO_FORKORTTET,
+                                        })}
+                                    </Table.DataCell>
+                                    <Table.DataCell>
+                                        {isoStringTilFormatertString({
+                                            isoString: barnehagebarn.tom,
+                                            tilFormat: Datoformat.DATO_FORKORTTET,
+                                        })}
+                                    </Table.DataCell>
+                                    <Table.DataCell align="center">
+                                        {barnehagebarn.antallTimerIBarnehage}
+                                    </Table.DataCell>
+                                    <Table.DataCell>{barnehagebarn.endringstype}</Table.DataCell>
+                                    <Table.DataCell>{visAvvikstekst(barnehagebarn.avvik)}</Table.DataCell>
+                                    <Table.DataCell>{barnehagebarn.kommuneNavn}</Table.DataCell>
+                                    <Table.DataCell>{barnehagebarn.kommuneNr}</Table.DataCell>
+                                    <Table.DataCell>
+                                        {barnehagebarn.fagsakstatus ? barnehagebarn.fagsakstatus : 'Ingen fagsak'}
+                                    </Table.DataCell>
+                                    <Table.DataCell>
+                                        {barnehagebarn.fagsakId ? (
+                                            <Link
+                                                as={ReactRouterLink}
+                                                title={`FagsakId: ${barnehagebarn.fagsakId}`}
+                                                to={`/fagsak/${barnehagebarn.fagsakId}/saksoversikt`}
+                                            >
+                                                Gå til saksoversikt
+                                            </Link>
+                                        ) : (
+                                            'Ingen fagsak'
+                                        )}
+                                    </Table.DataCell>
+                                </Table.Row>
+                            );
+                        })}
                 </Table.Body>
             </Table>
 
-            {barnehagebarnResponse.status === RessursStatus.SUKSESS &&
-                barnehagebarnResponse.data.content.length === 0 && (
-                    <Box marginBlock="space-16 0">
-                        <Alert variant="warning">Ingen barnehagebarn (ev tøm filter)</Alert>
-                    </Box>
-                )}
-            {(barnehagebarnResponse.status === RessursStatus.FEILET ||
-                barnehagebarnResponse.status === RessursStatus.FUNKSJONELL_FEIL ||
-                barnehagebarnResponse.status === RessursStatus.IKKE_TILGANG) && (
-                <Box marginBlock="space-16 0">
-                    <Alert variant="error">{barnehagebarnResponse.frontendFeilmelding}</Alert>
+            {isPending && (
+                <HStack width={'100%'} justify={'center'} align={'center'} margin={'space-16'} gap={'space-6'}>
+                    <Loader /> Laster barnehagebarn
+                </HStack>
+            )}
+
+            {error && (
+                <Box margin={'space-8'}>
+                    <Alert variant={'error'}>{error.message}</Alert>
                 </Box>
             )}
-            {barnehagebarnResponse.status === RessursStatus.HENTER && (
+
+            {!error && data?.content.length === 0 && (
                 <Box marginBlock="space-16 0">
-                    <Alert variant="info">Henter...</Alert>
+                    <Alert variant="warning">Ingen barnehagebarn (ev tøm filter)</Alert>
                 </Box>
             )}
         </>

--- a/src/frontend/sider/Barnehagelister/BarnehagebarnTabellNavigator.tsx
+++ b/src/frontend/sider/Barnehagelister/BarnehagebarnTabellNavigator.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 
 import { HStack, Pagination, Select } from '@navikt/ds-react';
-import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
-import type { Barnehagebarn, BarnehagebarnRequestParams, BarnehagebarnResponse } from '../../typer/barnehagebarn';
+import { useHentBarnehagebarn } from '../../hooks/useHentBarnehagebarn';
+import type { BarnehagebarnRequestParams } from '../../typer/barnehagebarn';
 
 const StyledHStack = styled(HStack)`
     margin-bottom: 1rem;
@@ -13,70 +13,70 @@ const StyledSelect = styled(Select)`
     margin-right: auto;
 `;
 
-interface BarnehagebarnTabellNavigatorProps<T> {
+interface BarnehagebarnTabellNavigatorProps {
     barnehagebarnRequestParams: BarnehagebarnRequestParams;
-    barnehagebarnResponse: Ressurs<BarnehagebarnResponse<T>>;
-    data: readonly T[];
     updateOffset: (offset: number) => void;
     updateLimit: (limit: number) => void;
     updateSortByAscDesc: (fieldName: string) => void;
 }
 
-const BarnehagebarnTabellNavigator = <T = Barnehagebarn,>(props: BarnehagebarnTabellNavigatorProps<T>) => {
-    const { barnehagebarnResponse, updateOffset, updateLimit, barnehagebarnRequestParams } = props;
+const BarnehagebarnTabellNavigator = (props: BarnehagebarnTabellNavigatorProps) => {
+    const { updateOffset, updateLimit, barnehagebarnRequestParams } = props;
+
+    const { data, isPending, error } = useHentBarnehagebarn(barnehagebarnRequestParams);
+
+    if (isPending || error) {
+        return null;
+    }
 
     return (
         <StyledHStack>
-            {barnehagebarnResponse.status === RessursStatus.SUKSESS &&
-                barnehagebarnResponse.data.content.length >= 0 && (
-                    <>
-                        <StyledSelect
-                            hideLabel
-                            label="Antall per side"
+            {data.content.length >= 0 && (
+                <>
+                    <StyledSelect
+                        hideLabel
+                        label="Antall per side"
+                        size="medium"
+                        aria-labelledby={'Antall per side'}
+                        value={barnehagebarnRequestParams.limit}
+                        onChange={event => updateLimit(+event.target.value)}
+                    >
+                        <option value="1">Vis 1 per side</option>
+                        <option value="2">Vis 2 per side</option>
+                        <option value="3">Vis 3 per side</option>
+                        <option value="4">Vis 4 per side</option>
+                        <option value="20">Vis 20 per side</option>
+                        <option value="50">Vis 50 per side</option>
+                        <option value="100">Vis 100 per side</option>
+                        <option value="200">Vis 200 per side</option>
+                    </StyledSelect>
+                    {data.totalElements > 0 ? (
+                        <HStack gap="2" align="center">
+                            |
+                            <span>
+                                <b>
+                                    Side {data.number + 1} av {data.totalPages}{' '}
+                                </b>
+                                ({data.pageable.offset + 1} - {data.pageable.offset + data.numberOfElements} av{' '}
+                                {data.totalElements} totalt)
+                            </span>
+                            |
+                        </HStack>
+                    ) : (
+                        <div>Ingen resultater</div>
+                    )}
+                    {data?.totalPages > 0 && (
+                        <Pagination
                             size="medium"
-                            aria-labelledby={'Antall per side'}
-                            value={barnehagebarnRequestParams.limit}
-                            onChange={event => updateLimit(+event.target.value)}
-                        >
-                            <option value="1">Vis 1 per side</option>
-                            <option value="2">Vis 2 per side</option>
-                            <option value="3">Vis 3 per side</option>
-                            <option value="4">Vis 4 per side</option>
-                            <option value="20">Vis 20 per side</option>
-                            <option value="50">Vis 50 per side</option>
-                            <option value="100">Vis 100 per side</option>
-                            <option value="200">Vis 200 per side</option>
-                        </StyledSelect>
-                        {barnehagebarnResponse.data.totalElements > 0 ? (
-                            <HStack gap="2" align="center">
-                                |
-                                <span>
-                                    <b>
-                                        Side {barnehagebarnResponse.data.number + 1} av{' '}
-                                        {barnehagebarnResponse.data.totalPages}{' '}
-                                    </b>
-                                    ({barnehagebarnResponse.data.pageable.offset + 1} -{' '}
-                                    {barnehagebarnResponse.data.pageable.offset +
-                                        barnehagebarnResponse.data.numberOfElements}{' '}
-                                    av {barnehagebarnResponse.data.totalElements} totalt)
-                                </span>
-                                |
-                            </HStack>
-                        ) : (
-                            <div>Ingen resultater</div>
-                        )}
-                        {barnehagebarnResponse?.data?.totalPages > 0 && (
-                            <Pagination
-                                size="medium"
-                                page={barnehagebarnResponse.data.number + 1}
-                                count={barnehagebarnResponse.data.totalPages}
-                                onPageChange={(side: number) => updateOffset(side - 1)}
-                                boundaryCount={1}
-                                siblingCount={1}
-                            />
-                        )}
-                    </>
-                )}
+                            page={data.number + 1}
+                            count={data.totalPages}
+                            onPageChange={(side: number) => updateOffset(side - 1)}
+                            boundaryCount={1}
+                            siblingCount={1}
+                        />
+                    )}
+                </>
+            )}
         </StyledHStack>
     );
 };

--- a/src/frontend/sider/Barnehagelister/BarnehagelisterFilterskjema.tsx
+++ b/src/frontend/sider/Barnehagelister/BarnehagelisterFilterskjema.tsx
@@ -23,7 +23,9 @@ interface BarnehagebarnFilterSkjemaProps {
 const BarnehagelisterFilterskjema = (props: BarnehagebarnFilterSkjemaProps) => {
     const { oppdaterFiltrering, barnehageKommuner } = props;
 
-    const { register, handleSubmit, reset, control, watch, setValue } = useForm<BarnehagebarnFilter>();
+    const { register, handleSubmit, reset, control, watch, setValue } = useForm<BarnehagebarnFilter>({
+        defaultValues: { ident: '', kommuneNavn: '', kunLøpendeAndel: false },
+    });
 
     const onSubmit: SubmitHandler<BarnehagebarnFilter> = barnehagebarnFilter => {
         oppdaterFiltrering(barnehagebarnFilter);

--- a/src/frontend/sider/Barnehagelister/BarnehagelisterInnhold.tsx
+++ b/src/frontend/sider/Barnehagelister/BarnehagelisterInnhold.tsx
@@ -5,6 +5,7 @@ import { Heading } from '@navikt/ds-react';
 import { BarnehagebarnTabell } from './BarnehagebarnTabell';
 import BarnehagebarnTabellNavigator from './BarnehagebarnTabellNavigator';
 import BarnehagelisterFilterskjema from './BarnehagelisterFilterskjema';
+import { LasterNyttTabellInnholdSpinner } from './LasterNyttTabellInnholdSpinner';
 import { useBarnehagelister } from './useBarnehagelister';
 
 const Container = styled.div`
@@ -24,6 +25,9 @@ const BarnehagelisterInnhold = () => {
             </Heading>
             <BarnehagelisterFilterskjema {...barnehagelisterContext} />
             <BarnehagebarnTabellNavigator {...barnehagelisterContext} />
+            <LasterNyttTabellInnholdSpinner
+                barnehagebarnRequestParams={barnehagelisterContext.barnehagebarnRequestParams}
+            />
             <BarnehagebarnTabell {...barnehagelisterContext} />
         </Container>
     );

--- a/src/frontend/sider/Barnehagelister/BarnehagelisterInnhold.tsx
+++ b/src/frontend/sider/Barnehagelister/BarnehagelisterInnhold.tsx
@@ -6,7 +6,6 @@ import { BarnehagebarnTabell } from './BarnehagebarnTabell';
 import BarnehagebarnTabellNavigator from './BarnehagebarnTabellNavigator';
 import BarnehagelisterFilterskjema from './BarnehagelisterFilterskjema';
 import { useBarnehagelister } from './useBarnehagelister';
-import type { Barnehagebarn } from '../../typer/barnehagebarn';
 
 const Container = styled.div`
     padding: 0.5rem;
@@ -15,10 +14,8 @@ const Container = styled.div`
     height: calc(100vh - 116px - 1.1rem);
 `;
 
-const BARNEHAGELISTE_URL = '/familie-ks-sak/api/barnehagebarn/barnehagebarnliste';
-
 const BarnehagelisterInnhold = () => {
-    const barnehagelisterContext = useBarnehagelister<Barnehagebarn>(BARNEHAGELISTE_URL);
+    const barnehagelisterContext = useBarnehagelister();
 
     return (
         <Container>

--- a/src/frontend/sider/Barnehagelister/LasterNyttTabellInnholdSpinner.tsx
+++ b/src/frontend/sider/Barnehagelister/LasterNyttTabellInnholdSpinner.tsx
@@ -1,0 +1,22 @@
+import { Box, HStack, Loader } from '@navikt/ds-react';
+
+import { useHentBarnehagebarn } from '../../hooks/useHentBarnehagebarn';
+import type { BarnehagebarnRequestParams } from '../../typer/barnehagebarn';
+
+interface Props {
+    barnehagebarnRequestParams: BarnehagebarnRequestParams;
+}
+
+export function LasterNyttTabellInnholdSpinner({ barnehagebarnRequestParams }: Props) {
+    const { isFetching, isPending } = useHentBarnehagebarn(barnehagebarnRequestParams);
+
+    if (!isFetching || isPending) {
+        return <Box height={'1.5rem'} />;
+    }
+    return (
+        <HStack height={'1.5rem'} gap={'space-8'} align={'center'} justify={'end'}>
+            <Loader />
+            Henter nyeste barnehagebarn
+        </HStack>
+    );
+}

--- a/src/frontend/typer/barnehagebarn.ts
+++ b/src/frontend/typer/barnehagebarn.ts
@@ -1,7 +1,4 @@
 export interface BarnehagebarnRequestParams extends BarnehagebarnFilter {
-    ident?: string;
-    kommuneNavn?: string;
-    kunLøpendeAndel: boolean;
     limit?: number;
     offset?: number;
     sortBy: string;
@@ -41,8 +38,8 @@ interface IPageable {
     paged: boolean;
     unpaged: false;
 }
-export interface BarnehagebarnResponse<T> {
-    content: T[];
+export interface BarnehagebarnResponse {
+    content: Barnehagebarn[];
     pageable: IPageable;
     sort: ISort;
     last: boolean;


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26627

### 💰 Hva forsøker du å løse i denne PR'en
Har fått inn klager på barnehaglister på at data forsvinner etter 10 sekunder. Dette skjer fordi vi gjør et tregt kall(som tar 10 sek) der vi henter alle barnehagebarn når vi åpner barnehageliste-siden. Hvis saksbehandler da gjør et kall på en spesifikk ident (som går veldig mye raskere) vil dataen fra det raske kallet vises helt til det trege blir ferdig. Når responsen fra det trege kommer vil dataene bli overskrevet med data fra det trege kallet. Dermed forsvinner det saksbehandler egentlig hadde lyst til å se. 

Bytter til å bruke react query siden dette løser problemet "out-of-the-box". 


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
