### PR TITLE
NO-FAVRO: Korrigerer test slik at den ikke feiler på siste dag i måneden

### DIFF
--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -164,7 +164,8 @@ describe('utils/validators', () => {
     });
 
     test('Fom som settes til senere enn inneværende måned på barnehageplass vilkår skal gi OK', () => {
-        const nesteMåned = addMonths(new Date(), 1);
+        const inneværendeMåned = new Date().setDate(1);
+        const nesteMåned = addMonths(inneværendeMåned, 1);
         const nesteMånedOgEnDag = addDays(nesteMåned, 1);
 
         const periode: FeltState<IIsoDatoPeriode> = nyFeltState(


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikser en feilende test som feiler pga. månedsskifte. Setter "dagens dato" til å være første dag i måneden.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Ingen visuelle endringer. 