### PR TITLE
NAV-26302 : refaktorer brev modul med module.css fra styled-components

### DIFF
--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.module.css
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.module.css
@@ -1,5 +1,5 @@
 .checkbox {
-    margin-left: var(--ax-space-16);
+    margin-left: var(--a-spacing-4);
 }
 
 .labelTekst {

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.module.css
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.module.css
@@ -1,0 +1,10 @@
+.checkbox {
+    margin-left: var(--ax-space-16);
+}
+
+.labelTekst {
+    margin: 0;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.tsx
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.tsx
@@ -1,32 +1,13 @@
 import { differenceInMilliseconds } from 'date-fns';
-import styled from 'styled-components';
 
 import { Alert, Checkbox, CheckboxGroup } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
+import styles from './BarnBrevetGjelder.module.css';
 import { BehandlingSteg, hentStegNummer } from '../../../typer/behandling';
 import type { IBarnMedOpplysninger } from '../../../typer/søknad';
 import { isoStringTilDate } from '../../../utils/dato';
 import { lagBarnLabel } from '../../../utils/formatter';
-
-const StyledCheckbox = styled(Checkbox)`
-    margin-left: 1rem;
-
-    > label {
-        width: 100%;
-    }
-`;
-
-const LabelContent = styled.div`
-    display: flex;
-    white-space: nowrap;
-`;
-
-const LabelTekst = styled.p`
-    margin: 0;
-    text-overflow: ellipsis;
-    overflow: hidden;
-`;
 
 interface IProps {
     barnBrevetGjelderFelt: Felt<IBarnMedOpplysninger[]>;
@@ -35,7 +16,7 @@ interface IProps {
     settVisFeilmeldinger: (visFeilmeldinger: boolean) => void;
 }
 
-const BarnBrevetGjelder = (props: IProps) => {
+export const BarnBrevetGjelder = (props: IProps) => {
     const { barnBrevetGjelderFelt, behandlingsSteg, visFeilmeldinger, settVisFeilmeldinger } = props;
 
     const skalViseVarselOmManglendeBarn =
@@ -85,11 +66,11 @@ const BarnBrevetGjelder = (props: IProps) => {
             {sorterteBarn.map((barn: IBarnMedOpplysninger, index: number) => {
                 const barnLabel = lagBarnLabel(barn);
                 return (
-                    <StyledCheckbox value={barn.ident} key={'barn-' + index}>
-                        <LabelContent>
-                            <LabelTekst title={barnLabel}>{barnLabel}</LabelTekst>
-                        </LabelContent>
-                    </StyledCheckbox>
+                    <Checkbox value={barn.ident} key={'barn-' + index} className={styles.checkbox}>
+                        <p title={barnLabel} className={styles.labelTekst}>
+                            {barnLabel}
+                        </p>
+                    </Checkbox>
                 );
             })}
             {skalViseVarselOmManglendeBarn && (
@@ -103,5 +84,3 @@ const BarnBrevetGjelder = (props: IProps) => {
         </CheckboxGroup>
     );
 };
-
-export default BarnBrevetGjelder;

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brev.tsx
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brev.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router';
 
 import { Button, Modal, VStack } from '@navikt/ds-react';
 
-import Brevskjema from './Brevskjema';
+import { Brevskjema } from './Brevskjema';
 import useSakOgBehandlingParams from '../../../hooks/useSakOgBehandlingParams';
 import type { IPersonInfo } from '../../../typer/person';
 

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brev.tsx
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brev.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
-import styled from 'styled-components';
 
-import { Button, Modal } from '@navikt/ds-react';
+import { Button, Modal, VStack } from '@navikt/ds-react';
 
 import Brevskjema from './Brevskjema';
 import useSakOgBehandlingParams from '../../../hooks/useSakOgBehandlingParams';
@@ -14,10 +13,6 @@ interface IProps {
     bruker: IPersonInfo;
 }
 
-const BoksMedMargin = styled.div`
-    margin: 1rem 1.25rem;
-`;
-
 const Brev = ({ onIModalClick, bruker }: IProps) => {
     const { fagsakId } = useSakOgBehandlingParams();
     const navigate = useNavigate();
@@ -25,7 +20,7 @@ const Brev = ({ onIModalClick, bruker }: IProps) => {
     const [visInnsendtBrevModal, settVisInnsendtBrevModal] = useState(false);
 
     return (
-        <BoksMedMargin>
+        <VStack marginBlock={'space-16'} marginInline={'space-20'}>
             <Brevskjema onSubmitSuccess={() => settVisInnsendtBrevModal(true)} bruker={bruker} />
             {visInnsendtBrevModal && (
                 <Modal
@@ -65,7 +60,7 @@ const Brev = ({ onIModalClick, bruker }: IProps) => {
                     </Modal.Footer>
                 </Modal>
             )}
-        </BoksMedMargin>
+        </VStack>
     );
 };
 export default Brev;

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.module.css
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.module.css
@@ -1,0 +1,18 @@
+.textarea {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+    flex: auto;
+}
+
+.freetext {
+    flex: auto;
+}
+
+.removeButton {
+    align-self: center;
+    height: fit-content;
+}
+
+.textField {
+    width: fit-content;
+}

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.module.css
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.module.css
@@ -13,6 +13,10 @@
     height: fit-content;
 }
 
+.addButton {
+    justify-content: flex-start;
+}
+
 .textField {
     width: fit-content;
 }

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -9,7 +9,7 @@ import type { FeltState } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import BarnBrevetGjelder from './BarnBrevetGjelder';
+import { BarnBrevetGjelder } from './BarnBrevetGjelder';
 import BrevmottakerListe from './BrevmottakerListe';
 import type { BrevtypeSelect, ISelectOptionMedBrevtekst } from './typer';
 import { Brevmal, brevmaler, leggTilValuePåOption, opplysningsdokumenter } from './typer';

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -230,6 +230,7 @@ export const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                                         size={'small'}
                                         variant={'tertiary'}
                                         icon={<PlusCircleIcon />}
+                                        className={styles.addButton}
                                     >
                                         {'Legg til kulepunkt'}
                                     </Button>
@@ -283,6 +284,7 @@ export const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                                         onClick={() => settVisFritekstAvsnittTekstboks(true)}
                                         id={`legg-til-fritekst-avsnitt`}
                                         size={'small'}
+                                        className={styles.addButton}
                                         icon={<PlusCircleIcon />}
                                     >
                                         {'Legg til fritekst avsnitt'}

--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -1,9 +1,7 @@
 import type { ChangeEvent } from 'react';
 
-import styled from 'styled-components';
-
 import { FileTextIcon, PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
-import { Button, Fieldset, Label, Select, Tag, Textarea, TextField } from '@navikt/ds-react';
+import { Button, Fieldset, HStack, Label, Select, Tag, Textarea, TextField, VStack } from '@navikt/ds-react';
 import { FamilieReactSelect } from '@navikt/familie-form-elements';
 import type { FeltState } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
@@ -11,6 +9,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { BarnBrevetGjelder } from './BarnBrevetGjelder';
 import BrevmottakerListe from './BrevmottakerListe';
+import styles from './Brevskjema.module.css';
 import type { BrevtypeSelect, ISelectOptionMedBrevtekst } from './typer';
 import { Brevmal, brevmaler, leggTilValuePåOption, opplysningsdokumenter } from './typer';
 import { useBrevModul } from './useBrevModul';
@@ -37,45 +36,7 @@ interface IProps {
     bruker: IPersonInfo;
 }
 
-const StyledSelect = styled(Select)`
-    margin-top: 1rem;
-`;
-
-const StyledFamilieFritekstFelt = styled.div`
-    display: flex;
-
-    .navds-form-field {
-        width: 100% !important;
-    }
-`;
-
-const TextareaBegrunnelseFritekst = styled(Textarea)`
-    .navds-textarea__wrapper {
-        margin-top: 0.5rem;
-        margin-bottom: 0.5rem;
-    }
-`;
-
-const StyledButton = styled(Button)`
-    height: fit-content;
-    align-self: center;
-`;
-
-const LabelOgEtikett = styled.div`
-    display: flex;
-    justify-content: space-between;
-    margin-top: 1rem;
-`;
-
-const StyledTextField = styled(TextField)`
-    width: fit-content;
-`;
-
-const FritekstWrapper = styled.div`
-    margin: 1rem 0;
-`;
-
-const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
+export const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
     const { behandling, settÅpenBehandling, vurderErLesevisning, hentLogg } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 
@@ -133,211 +94,220 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
     }
 
     return (
-        <div>
+        <>
             <Fieldset error={hentFrontendFeilmelding(skjema.submitRessurs)} legend={'Send brev'} hideLegend>
                 <Label>Brev sendes til</Label>
                 <BrevmottakerListe bruker={bruker} brevmottakere={brevmottakere} />
-                <Select
-                    {...skjema.felter.mottakerIdent.hentNavInputProps(skjema.visFeilmeldinger)}
-                    label={'Velg mottaker'}
-                    onChange={(event: ChangeEvent<HTMLSelectElement>): void => {
-                        skjema.felter.mottakerIdent.onChange(event.target.value);
-                    }}
-                >
-                    <option value={''}>Velg</option>
-                    {personer
-                        .filter((person: IGrunnlagPerson) => person.type !== PersonType.BARN)
-                        .map((person, index) => {
+                <VStack gap={'space-16'}>
+                    <Select
+                        {...skjema.felter.mottakerIdent.hentNavInputProps(skjema.visFeilmeldinger)}
+                        label={'Velg mottaker'}
+                        onChange={(event: ChangeEvent<HTMLSelectElement>): void => {
+                            skjema.felter.mottakerIdent.onChange(event.target.value);
+                        }}
+                    >
+                        <option value={''}>Velg</option>
+                        {personer
+                            .filter((person: IGrunnlagPerson) => person.type !== PersonType.BARN)
+                            .map((person, index) => {
+                                return (
+                                    <option
+                                        aria-selected={person.personIdent === skjema.felter.mottakerIdent.verdi}
+                                        key={`${index}_${person.fødselsdato}`}
+                                        value={person.personIdent}
+                                    >
+                                        {lagPersonLabel(person.personIdent, personer)}
+                                    </option>
+                                );
+                            })}
+                    </Select>
+                    <Select
+                        {...skjema.felter.brevmal.hentNavInputProps(skjema.visFeilmeldinger)}
+                        label={'Velg brevmal'}
+                        onChange={(event: ChangeEvent<BrevtypeSelect>): void => {
+                            skjema.felter.brevmal.onChange(event.target.value);
+                            skjema.felter.dokumenter.nullstill();
+                        }}
+                    >
+                        <option value={''}>Velg</option>
+                        {brevMaler.map(mal => {
                             return (
-                                <option
-                                    aria-selected={person.personIdent === skjema.felter.mottakerIdent.verdi}
-                                    key={`${index}_${person.fødselsdato}`}
-                                    value={person.personIdent}
-                                >
-                                    {lagPersonLabel(person.personIdent, personer)}
+                                <option aria-selected={mal === skjema.felter.brevmal.verdi} key={mal} value={mal}>
+                                    {brevmaler[mal]}
                                 </option>
                             );
                         })}
-                </Select>
-                <StyledSelect
-                    {...skjema.felter.brevmal.hentNavInputProps(skjema.visFeilmeldinger)}
-                    label={'Velg brevmal'}
-                    onChange={(event: ChangeEvent<BrevtypeSelect>): void => {
-                        skjema.felter.brevmal.onChange(event.target.value);
-                        skjema.felter.dokumenter.nullstill();
-                    }}
-                >
-                    <option value={''}>Velg</option>
-                    {brevMaler.map(mal => {
-                        return (
-                            <option aria-selected={mal === skjema.felter.brevmal.verdi} key={mal} value={mal}>
-                                {brevmaler[mal]}
-                            </option>
-                        );
-                    })}
-                </StyledSelect>
-
-                {skjema.felter.dokumenter.erSynlig && (
-                    <FamilieReactSelect
-                        {...skjema.felter.dokumenter.hentNavInputProps(skjema.visFeilmeldinger)}
-                        label={
-                            <LabelOgEtikett>
-                                <Label htmlFor={skjema.felter.dokumenter.hentNavInputProps(skjema.visFeilmeldinger).id}>
-                                    Velg dokumenter
-                                </Label>
-                                <Tag variant="neutral" size="small">
-                                    Skriv {målform[mottakersMålform()].toLowerCase()}
-                                </Tag>
-                            </LabelOgEtikett>
-                        }
-                        creatable={false}
-                        isMulti={true}
-                        onChange={valgteOptions => {
-                            skjema.felter.dokumenter.onChange(
-                                valgteOptions === null ? [] : (valgteOptions as ISelectOptionMedBrevtekst[])
-                            );
-                        }}
-                        options={opplysningsdokumenter.map(leggTilValuePåOption)}
-                    />
-                )}
-                {skjema.felter.friteksterKulepunkter.erSynlig && (
-                    <FritekstWrapper>
-                        <Label htmlFor={fieldsetId}>Legg til kulepunkt</Label>
+                    </Select>
+                    {skjema.felter.dokumenter.erSynlig && (
+                        <FamilieReactSelect
+                            {...skjema.felter.dokumenter.hentNavInputProps(skjema.visFeilmeldinger)}
+                            label={
+                                <HStack marginBlock={'space-16 space-8'} justify={'space-between'}>
+                                    <Label
+                                        htmlFor={skjema.felter.dokumenter.hentNavInputProps(skjema.visFeilmeldinger).id}
+                                    >
+                                        Velg dokumenter
+                                    </Label>
+                                    <Tag variant="neutral" size="small">
+                                        Skriv {målform[mottakersMålform()].toLowerCase()}
+                                    </Tag>
+                                </HStack>
+                            }
+                            creatable={false}
+                            isMulti={true}
+                            onChange={valgteOptions => {
+                                skjema.felter.dokumenter.onChange(
+                                    valgteOptions === null ? [] : (valgteOptions as ISelectOptionMedBrevtekst[])
+                                );
+                            }}
+                            options={opplysningsdokumenter.map(leggTilValuePåOption)}
+                        />
+                    )}
+                    {skjema.felter.friteksterKulepunkter.erSynlig && (
                         <>
-                            <Fieldset
-                                id={fieldsetId}
-                                error={skjema.visFeilmeldinger && hentFrontendFeilmelding(skjema.submitRessurs)}
-                                hideLegend
-                                legend={'Legg til kulepunkt'}
-                            >
-                                {skjema.felter.friteksterKulepunkter.verdi.map(
-                                    (fritekst: FeltState<IFritekstFelt>, index: number) => {
-                                        const fritekstId = fritekst.verdi.id;
-
-                                        return (
-                                            <StyledFamilieFritekstFelt key={`fritekst-${fritekstId}`}>
-                                                <SkjultLegend>{`Kulepunkt ${fritekstId}`}</SkjultLegend>
-                                                <TextareaBegrunnelseFritekst
-                                                    key={`fritekst-${fritekstId}`}
-                                                    id={`${fritekstId}`}
-                                                    label={`Kulepunkt ${fritekstId}`}
-                                                    hideLabel
-                                                    size={'small'}
-                                                    className={'fritekst-textarea'}
-                                                    value={fritekst.verdi.tekst}
-                                                    maxLength={makslengdeFritekstHvertKulepunkt}
-                                                    onChange={event => onChangeFritekst(event, fritekstId)}
-                                                    error={skjema.visFeilmeldinger && fritekst.feilmelding}
-                                                    /* eslint-disable-next-line jsx-a11y/no-autofocus */
-                                                    autoFocus
-                                                />
-                                                {!(
-                                                    erBrevmalMedObligatoriskFritekst(
-                                                        skjema.felter.brevmal.verdi as Brevmal
-                                                    ) && index === 0
-                                                ) && (
-                                                    <StyledButton
-                                                        onClick={() => {
-                                                            skjema.felter.friteksterKulepunkter.validerOgSettFelt([
-                                                                ...skjema.felter.friteksterKulepunkter.verdi.filter(
-                                                                    mapFritekst =>
-                                                                        mapFritekst.verdi.id !== fritekst.verdi.id
-                                                                ),
-                                                            ]);
-                                                        }}
-                                                        id={`fjern_fritekst-${fritekstId}`}
-                                                        size={'small'}
-                                                        variant={'tertiary'}
-                                                        aria-label={'Fjern fritekst'}
-                                                        icon={<TrashIcon />}
-                                                    >
-                                                        {'Fjern'}
-                                                    </StyledButton>
-                                                )}
-                                            </StyledFamilieFritekstFelt>
-                                        );
-                                    }
-                                )}
-                            </Fieldset>
-                            {!erMaksAntallKulepunkter && (
-                                <Button
-                                    onClick={() => leggTilFritekst()}
-                                    id={`legg-til-fritekst`}
-                                    size={'small'}
-                                    variant={'tertiary'}
-                                    icon={<PlusCircleIcon />}
+                            <Label htmlFor={fieldsetId}>Legg til kulepunkt</Label>
+                            <>
+                                <Fieldset
+                                    id={fieldsetId}
+                                    error={skjema.visFeilmeldinger && hentFrontendFeilmelding(skjema.submitRessurs)}
+                                    hideLegend
+                                    legend={'Legg til kulepunkt'}
                                 >
-                                    {'Legg til kulepunkt'}
-                                </Button>
+                                    {skjema.felter.friteksterKulepunkter.verdi.map(
+                                        (fritekst: FeltState<IFritekstFelt>, index: number) => {
+                                            const fritekstId = fritekst.verdi.id;
+
+                                            return (
+                                                <HStack key={`fritekst-${fritekstId}`}>
+                                                    <SkjultLegend>{`Kulepunkt ${fritekstId}`}</SkjultLegend>
+                                                    <Textarea
+                                                        key={`fritekst-${fritekstId}`}
+                                                        id={`${fritekstId}`}
+                                                        label={`Kulepunkt ${fritekstId}`}
+                                                        hideLabel
+                                                        size={'small'}
+                                                        className={styles.textarea}
+                                                        value={fritekst.verdi.tekst}
+                                                        maxLength={makslengdeFritekstHvertKulepunkt}
+                                                        onChange={event => onChangeFritekst(event, fritekstId)}
+                                                        error={skjema.visFeilmeldinger && fritekst.feilmelding}
+                                                        /* eslint-disable-next-line jsx-a11y/no-autofocus */
+                                                        autoFocus
+                                                    />
+                                                    {!(
+                                                        erBrevmalMedObligatoriskFritekst(
+                                                            skjema.felter.brevmal.verdi as Brevmal
+                                                        ) && index === 0
+                                                    ) && (
+                                                        <Button
+                                                            onClick={() => {
+                                                                skjema.felter.friteksterKulepunkter.validerOgSettFelt([
+                                                                    ...skjema.felter.friteksterKulepunkter.verdi.filter(
+                                                                        mapFritekst =>
+                                                                            mapFritekst.verdi.id !== fritekst.verdi.id
+                                                                    ),
+                                                                ]);
+                                                            }}
+                                                            id={`fjern_fritekst-${fritekstId}`}
+                                                            size={'small'}
+                                                            variant={'tertiary'}
+                                                            aria-label={'Fjern fritekst'}
+                                                            icon={<TrashIcon />}
+                                                            className={styles.removeButton}
+                                                        >
+                                                            {'Fjern'}
+                                                        </Button>
+                                                    )}
+                                                </HStack>
+                                            );
+                                        }
+                                    )}
+                                </Fieldset>
+                                {!erMaksAntallKulepunkter && (
+                                    <Button
+                                        onClick={() => leggTilFritekst()}
+                                        id={`legg-til-fritekst`}
+                                        size={'small'}
+                                        variant={'tertiary'}
+                                        icon={<PlusCircleIcon />}
+                                    >
+                                        {'Legg til kulepunkt'}
+                                    </Button>
+                                )}
+                            </>
+                        </>
+                    )}
+                    {skjema.felter.fritekstAvsnitt.erSynlig && (
+                        <>
+                            <Label htmlFor={fieldsetId}>Legg til fritekst avsnitt</Label>
+                            {visFritekstAvsnittTekstboks ? (
+                                <Fieldset legend="Legg til fritekst avsnitt" hideLegend id={fieldsetId}>
+                                    <HStack>
+                                        <Textarea
+                                            label="Skriv inn fritekstavsnitt"
+                                            className={styles.freetext}
+                                            hideLabel
+                                            size={'small'}
+                                            value={skjema.felter.fritekstAvsnitt.verdi}
+                                            maxLength={maksLengdeFritekstAvsnitt}
+                                            onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+                                                skjema.felter.fritekstAvsnitt.validerOgSettFelt(event.target.value)
+                                            }
+                                            error={
+                                                skjema.visFeilmeldinger && skjema.felter.fritekstAvsnitt?.feilmelding
+                                            }
+                                            /* eslint-disable-next-line jsx-a11y/no-autofocus */
+                                            autoFocus
+                                        />
+                                        <Button
+                                            variant={'tertiary'}
+                                            className={styles.removeButton}
+                                            onClick={() => {
+                                                skjema.felter.fritekstAvsnitt.nullstill();
+                                                settVisFritekstAvsnittTekstboks(false);
+                                            }}
+                                            id={`fjern_fritekst`}
+                                            size={'small'}
+                                            aria-label={'Fjern fritekst'}
+                                            icon={<TrashIcon />}
+                                        >
+                                            {'Fjern'}
+                                        </Button>
+                                    </HStack>
+                                </Fieldset>
+                            ) : (
+                                skjema.felter.fritekstAvsnitt &&
+                                !erLesevisning && (
+                                    <Button
+                                        variant={'tertiary'}
+                                        onClick={() => settVisFritekstAvsnittTekstboks(true)}
+                                        id={`legg-til-fritekst-avsnitt`}
+                                        size={'small'}
+                                        icon={<PlusCircleIcon />}
+                                    >
+                                        {'Legg til fritekst avsnitt'}
+                                    </Button>
+                                )
                             )}
                         </>
-                    </FritekstWrapper>
-                )}
-                {skjema.felter.fritekstAvsnitt.erSynlig && (
-                    <FritekstWrapper>
-                        <Label htmlFor={fieldsetId}>Legg til fritekst avsnitt</Label>
-                        {visFritekstAvsnittTekstboks ? (
-                            <Fieldset legend="Legg til fritekst avsnitt" hideLegend id={fieldsetId}>
-                                <StyledFamilieFritekstFelt>
-                                    <Textarea
-                                        label="Skriv inn fritekstavsnitt"
-                                        hideLabel
-                                        size={'small'}
-                                        value={skjema.felter.fritekstAvsnitt.verdi}
-                                        maxLength={maksLengdeFritekstAvsnitt}
-                                        onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
-                                            skjema.felter.fritekstAvsnitt.validerOgSettFelt(event.target.value)
-                                        }
-                                        error={skjema.visFeilmeldinger && skjema.felter.fritekstAvsnitt?.feilmelding}
-                                        /* eslint-disable-next-line jsx-a11y/no-autofocus */
-                                        autoFocus
-                                    />
-                                    <StyledButton
-                                        variant={'tertiary'}
-                                        onClick={() => {
-                                            skjema.felter.fritekstAvsnitt.nullstill();
-                                            settVisFritekstAvsnittTekstboks(false);
-                                        }}
-                                        id={`fjern_fritekst`}
-                                        size={'small'}
-                                        aria-label={'Fjern fritekst'}
-                                        icon={<TrashIcon />}
-                                    >
-                                        {'Fjern'}
-                                    </StyledButton>
-                                </StyledFamilieFritekstFelt>
-                            </Fieldset>
-                        ) : (
-                            skjema.felter.fritekstAvsnitt &&
-                            !erLesevisning && (
-                                <Button
-                                    variant={'tertiary'}
-                                    onClick={() => settVisFritekstAvsnittTekstboks(true)}
-                                    id={`legg-til-fritekst-avsnitt`}
-                                    size={'small'}
-                                    icon={<PlusCircleIcon />}
-                                >
-                                    {'Legg til fritekst avsnitt'}
-                                </Button>
-                            )
-                        )}
-                    </FritekstWrapper>
-                )}
-                {skjema.felter.barnBrevetGjelder.erSynlig && (
-                    <BarnBrevetGjelder
-                        barnBrevetGjelderFelt={skjema.felter.barnBrevetGjelder}
-                        behandlingsSteg={behandling.steg}
-                        visFeilmeldinger={skjema.visFeilmeldinger}
-                        settVisFeilmeldinger={settVisfeilmeldinger}
-                    />
-                )}
-                {skjema.felter.brevmal.verdi === Brevmal.FORLENGET_SVARTIDSBREV && (
-                    <StyledTextField
-                        {...skjema.felter.antallUkerSvarfrist.hentNavInputProps(skjema.visFeilmeldinger)}
-                        label={'Antall uker svarfrist'}
-                        size={'small'}
-                    />
-                )}
+                    )}
+                    {skjema.felter.barnBrevetGjelder.erSynlig && (
+                        <BarnBrevetGjelder
+                            barnBrevetGjelderFelt={skjema.felter.barnBrevetGjelder}
+                            behandlingsSteg={behandling.steg}
+                            visFeilmeldinger={skjema.visFeilmeldinger}
+                            settVisFeilmeldinger={settVisfeilmeldinger}
+                        />
+                    )}
+                    {skjema.felter.brevmal.verdi === Brevmal.FORLENGET_SVARTIDSBREV && (
+                        <TextField
+                            className={styles.textField}
+                            {...skjema.felter.antallUkerSvarfrist.hentNavInputProps(skjema.visFeilmeldinger)}
+                            label={'Antall uker svarfrist'}
+                            size={'small'}
+                        />
+                    )}
+                </VStack>
             </Fieldset>
             <Knapperekke>
                 <Button
@@ -383,8 +353,6 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                     Send brev
                 </Button>
             </Knapperekke>
-        </div>
+        </>
     );
 };
-
-export default Brevskjema;


### PR DESCRIPTION
[NAV-26302](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26302)

### 💰 Hva forsøker du å løse i denne PR'en
Går bort fra styled-components over til Aksel primitives der mulig og module.css styling.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Det er vanskelig å teste alle optional felter og kombinasjoner mulig i løsningen. Gjerne sjekk gjennom for å se om alt ser riktig ut og om småendringer er foretrukket eller ei.

I komponent BarnBrevetGjelder har jeg fjernet styling `
    > label {
        width: 100%;
    }` ettersom jeg ikke ser noen visuelle endringer med eller uten.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Ingen visuelle endringer bortsett fra det jeg har spesifisert under:
Gammel venstre, ny høyre. Jeg syns spacing mellom label og select på den med tag var mindre og ikke lik de andre, i tillegg var tag rett på selecten, så jeg legger til litt mer spacing under.
<img width="376" height="166" alt="image" src="https://github.com/user-attachments/assets/f31df427-baf1-4a71-ba63-b9341559b8ee" /><img width="361" height="226" alt="image" src="https://github.com/user-attachments/assets/690a7989-054d-4551-9a4b-c626e51e9cae" />


Fritekst avsnitt:
Før
<img width="386" height="180" alt="image" src="https://github.com/user-attachments/assets/75ae1923-5acb-4b38-bc95-3ff5db3b253b" />
Etter
<img width="474" height="379" alt="image" src="https://github.com/user-attachments/assets/d144391e-2dfa-460e-9d44-f206fd7bea4f" />

Legg til kulepunkt er sentrert og fyller plassen. Jeg syns det ble fint. Matcher knapp for legg til fritekst.
FØR
<img width="400" height="309" alt="image" src="https://github.com/user-attachments/assets/99ded649-13de-47b3-89f0-9bb50eb504dd" />
ETTER
<img width="367" height="410" alt="image" src="https://github.com/user-attachments/assets/c3b003f7-1f3c-40a0-99fc-3369eb23130f" /><img width="383" height="261" alt="image" src="https://github.com/user-attachments/assets/28ff6378-cc5c-458f-b085-12c3d78b7992" />

