### PR TITLE
NAV-26760: Legger til fagsakmeny

### DIFF
--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/Fagsakmeny.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/Fagsakmeny.test.tsx
@@ -1,0 +1,120 @@
+import { type PropsWithChildren } from 'react';
+
+import { Route, Routes } from 'react-router';
+import { describe, expect } from 'vitest';
+
+import { Heading } from '@navikt/ds-react';
+
+import { Fagsakmeny } from './Fagsakmeny';
+import { FagsakTestdata } from '../../../../testutils/testdata/fagsakTestdata';
+import { lagPerson } from '../../../../testutils/testdata/personTestdata';
+import { render, TestProviders } from '../../../../testutils/testrender';
+import { BrukerProvider } from '../../BrukerContext';
+import { FagsakProvider } from '../../FagsakContext';
+import { ManuelleBrevmottakerePåFagsakProvider } from '../../ManuelleBrevmottakerePåFagsakContext';
+
+interface WrapperProps extends PropsWithChildren {
+    initialEntries?: [{ pathname: string }];
+}
+
+function Wrapper({ initialEntries = [{ pathname: '/fagsak/1' }], children }: WrapperProps) {
+    return (
+        <TestProviders initialEntries={initialEntries}>
+            <FagsakProvider fagsak={FagsakTestdata.lagFagsak()}>
+                <BrukerProvider bruker={lagPerson()}>
+                    <ManuelleBrevmottakerePåFagsakProvider>
+                        <Routes>
+                            <Route
+                                path={'/fagsak/:fagsakId/dokumentutsending'}
+                                element={
+                                    <>
+                                        <Heading level={'1'} size={'medium'}>
+                                            Dokumentutsending
+                                        </Heading>
+                                        {children}
+                                    </>
+                                }
+                            />
+                            <Route path={'/fagsak/:fagsakId'} element={<>{children}</>} />
+                        </Routes>
+                    </ManuelleBrevmottakerePåFagsakProvider>
+                </BrukerProvider>
+            </FagsakProvider>
+        </TestProviders>
+    );
+}
+
+describe('Fagsakmeny', () => {
+    test('skal rendre komponenten som forventent', () => {
+        const { screen } = render(<Fagsakmeny />, { wrapper: Wrapper });
+        expect(screen.getByRole('button', { name: 'Meny' })).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Opprett behandling' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Send informasjonsbrev' })).not.toBeInTheDocument();
+    });
+
+    test('skal vise de korrekt knappene når man trykker på menyen når man ikke er på dokumentsiden', async () => {
+        const { screen, user } = render(<Fagsakmeny />, {
+            wrapper: props => <Wrapper {...props} initialEntries={[{ pathname: '/fagsak/1' }]} />,
+        });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        expect(screen.getByRole('menuitem', { name: 'Opprett behandling' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Send informasjonsbrev' })).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Legg til brevmottaker' })).not.toBeInTheDocument();
+    });
+
+    test('skal vise de korrekte knappene når man trykker på menyen når man er på dokumentsiden', async () => {
+        const { screen, user } = render(<Fagsakmeny />, {
+            wrapper: props => <Wrapper {...props} initialEntries={[{ pathname: '/fagsak/1/dokumentutsending' }]} />,
+        });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        expect(screen.getByRole('menuitem', { name: 'Opprett behandling' })).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Send informasjonsbrev' })).not.toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Legg til brevmottaker' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne opprett behandling modal', async () => {
+        const { screen, user } = render(<Fagsakmeny />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Opprett behandling' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('dialog', { name: 'Opprett ny behandling' })).toBeInTheDocument();
+    });
+
+    test('skal kunne navigere til dokumentutsending', async () => {
+        const { screen, user } = render(<Fagsakmeny />, {
+            wrapper: props => <Wrapper {...props} initialEntries={[{ pathname: '/fagsak/1' }]} />,
+        });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Send informasjonsbrev' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('heading', { name: 'Dokumentutsending' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne legg til brevmottaker modal på dokumentutsending siden', async () => {
+        const { screen, user } = render(<Fagsakmeny />, {
+            wrapper: props => <Wrapper {...props} initialEntries={[{ pathname: '/fagsak/1/dokumentutsending' }]} />,
+        });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Legg til brevmottaker' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('dialog', { name: 'Legg til brevmottaker' })).toBeInTheDocument();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/Fagsakmeny.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/Fagsakmeny.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+
+import { ChevronDownIcon } from '@navikt/aksel-icons';
+import { ActionMenu, Button } from '@navikt/ds-react';
+
+import { LeggTilBrevmottakerModalFagsak } from './LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak';
+import { LeggTilEllerFjernBrevmottakerePåFagsak } from './LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak';
+import { OpprettBehandlingModal } from './OpprettBehandling/OpprettBehandlingModal';
+import { OpprettBehandlingNy } from './OpprettBehandling/OpprettBehandlingNy';
+import { SendInformasjonsbrev } from './SendInformasjonsbrev/SendInformasjonsbrev';
+
+export function Fagsakmeny() {
+    const [visOpprettBehandlingModal, settVisOpprettBehandlingModal] = useState(false);
+    const [visLeggTilBrevmottakerModal, settVisLeggTilBrevmottakerModal] = useState(false);
+
+    return (
+        <>
+            {visOpprettBehandlingModal && (
+                <OpprettBehandlingModal lukkModal={() => settVisOpprettBehandlingModal(false)} />
+            )}
+            {visLeggTilBrevmottakerModal && (
+                <LeggTilBrevmottakerModalFagsak lukkModal={() => settVisLeggTilBrevmottakerModal(false)} />
+            )}
+            <ActionMenu>
+                <ActionMenu.Trigger>
+                    <Button variant={'secondary'} size={'small'} iconPosition={'right'} icon={<ChevronDownIcon />}>
+                        Meny
+                    </Button>
+                </ActionMenu.Trigger>
+                <ActionMenu.Content>
+                    <ActionMenu.Group aria-label={'Fagsak'}>
+                        <OpprettBehandlingNy åpneModal={() => settVisOpprettBehandlingModal(true)} />
+                        <LeggTilEllerFjernBrevmottakerePåFagsak
+                            åpneModal={() => settVisLeggTilBrevmottakerModal(true)}
+                        />
+                        <SendInformasjonsbrev />
+                    </ActionMenu.Group>
+                </ActionMenu.Content>
+            </ActionMenu>
+        </>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.test.tsx
@@ -1,0 +1,118 @@
+import { type PropsWithChildren } from 'react';
+
+import { Route, Routes } from 'react-router';
+import { describe, expect } from 'vitest';
+
+import { ActionMenu, Heading } from '@navikt/ds-react';
+
+import { LeggTilEllerFjernBrevmottakerePåFagsak } from './LeggTilEllerFjernBrevmottakerePåFagsak';
+import type { SkjemaBrevmottaker } from './useBrevmottakerSkjema';
+import { BrevmottakerTestdata } from '../../../../../testutils/testdata/brevmottakerTestdata';
+import { render, TestProviders } from '../../../../../testutils/testrender';
+import { ManuelleBrevmottakerePåFagsakProvider } from '../../../ManuelleBrevmottakerePåFagsakContext';
+
+interface WrapperProps extends PropsWithChildren {
+    initialEntries?: [{ pathname: string }];
+    brevmottakere?: SkjemaBrevmottaker[];
+}
+
+function Wrapper({ initialEntries = [{ pathname: '/fagsak/1' }], brevmottakere = [], children }: WrapperProps) {
+    return (
+        <TestProviders initialEntries={initialEntries}>
+            <ManuelleBrevmottakerePåFagsakProvider brevmottakere={brevmottakere}>
+                <Routes>
+                    <Route
+                        path={'/fagsak/:fagsakId/dokumentutsending'}
+                        element={
+                            <>
+                                <Heading level={'1'} size={'medium'}>
+                                    Dokumentutsending
+                                </Heading>
+                                <ActionMenu open={true}>
+                                    <ActionMenu.Content>{children}</ActionMenu.Content>
+                                </ActionMenu>
+                            </>
+                        }
+                    />
+                    <Route
+                        path={'/fagsak/:fagsakId'}
+                        element={
+                            <ActionMenu open={true}>
+                                <ActionMenu.Content>{children}</ActionMenu.Content>
+                            </ActionMenu>
+                        }
+                    />
+                </Routes>
+            </ManuelleBrevmottakerePåFagsakProvider>
+        </TestProviders>
+    );
+}
+
+describe('LeggTilEllerFjernBrevmottakerePåFagsak', () => {
+    test('skal ikke rendre komponenten hvis man ikke befinner seg på dokumentutsending', () => {
+        const åpneModal = vi.fn();
+
+        const { screen } = render(<LeggTilEllerFjernBrevmottakerePåFagsak åpneModal={åpneModal} />, {
+            wrapper: props => <Wrapper {...props} initialEntries={[{ pathname: '/fagsak/1' }]} />,
+        });
+
+        expect(screen.queryByRole('menuitem', { name: 'Legg til brevmottaker' })).not.toBeInTheDocument();
+    });
+
+    test('skal rendre komponenten uten brevmottakere hvis man befinner seg på dokumentutsending', () => {
+        const åpneModal = vi.fn();
+
+        const { screen } = render(<LeggTilEllerFjernBrevmottakerePåFagsak åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper {...props} initialEntries={[{ pathname: '/fagsak/1/dokumentutsending' }]} brevmottakere={[]} />
+            ),
+        });
+
+        expect(screen.getByRole('menuitem', { name: 'Legg til brevmottaker' })).toBeInTheDocument();
+    });
+
+    test('skal rendre komponenten med en brevmottaker hvis man befinner seg på dokumentutsending', () => {
+        const åpneModal = vi.fn();
+
+        const { screen } = render(<LeggTilEllerFjernBrevmottakerePåFagsak åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    initialEntries={[{ pathname: '/fagsak/1/dokumentutsending' }]}
+                    brevmottakere={[BrevmottakerTestdata.lagBrevmottaker()]}
+                />
+            ),
+        });
+
+        expect(screen.getByRole('menuitem', { name: 'Legg til eller fjern brevmottaker' })).toBeInTheDocument();
+    });
+
+    test('skal rendre komponenten med mer enn en brevmottaker hvis man befinner seg på dokumentutsending', () => {
+        const åpneModal = vi.fn();
+
+        const { screen } = render(<LeggTilEllerFjernBrevmottakerePåFagsak åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    initialEntries={[{ pathname: '/fagsak/1/dokumentutsending' }]}
+                    brevmottakere={[BrevmottakerTestdata.lagBrevmottaker(), BrevmottakerTestdata.lagBrevmottaker()]}
+                />
+            ),
+        });
+
+        expect(screen.getByRole('menuitem', { name: 'Se eller fjern brevmottakere' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne legg til brevmottaker modal', async () => {
+        const åpneModal = vi.fn();
+
+        const { screen, user } = render(<LeggTilEllerFjernBrevmottakerePåFagsak åpneModal={åpneModal} />, {
+            wrapper: props => <Wrapper {...props} initialEntries={[{ pathname: '/fagsak/1/dokumentutsending' }]} />,
+        });
+
+        const knapp = screen.getByRole('menuitem', { name: 'Legg til brevmottaker' });
+        await user.click(knapp);
+
+        expect(åpneModal).toHaveBeenCalledOnce();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.tsx
@@ -1,0 +1,32 @@
+import { useLocation } from 'react-router';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+import type { SkjemaBrevmottaker } from './useBrevmottakerSkjema';
+import { useManuelleBrevmottakerePåFagsakContext } from '../../../ManuelleBrevmottakerePåFagsakContext';
+
+function utledLabel(brevmottakere: SkjemaBrevmottaker[]) {
+    if (brevmottakere.length === 0) {
+        return 'Legg til brevmottaker';
+    }
+    return brevmottakere.length === 1 ? 'Legg til eller fjern brevmottaker' : 'Se eller fjern brevmottakere';
+}
+
+interface Props {
+    åpneModal: () => void;
+}
+
+export function LeggTilEllerFjernBrevmottakerePåFagsak({ åpneModal }: Props) {
+    const { manuelleBrevmottakerePåFagsak } = useManuelleBrevmottakerePåFagsakContext();
+    const location = useLocation();
+
+    const erPåDokumentutsending = location.pathname.includes('dokumentutsending');
+
+    if (!erPåDokumentutsending) {
+        return null;
+    }
+
+    const label = utledLabel(manuelleBrevmottakerePåFagsak);
+
+    return <ActionMenu.Item onSelect={åpneModal}>{label}</ActionMenu.Item>;
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingModal.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingModal.tsx
@@ -1,0 +1,121 @@
+import { isBefore, subDays } from 'date-fns';
+import styled from 'styled-components';
+
+import { Alert, Button, Fieldset, Modal } from '@navikt/ds-react';
+import { RessursStatus } from '@navikt/familie-typer';
+
+import BehandlingstypeFelt from './BehandlingstypeFelt';
+import { BehandlingårsakFelt } from './BehandlingsårsakFelt';
+import useOpprettBehandling from './useOpprettBehandling';
+import { BehandlingstemaSelect } from '../../../../../komponenter/BehandlingstemaSelect';
+import Datovelger from '../../../../../komponenter/Datovelger/Datovelger';
+import { hentDagensDato } from '../../../../../utils/dato';
+import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
+import { useFagsakContext } from '../../../FagsakContext';
+
+const StyledFieldset = styled(Fieldset)`
+    && > div:not(:last-child):not(:empty) {
+        margin-bottom: 1rem;
+    }
+`;
+
+const StyledAlert = styled(Alert)`
+    margin-top: 1.5rem;
+`;
+
+interface Props {
+    lukkModal: () => void;
+}
+
+export function OpprettBehandlingModal({ lukkModal }: Props) {
+    const { fagsak } = useFagsakContext();
+
+    const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus } = useOpprettBehandling({ lukkModal });
+
+    const lukkOpprettBehandlingModal = () => {
+        nullstillSkjemaStatus();
+        lukkModal();
+    };
+
+    const søknadMottattDatoErMerEnn360DagerSiden =
+        opprettBehandlingSkjema.felter.søknadMottattDato.verdi &&
+        isBefore(opprettBehandlingSkjema.felter.søknadMottattDato.verdi, subDays(hentDagensDato(), 360));
+
+    return (
+        <Modal
+            open={true}
+            portal={true}
+            width={'35rem'}
+            header={{ heading: 'Opprett ny behandling' }}
+            onClose={lukkOpprettBehandlingModal}
+        >
+            <Modal.Body>
+                <StyledFieldset
+                    error={hentFrontendFeilmelding(opprettBehandlingSkjema.submitRessurs)}
+                    legend={'Opprett ny behandling'}
+                    hideLegend
+                >
+                    <BehandlingstypeFelt
+                        behandlingstype={opprettBehandlingSkjema.felter.behandlingstype}
+                        visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
+                        minimalFagsak={fagsak}
+                    />
+                    {opprettBehandlingSkjema.felter.behandlingsårsak.erSynlig && (
+                        <BehandlingårsakFelt
+                            behandlingsårsak={opprettBehandlingSkjema.felter.behandlingsårsak}
+                            visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
+                        />
+                    )}
+                    {opprettBehandlingSkjema.felter.behandlingstema.erSynlig && (
+                        <BehandlingstemaSelect
+                            behandlingstema={opprettBehandlingSkjema.felter.behandlingstema}
+                            visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
+                            name="Behandlingstema"
+                            label="Velg behandlingstema"
+                        />
+                    )}
+                    {opprettBehandlingSkjema.felter.klageMottattDato.erSynlig && (
+                        <Datovelger
+                            felt={opprettBehandlingSkjema.felter.klageMottattDato}
+                            visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
+                            label={'Klage mottatt'}
+                            kanKunVelgeFortid
+                        />
+                    )}
+                    {opprettBehandlingSkjema.felter.søknadMottattDato.erSynlig && (
+                        <Datovelger
+                            felt={opprettBehandlingSkjema.felter.søknadMottattDato}
+                            visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
+                            label={'Mottatt dato'}
+                            kanKunVelgeFortid
+                        />
+                    )}
+                </StyledFieldset>
+                {søknadMottattDatoErMerEnn360DagerSiden && (
+                    <StyledAlert variant={'warning'}>
+                        Er mottatt dato riktig? <br />
+                        Det er mer enn 360 dager siden denne datoen.
+                    </StyledAlert>
+                )}
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    key={'bekreft'}
+                    variant="primary"
+                    size="small"
+                    onClick={() => onBekreft(fagsak.søkerFødselsnummer)}
+                    children={'Bekreft'}
+                    loading={opprettBehandlingSkjema.submitRessurs.status === RessursStatus.HENTER}
+                    disabled={opprettBehandlingSkjema.submitRessurs.status === RessursStatus.HENTER}
+                />
+                <Button
+                    key={'avbryt'}
+                    variant="tertiary"
+                    size="small"
+                    onClick={lukkOpprettBehandlingModal}
+                    children={'Avbryt'}
+                />
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingNy.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingNy.test.tsx
@@ -1,0 +1,37 @@
+import { type PropsWithChildren } from 'react';
+
+import { expect } from 'vitest';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+import { OpprettBehandlingNy } from './OpprettBehandlingNy';
+import { render } from '../../../../../testutils/testrender';
+
+function Wrapper({ children }: PropsWithChildren) {
+    return (
+        <ActionMenu open={true}>
+            <ActionMenu.Content>{children}</ActionMenu.Content>
+        </ActionMenu>
+    );
+}
+
+describe('OpprettBehandlingNy', () => {
+    test('skal rendre komponent som forventet', () => {
+        const åpneModal = vi.fn();
+
+        const { screen } = render(<OpprettBehandlingNy åpneModal={åpneModal} />, { wrapper: Wrapper });
+
+        expect(screen.getByRole('menuitem', { name: 'Opprett behandling' })).toBeInTheDocument();
+    });
+
+    test('skal kunne klikke på opprett behandling', async () => {
+        const åpneModal = vi.fn();
+
+        const { screen, user } = render(<OpprettBehandlingNy åpneModal={åpneModal} />, { wrapper: Wrapper });
+
+        const knapp = screen.getByRole('menuitem', { name: 'Opprett behandling' });
+        await user.click(knapp);
+
+        expect(åpneModal).toHaveBeenCalledOnce();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingNy.tsx
@@ -1,0 +1,9 @@
+import { ActionMenu } from '@navikt/ds-react';
+
+interface Props {
+    åpneModal: () => void;
+}
+
+export function OpprettBehandlingNy({ åpneModal }: Props) {
+    return <ActionMenu.Item onSelect={åpneModal}>Opprett behandling</ActionMenu.Item>;
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -36,7 +36,7 @@ const useOpprettBehandling = ({
     onOpprettTilbakekrevingSuccess,
 }: {
     lukkModal: () => void;
-    onOpprettTilbakekrevingSuccess: () => void;
+    onOpprettTilbakekrevingSuccess?: () => void;
 }) => {
     const { fagsakId } = useSakOgBehandlingParams();
     const { fagsak } = useFagsakContext();
@@ -154,7 +154,7 @@ const useOpprettBehandling = ({
             response => {
                 if (response.status === RessursStatus.SUKSESS) {
                     nullstillSkjemaStatus();
-                    onOpprettTilbakekrevingSuccess();
+                    onOpprettTilbakekrevingSuccess?.();
                     queryClient.invalidateQueries({
                         queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.tilbakekrevingsbehandlinger(fagsak.id),
                     });

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/SendInformasjonsbrev/SendInformasjonsbrev.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/SendInformasjonsbrev/SendInformasjonsbrev.test.tsx
@@ -1,0 +1,44 @@
+import { type PropsWithChildren } from 'react';
+
+import { describe, expect } from 'vitest';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+import { SendInformasjonsbrev } from './SendInformasjonsbrev';
+import { lagFagsak } from '../../../../../testutils/testdata/fagsakTestdata';
+import { render, TestProviders } from '../../../../../testutils/testrender';
+import { FagsakProvider } from '../../../FagsakContext';
+
+interface WrapperProps extends PropsWithChildren {
+    initialEntries?: [{ pathname: string }];
+}
+
+function Wrapper({ initialEntries = [{ pathname: '/fagsak/1' }], children }: WrapperProps) {
+    return (
+        <TestProviders initialEntries={initialEntries}>
+            <FagsakProvider fagsak={lagFagsak()}>
+                <ActionMenu open={true}>
+                    <ActionMenu.Content>{children}</ActionMenu.Content>
+                </ActionMenu>
+            </FagsakProvider>
+        </TestProviders>
+    );
+}
+
+describe('SendInformasjonsbrev', () => {
+    test('skal ikke vise komponenten hvis man befinner seg på dokumentutsending siden', () => {
+        const { screen } = render(<SendInformasjonsbrev />, {
+            wrapper: props => <Wrapper {...props} initialEntries={[{ pathname: '/fagsak/1/dokumentutsending' }]} />,
+        });
+
+        expect(screen.queryByRole('menuitem', { name: 'Send informasjonsbrev' })).not.toBeInTheDocument();
+    });
+
+    test('skal vise komponenten som forventet', () => {
+        const { screen } = render(<SendInformasjonsbrev />, {
+            wrapper: props => <Wrapper {...props} initialEntries={[{ pathname: '/fagsak/1' }]} />,
+        });
+
+        expect(screen.getByRole('menuitem', { name: 'Send informasjonsbrev' })).toBeInTheDocument();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/SendInformasjonsbrev/SendInformasjonsbrev.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/SendInformasjonsbrev/SendInformasjonsbrev.tsx
@@ -1,0 +1,24 @@
+import { useLocation, useNavigate } from 'react-router';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+import { useFagsakContext } from '../../../FagsakContext';
+
+export function SendInformasjonsbrev() {
+    const { fagsak } = useFagsakContext();
+
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    const erPåDokumentutsending = location.pathname.includes('dokumentutsending');
+
+    if (erPåDokumentutsending) {
+        return null;
+    }
+
+    return (
+        <ActionMenu.Item onSelect={() => navigate(`/fagsak/${fagsak.id}/dokumentutsending`)}>
+            Send informasjonsbrev
+        </ActionMenu.Item>
+    );
+}

--- a/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.tsx
+++ b/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.tsx
@@ -10,8 +10,12 @@ interface ManuelleBrevmottakerePåFagsakContext {
 
 const ManuelleBrevmottakerePåFagsakContext = createContext<ManuelleBrevmottakerePåFagsakContext | undefined>(undefined);
 
-export function ManuelleBrevmottakerePåFagsakProvider({ children }: PropsWithChildren) {
-    const [manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak] = useState<SkjemaBrevmottaker[]>([]);
+interface Props extends PropsWithChildren {
+    brevmottakere?: SkjemaBrevmottaker[];
+}
+
+export function ManuelleBrevmottakerePåFagsakProvider({ brevmottakere = [], children }: Props) {
+    const [manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak] = useState(brevmottakere);
 
     const value = useMemo(
         () => ({

--- a/src/frontend/testutils/mocks/handlers/fagsakHandlers.ts
+++ b/src/frontend/testutils/mocks/handlers/fagsakHandlers.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from 'msw';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+import { FagsakTestdata } from '../../testdata/fagsakTestdata';
+
+export const fagsakHandlers = [
+    http.post<never, { ident: string }>('/familie-ks-sak/api/fagsaker/hent-fagsak-paa-person', async ({ request }) => {
+        const payload = await request.json();
+        return HttpResponse.json(byggSuksessRessurs([FagsakTestdata.lagFagsak({ søkerFødselsnummer: payload.ident })]));
+    }),
+];

--- a/src/frontend/testutils/mocks/handlers/featureToggleHandlers.ts
+++ b/src/frontend/testutils/mocks/handlers/featureToggleHandlers.ts
@@ -1,0 +1,11 @@
+import { http, HttpResponse } from 'msw';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+import { alleTogglerAv } from '../../../typer/toggles';
+
+export const featureToggleHandlers = [
+    http.post('/familie-ks-sak/api/featuretoggles', () => {
+        return HttpResponse.json(byggSuksessRessurs(alleTogglerAv()));
+    }),
+];

--- a/src/frontend/testutils/mocks/handlers/handlers.ts
+++ b/src/frontend/testutils/mocks/handlers/handlers.ts
@@ -1,5 +1,17 @@
 import { behandlingHandlers } from './behandlingHandlers';
+import { fagsakHandlers } from './fagsakHandlers';
+import { featureToggleHandlers } from './featureToggleHandlers';
 import { klageHandlers } from './klageHandlers';
+import { personHandlers } from './personHandlers';
 import { tilbakekrevingHandlers } from './tilbakekrevingHandlers';
+import { versionHandlers } from './versionHandlers';
 
-export const handlers = [...behandlingHandlers, ...klageHandlers, ...tilbakekrevingHandlers];
+export const handlers = [
+    ...behandlingHandlers,
+    ...klageHandlers,
+    ...tilbakekrevingHandlers,
+    ...featureToggleHandlers,
+    ...versionHandlers,
+    ...personHandlers,
+    ...fagsakHandlers,
+];

--- a/src/frontend/testutils/mocks/handlers/personHandlers.ts
+++ b/src/frontend/testutils/mocks/handlers/personHandlers.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from 'msw';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+import { PersonTestdata } from '../../testdata/personTestdata';
+
+export const personHandlers = [
+    http.post<never, { ident: string }>('/familie-ks-sak/api/person', async ({ request }) => {
+        const payload = await request.json();
+        return HttpResponse.json(byggSuksessRessurs(PersonTestdata.lagPerson({ personIdent: payload.ident })));
+    }),
+];

--- a/src/frontend/testutils/mocks/handlers/versionHandlers.ts
+++ b/src/frontend/testutils/mocks/handlers/versionHandlers.ts
@@ -1,0 +1,9 @@
+import { http, HttpResponse } from 'msw';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+export const versionHandlers = [
+    http.get('/version', () => {
+        return HttpResponse.json(byggSuksessRessurs('1'));
+    }),
+];

--- a/src/frontend/testutils/testdata/personTestdata.ts
+++ b/src/frontend/testutils/testdata/personTestdata.ts
@@ -1,0 +1,24 @@
+import { kjønnType } from '@navikt/familie-typer';
+
+import { Adressebeskyttelsegradering, type IPersonInfo, PersonType } from '../../typer/person';
+
+export function lagPerson(person: Partial<IPersonInfo> = {}): IPersonInfo {
+    return {
+        kommunenummer: '0001',
+        adressebeskyttelseGradering: Adressebeskyttelsegradering.UGRADERT,
+        harTilgang: true,
+        forelderBarnRelasjon: [],
+        forelderBarnRelasjonMaskert: [],
+        fødselsdato: '1995-01-01',
+        kjønn: kjønnType.MANN,
+        navn: 'Test Testersen',
+        personIdent: '12345678903',
+        type: PersonType.SØKER,
+        dødsfallDato: undefined,
+        bostedsadresse: undefined,
+        erEgenAnsatt: false,
+        ...person,
+    };
+}
+
+export * as PersonTestdata from './personTestdata';

--- a/src/frontend/testutils/testdata/saksbehandlerTestdata.ts
+++ b/src/frontend/testutils/testdata/saksbehandlerTestdata.ts
@@ -1,0 +1,17 @@
+import { type ISaksbehandler } from '@navikt/familie-typer';
+
+export function lagSaksbehandler(saksbehandler: Partial<ISaksbehandler> = {}): ISaksbehandler {
+    return {
+        displayName: 'Saksbehandler',
+        email: 'saksbehandler@nav.no',
+        firstName: 'Sak',
+        groups: ['d21e00a4-969d-4b28-8782-dc818abfae65'],
+        identifier: '30987654321',
+        lastName: 'Behandler',
+        enhet: '0001',
+        navIdent: 'A1',
+        ...saksbehandler,
+    };
+}
+
+export * as SaksbehandlerTestdata from './saksbehandlerTestdata';

--- a/src/frontend/testutils/testrender.tsx
+++ b/src/frontend/testutils/testrender.tsx
@@ -3,11 +3,14 @@ import type { PropsWithChildren } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as rtlRender, type RenderOptions, screen as rtlScreen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BrowserRouter } from 'react-router';
+import { MemoryRouter } from 'react-router';
+
+import type { ISaksbehandler } from '@navikt/familie-typer';
 
 import { AppProvider } from '../context/AppContext';
 import { AuthOgHttpProvider } from '../context/AuthContext';
 import { ModalProvider } from '../context/ModalContext';
+import { lagSaksbehandler } from './testdata/saksbehandlerTestdata';
 
 function lagQueryClient() {
     return new QueryClient({
@@ -19,14 +22,24 @@ function lagQueryClient() {
     });
 }
 
-export function TestProviders({ children }: PropsWithChildren) {
-    const queryClient = lagQueryClient(); // Ny instans for hver test
+interface Props extends PropsWithChildren {
+    queryClient?: QueryClient;
+    initialEntries?: [{ pathname: string }];
+    saksbehandler?: ISaksbehandler;
+}
+
+export function TestProviders({
+    queryClient = lagQueryClient(), // Ny instans for hver test
+    initialEntries = [{ pathname: '/' }],
+    saksbehandler = lagSaksbehandler(),
+    children,
+}: Props) {
     return (
-        <AuthOgHttpProvider autentisertSaksbehandler={undefined}>
+        <AuthOgHttpProvider autentisertSaksbehandler={saksbehandler}>
             <QueryClientProvider client={queryClient}>
                 <AppProvider>
                     <ModalProvider>
-                        <BrowserRouter>{children}</BrowserRouter>
+                        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
                     </ModalProvider>
                 </AppProvider>
             </QueryClientProvider>


### PR DESCRIPTION
### 📮 Favro
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26760

### 💰 Hva skal gjøres, og hvorfor?
Introduserer en ny komponent `<Fagsakmeny />` som skal vises når man befinner seg på fagsaken, men enda ikke har gått inn i en behandling. I en annen PR vil det komme en ny `<Behandlingsmeny />` komponent som skal vises når man befinner seg inne på behandlingen. `<Fagsakmeny />` vil ikke bli tatt i bruk før den nye `<Behandlingsmeny />` komponenten er på plass. 

Tar i bruk `<ActionMenu />` da det skal erstatte `<Dropdown />`. Flytter tilstanden for modalen opp/over `<ActionMenu />` slik at den bevares når `<ActionMenu />` lukkes.

Har ikke lagt til modalen for å bekrefte tilbakekrevingsbehandlinger da jeg vil dobbeltsjekke at den faktisk fortsatt er ønskelig å bruke. Legger den til i en annen PR om vi fortsatt vil bruke den. 

Relatert endring i ba-sak-frontend: https://github.com/navikt/familie-ba-sak-frontend/pull/4144

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Gammel:
<img width="249" height="150" alt="image" src="https://github.com/user-attachments/assets/491a1a69-aa60-44c3-a920-4d11fba76657" />

Ny:
<img width="249" height="150" alt="image" src="https://github.com/user-attachments/assets/7fc91067-c953-4c74-942b-7d7c8d56315f" />
