### PR TITLE
Nav 26760 legg til behandling meny

### DIFF
--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/AInntekt/AInntektNy.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/AInntekt/AInntektNy.test.tsx
@@ -1,0 +1,96 @@
+import type { PropsWithChildren } from 'react';
+
+import { delay, http, HttpResponse } from 'msw';
+import { describe, expect, type MockInstance, vi } from 'vitest';
+
+import { ActionMenu } from '@navikt/ds-react';
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+import { AInntektNy } from './AInntektNy';
+import { FeilmeldingModal } from '../../../../../komponenter/Modal/FeilmeldingModal';
+import { server } from '../../../../../testutils/mocks/node';
+import { lagFagsak } from '../../../../../testutils/testdata/fagsakTestdata';
+import { render, TestProviders } from '../../../../../testutils/testrender';
+import type { IMinimalFagsak } from '../../../../../typer/fagsak';
+import { FagsakProvider } from '../../../FagsakContext';
+
+interface WrapperProps extends PropsWithChildren {
+    fagsak?: IMinimalFagsak;
+}
+
+function Wrapper({ fagsak = lagFagsak(), children }: WrapperProps) {
+    return (
+        <TestProviders>
+            <FeilmeldingModal />
+            <FagsakProvider fagsak={fagsak}>
+                <ActionMenu open={true}>
+                    <ActionMenu.Content>{children}</ActionMenu.Content>
+                </ActionMenu>
+            </FagsakProvider>
+        </TestProviders>
+    );
+}
+
+describe('AInntektNy', () => {
+    let windowOpenSpy: MockInstance;
+
+    beforeEach(() => {
+        windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    });
+
+    afterEach(() => {
+        windowOpenSpy.mockRestore();
+    });
+
+    test('skal rendre komponent', () => {
+        const { screen } = render(<AInntektNy />, { wrapper: Wrapper });
+
+        expect(screen.getByRole('menuitem', { name: 'A-Inntekt' })).toBeInTheDocument();
+    });
+
+    test('skal vise loader når man trykker på a-inntekt', async () => {
+        server.use(
+            http.post('/familie-ks-sak/api/a-inntekt/hent-url', async () => {
+                await delay('infinite');
+                return HttpResponse.json(byggSuksessRessurs('url'));
+            })
+        );
+
+        const { screen, user } = render(<AInntektNy />, { wrapper: Wrapper });
+
+        const knapp = screen.getByRole('menuitem', { name: 'A-Inntekt' });
+        await user.click(knapp);
+
+        const loader = await screen.findByTestId('loader');
+        expect(loader).toBeInTheDocument();
+
+        expect(windowOpenSpy).not.toHaveBeenCalledOnce();
+    });
+
+    test('skal kunne åpne a-inntekt', async () => {
+        const { screen, user } = render(<AInntektNy />, { wrapper: Wrapper });
+
+        const knapp = screen.getByRole('menuitem', { name: 'A-Inntekt' });
+        await user.click(knapp);
+
+        expect(windowOpenSpy).toHaveBeenCalledOnce();
+    });
+
+    test('skal vise feilmeldingsmodal hvis kallet mot a-inntekt feiler', async () => {
+        server.use(
+            http.post('/familie-ks-sak/api/a-inntekt/hent-url', () => {
+                return new HttpResponse(null, { status: 500 });
+            })
+        );
+
+        const { screen, user } = render(<AInntektNy />, { wrapper: Wrapper });
+
+        const knapp = screen.getByRole('menuitem', { name: 'A-Inntekt' });
+        await user.click(knapp);
+
+        expect(screen.getByRole('dialog', { name: 'Det har oppstått en feil' })).toBeInTheDocument();
+        expect(screen.getByText('Vi får ikke hentet informasjon fra A-inntekt akkurat nå.')).toBeInTheDocument();
+
+        expect(windowOpenSpy).not.toHaveBeenCalledOnce();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/AInntekt/AInntektNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/AInntekt/AInntektNy.tsx
@@ -1,0 +1,33 @@
+import { ActionMenu, BodyShort, Loader } from '@navikt/ds-react';
+
+import { useHentAInntektUrl } from './useHentAInntektUrl';
+import { ModalType } from '../../../../../context/ModalContext';
+import { useModal } from '../../../../../hooks/useModal';
+import { useFagsakContext } from '../../../FagsakContext';
+
+function Feilmelding({ error }: { error: Error }) {
+    return (
+        <>
+            <BodyShort spacing>Vi får ikke hentet informasjon fra A-inntekt akkurat nå.</BodyShort>
+            <BodyShort>Feilmelding: {error.message}</BodyShort>
+        </>
+    );
+}
+
+export function AInntektNy() {
+    const { fagsak } = useFagsakContext();
+    const { åpneModal } = useModal(ModalType.FEILMELDING);
+
+    const { isFetching, refetch } = useHentAInntektUrl({
+        søkerFødselsnummer: fagsak.søkerFødselsnummer,
+        onSuccess: url => window.open(url, '_blank'),
+        onError: error => åpneModal({ feilmelding: <Feilmelding error={error} /> }),
+        enabled: false,
+    });
+
+    return (
+        <ActionMenu.Item onSelect={() => refetch()} disabled={isFetching}>
+            A-Inntekt {isFetching && <Loader data-testid={'loader'} size="small" />}
+        </ActionMenu.Item>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/BehandlingsmenyNy.module.css
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/BehandlingsmenyNy.module.css
@@ -1,0 +1,3 @@
+.group > * {
+    color: var(--a-text-action);
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/BehandlingsmenyNy.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/BehandlingsmenyNy.test.tsx
@@ -1,0 +1,239 @@
+import type { PropsWithChildren } from 'react';
+
+import { Route, Routes } from 'react-router';
+import { describe, expect, type MockInstance, vi } from 'vitest';
+
+import { Heading } from '@navikt/ds-react';
+
+import { BehandlingsmenyNy } from './BehandlingsmenyNy';
+import { lagBehandling, lagVisningBehandling } from '../../../../testutils/testdata/behandlingTestdata';
+import { lagFagsak } from '../../../../testutils/testdata/fagsakTestdata';
+import { lagPerson } from '../../../../testutils/testdata/personTestdata';
+import { render, TestProviders } from '../../../../testutils/testrender';
+import { BehandlingProvider } from '../../Behandling/context/BehandlingContext';
+import { HentOgSettBehandlingProvider } from '../../Behandling/context/HentOgSettBehandlingContext';
+import { FagsakProvider } from '../../FagsakContext';
+import { ManuelleBrevmottakerePåFagsakProvider } from '../../ManuelleBrevmottakerePåFagsakContext';
+import { HenleggBehandlingModal } from './HenleggBehandling/HenleggBehandlingModal';
+import { BehandlingÅrsak, type IBehandling, SettPåVentÅrsak } from '../../../../typer/behandling';
+import type { IMinimalFagsak } from '../../../../typer/fagsak';
+import { BrukerProvider } from '../../BrukerContext';
+
+interface WrapperProps extends PropsWithChildren {
+    initialEntries?: [{ pathname: string }];
+    fagsak?: IMinimalFagsak;
+    behandling?: IBehandling;
+}
+
+function Wrapper({
+    initialEntries = [{ pathname: '/fagsak/1/1/registrer-soknad' }],
+    behandling = lagBehandling({ årsak: BehandlingÅrsak.NYE_OPPLYSNINGER }),
+    fagsak = lagFagsak({ behandlinger: [lagVisningBehandling({ behandlingId: behandling?.behandlingId })] }),
+    children,
+}: WrapperProps) {
+    return (
+        <TestProviders initialEntries={initialEntries}>
+            <FagsakProvider fagsak={fagsak}>
+                <BrukerProvider bruker={lagPerson()}>
+                    <ManuelleBrevmottakerePåFagsakProvider>
+                        <Routes>
+                            <Route
+                                path={'/fagsak/:fagsakId/dokumentutsending'}
+                                element={
+                                    <>
+                                        <Heading level={'1'} size={'medium'}>
+                                            Dokumentutsending
+                                        </Heading>
+                                    </>
+                                }
+                            />
+                            <Route
+                                path={`/fagsak/:fagsakId/:behandlingId/registrer-soknad`}
+                                element={
+                                    <HentOgSettBehandlingProvider fagsak={fagsak}>
+                                        <BehandlingProvider behandling={behandling}>
+                                            <HenleggBehandlingModal />
+                                            {children}
+                                        </BehandlingProvider>
+                                    </HentOgSettBehandlingProvider>
+                                }
+                            />
+                        </Routes>
+                    </ManuelleBrevmottakerePåFagsakProvider>
+                </BrukerProvider>
+            </FagsakProvider>
+        </TestProviders>
+    );
+}
+
+describe('BehandlingsmenyNy', () => {
+    test('skal vise en uåpnet behandlingsmeny ', () => {
+        const { screen } = render(<BehandlingsmenyNy />, { wrapper: Wrapper });
+        expect(screen.getByRole('button', { name: 'Meny' })).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Opprett behandling' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Send informasjonsbrev' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Henlegg behandling' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Endre behandlende enhet' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Endre behandlingstema' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Legg til barn' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Sett behandling på vent' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Fortsett behandling' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Legg til brevmottaker' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'A-Inntekt' })).not.toBeInTheDocument();
+    });
+
+    test('skal kunne åpne behandlingsmenyen', async () => {
+        const { screen, user } = render(<BehandlingsmenyNy />, { wrapper: Wrapper });
+
+        await user.click(screen.getByRole('button', { name: 'Meny' }));
+
+        expect(screen.getByRole('menuitem', { name: 'Opprett behandling' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Send informasjonsbrev' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Henlegg behandling' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Endre behandlende enhet' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Endre behandlingstema' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Legg til barn' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Sett behandling på vent' })).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Fortsett behandling' })).not.toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Legg til brevmottaker' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'A-Inntekt' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne opprett behandling modal', async () => {
+        const { screen, user } = render(<BehandlingsmenyNy />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Opprett behandling' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('dialog', { name: 'Opprett ny behandling' })).toBeInTheDocument();
+    });
+
+    test('skal kunne navigere til dokumentutsending', async () => {
+        const { screen, user } = render(<BehandlingsmenyNy />, {
+            wrapper: props => <Wrapper {...props} initialEntries={[{ pathname: '/fagsak/1/1/registrer-soknad' }]} />,
+        });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Send informasjonsbrev' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('heading', { name: 'Dokumentutsending' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne henlegg behandling modal', async () => {
+        const { screen, user } = render(<BehandlingsmenyNy />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Henlegg behandling' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('dialog', { name: 'Henlegg behandling' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne endre behandlede enhet modal', async () => {
+        const { screen, user } = render(<BehandlingsmenyNy />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Endre behandlende enhet' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('dialog', { name: 'Endre enhet for denne behandlingen' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne endre behandlingstema modal', async () => {
+        const { screen, user } = render(<BehandlingsmenyNy />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Endre behandlingstema' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('dialog', { name: 'Endre behandlingstema' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne legg til barn på behandling modal', async () => {
+        const { screen, user } = render(<BehandlingsmenyNy />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Legg til barn' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('dialog', { name: 'Legg til barn' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne sett behandling på vent modal', async () => {
+        const { screen, user } = render(<BehandlingsmenyNy />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Sett behandling på vent' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('dialog', { name: 'Sett behandling på vent' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne ta behandling av vent modal', async () => {
+        const { screen, user } = render(<BehandlingsmenyNy />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        behandlingPåVent: {
+                            frist: '2025-10-10',
+                            årsak: SettPåVentÅrsak.AVVENTER_DOKUMENTASJON,
+                        },
+                    })}
+                />
+            ),
+        });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Fortsett behandling' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('dialog', { name: 'Fortsett behandling' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne legg til brevmottakere modal', async () => {
+        const { screen, user } = render(<BehandlingsmenyNy />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const menuitem = screen.getByRole('menuitem', { name: 'Legg til brevmottaker' });
+        await user.click(menuitem);
+
+        expect(screen.getByRole('dialog', { name: 'Legg til brevmottaker' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne a-inntekt', async () => {
+        const windowOpenSpy: MockInstance = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+        const { screen, user } = render(<BehandlingsmenyNy />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        const knapp = screen.getByRole('menuitem', { name: 'A-Inntekt' });
+        await user.click(knapp);
+
+        expect(windowOpenSpy).toHaveBeenCalledOnce();
+
+        windowOpenSpy.mockRestore();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/BehandlingsmenyNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/BehandlingsmenyNy.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+
+import { ChevronDownIcon } from '@navikt/aksel-icons';
+import { ActionMenu, Button } from '@navikt/ds-react';
+
+import { AInntektNy } from './AInntekt/AInntektNy';
+import Styles from './BehandlingsmenyNy.module.css';
+import { EndreBehandlendeEnhetModal } from './EndreBehandlendeEnhet/EndreBehandlendeEnhetModal';
+import { EndreBehandlendeEnhetNy } from './EndreBehandlendeEnhet/EndreBehandlendeEnhetNy';
+import { EndreBehandlingstemaModal } from './EndreBehandling/EndreBehandlingstemaModal';
+import { EndreBehandlingstemaNy } from './EndreBehandling/EndreBehandlingstemaNy';
+import { HenleggBehandlingNy } from './HenleggBehandling/HenleggBehandlingNy';
+import { SettBehandlingPåVentModal } from './LeggBehandlingPåVent/SettBehandlingPåVentModal';
+import { SettEllerOppdaterVentingNy } from './LeggBehandlingPåVent/SettEllerOppdaterVentingNy';
+import { TaBehandlingAvVentModal } from './LeggBehandlingPåVent/TaBehandlingAvVentModal';
+import { TaBehandlingAvVentNy } from './LeggBehandlingPåVent/TaBehandlingAvVentNy';
+import { LeggTiLBarnPåBehandlingModal } from './LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal';
+import { LeggTiLBarnPåBehandlingNy } from './LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingNy';
+import { LeggTilBrevmottakerModalBehandling } from './LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalBehandling';
+import { LeggTilEllerFjernBrevmottakerePåBehandling } from './LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling';
+import { OpprettBehandlingModal } from './OpprettBehandling/OpprettBehandlingModal';
+import { OpprettBehandlingNy } from './OpprettBehandling/OpprettBehandlingNy';
+import { SendInformasjonsbrev } from './SendInformasjonsbrev/SendInformasjonsbrev';
+import { sjekkErBehandleneEnhetMidlertidig } from '../../../../typer/behandling';
+import { useBehandlingContext } from '../../Behandling/context/BehandlingContext';
+
+export function BehandlingsmenyNy() {
+    const { behandling } = useBehandlingContext();
+
+    const erBehandleneEnhetMidlertidig = sjekkErBehandleneEnhetMidlertidig(behandling);
+    const erBehandlingPåVent = !!behandling.behandlingPåVent;
+
+    const [visOpprettBehandlingModal, settVisOpprettBehandlingModal] = useState(false);
+    const [visEndreBehandlendeEnhetModal, settVisEndreBehandlendeEnhetModal] = useState(erBehandleneEnhetMidlertidig);
+    const [visEndreBehandlingstemaModal, settVisEndreBehandlingstemaModal] = useState(false);
+    const [visLeggTilBarnPåBehandlingaModal, settVisLeggTilBarnPåBehandlingaModal] = useState(false);
+    const [visBehandlingPåVentModal, settVisBehandlingPåVentModal] = useState(erBehandlingPåVent);
+    const [visTaBehandlingAvVentModal, settVisTaBehandlingAvVentModal] = useState(false);
+    const [visLeggTilBrevmottakerPåBehandlingModal, settVisLeggTilBrevmottakerPåBehandlingModal] = useState(false);
+
+    return (
+        <>
+            {visOpprettBehandlingModal && (
+                <OpprettBehandlingModal lukkModal={() => settVisOpprettBehandlingModal(false)} />
+            )}
+            {visEndreBehandlendeEnhetModal && (
+                <EndreBehandlendeEnhetModal lukkModal={() => settVisEndreBehandlendeEnhetModal(false)} />
+            )}
+            {visEndreBehandlingstemaModal && (
+                <EndreBehandlingstemaModal lukkModal={() => settVisEndreBehandlingstemaModal(false)} />
+            )}
+            {visLeggTilBarnPåBehandlingaModal && (
+                <LeggTiLBarnPåBehandlingModal lukkModal={() => settVisLeggTilBarnPåBehandlingaModal(false)} />
+            )}
+            {visBehandlingPåVentModal && (
+                <SettBehandlingPåVentModal lukkModal={() => settVisBehandlingPåVentModal(false)} />
+            )}
+            {visTaBehandlingAvVentModal && (
+                <TaBehandlingAvVentModal lukkModal={() => settVisTaBehandlingAvVentModal(false)} />
+            )}
+            {visLeggTilBrevmottakerPåBehandlingModal && (
+                <LeggTilBrevmottakerModalBehandling
+                    lukkModal={() => settVisLeggTilBrevmottakerPåBehandlingModal(false)}
+                />
+            )}
+            <ActionMenu>
+                <ActionMenu.Trigger>
+                    <Button variant={'secondary'} size={'small'} iconPosition={'right'} icon={<ChevronDownIcon />}>
+                        Meny
+                    </Button>
+                </ActionMenu.Trigger>
+                <ActionMenu.Content>
+                    <ActionMenu.Group className={Styles.group} aria-label={'Fagsak'}>
+                        <OpprettBehandlingNy åpneModal={() => settVisOpprettBehandlingModal(true)} />
+                        <SendInformasjonsbrev />
+                    </ActionMenu.Group>
+                    <ActionMenu.Divider />
+                    <ActionMenu.Group className={Styles.group} aria-label={'Behandling'}>
+                        <HenleggBehandlingNy />
+                        <EndreBehandlendeEnhetNy åpneModal={() => settVisEndreBehandlendeEnhetModal(true)} />
+                        <EndreBehandlingstemaNy åpneModal={() => settVisEndreBehandlingstemaModal(true)} />
+                        <LeggTiLBarnPåBehandlingNy åpneModal={() => settVisLeggTilBarnPåBehandlingaModal(true)} />
+                        <SettEllerOppdaterVentingNy åpneModal={() => settVisBehandlingPåVentModal(true)} />
+                        <TaBehandlingAvVentNy åpneModal={() => settVisTaBehandlingAvVentModal(true)} />
+                        <LeggTilEllerFjernBrevmottakerePåBehandling
+                            åpneModal={() => settVisLeggTilBrevmottakerPåBehandlingModal(true)}
+                        />
+                        <AInntektNy />
+                    </ActionMenu.Group>
+                </ActionMenu.Content>
+            </ActionMenu>
+        </>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhetModal.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhetModal.tsx
@@ -1,0 +1,123 @@
+import { type ChangeEvent } from 'react';
+
+import { Button, Fieldset, Modal, Select, Textarea } from '@navikt/ds-react';
+import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
+
+import useEndreBehandlendeEnhet from './useEndreBehandlendeEnhet';
+import { useAppContext } from '../../../../../context/AppContext';
+import { BehandlingSteg, hentStegNummer } from '../../../../../typer/behandling';
+import type { IArbeidsfordelingsenhet } from '../../../../../typer/enhet';
+import { behandendeEnheter } from '../../../../../typer/enhet';
+import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+interface Props {
+    lukkModal: () => void;
+}
+
+export function EndreBehandlendeEnhetModal({ lukkModal }: Props) {
+    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const { innloggetSaksbehandler } = useAppContext();
+
+    const {
+        begrunnelse,
+        settBegrunnelse,
+        endreEnhet,
+        enhetId,
+        fjernState,
+        settEnhetId,
+        settSubmitRessurs,
+        submitRessurs,
+    } = useEndreBehandlendeEnhet(() => lukkModal());
+
+    const lukkBehandlendeEnhetModal = () => {
+        fjernState();
+        lukkModal();
+    };
+
+    const erLesevisningPåBehandling = () => {
+        const steg = behandling.steg;
+        if (
+            steg &&
+            hentStegNummer(steg) === hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK) &&
+            innloggetSaksbehandler?.navIdent !== behandling.totrinnskontroll?.saksbehandlerId
+        ) {
+            return false;
+        } else {
+            return vurderErLesevisning(false, true);
+        }
+    };
+
+    return (
+        <Modal
+            open
+            onClose={lukkBehandlendeEnhetModal}
+            width={'35rem'}
+            header={{
+                heading: 'Endre enhet for denne behandlingen',
+                size: 'small',
+            }}
+            portal
+        >
+            <Modal.Body>
+                <Fieldset error={hentFrontendFeilmelding(submitRessurs)} legend="Endre enhet" hideLegend>
+                    <Select
+                        readOnly={erLesevisningPåBehandling()}
+                        name="enhet"
+                        value={enhetId}
+                        label={'Velg ny enhet'}
+                        onChange={(event: ChangeEvent<HTMLSelectElement>): void => {
+                            settEnhetId(event.target.value);
+                            settSubmitRessurs(byggTomRessurs());
+                        }}
+                    >
+                        {behandendeEnheter.map((enhet: IArbeidsfordelingsenhet) => {
+                            return (
+                                <option
+                                    aria-selected={enhetId === enhet.enhetId}
+                                    key={enhet.enhetId}
+                                    value={enhet.enhetId}
+                                    disabled={
+                                        behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId === enhet.enhetId
+                                    }
+                                >
+                                    {`${enhet.enhetId} ${enhet.enhetNavn}`}
+                                </option>
+                            );
+                        })}
+                    </Select>
+
+                    <Textarea
+                        disabled={submitRessurs.status === RessursStatus.HENTER}
+                        readOnly={erLesevisningPåBehandling()}
+                        label={'Begrunnelse'}
+                        value={begrunnelse}
+                        maxLength={4000}
+                        onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
+                            settBegrunnelse(event.target.value);
+                            settSubmitRessurs(byggTomRessurs());
+                        }}
+                    />
+                </Fieldset>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    key={'bekreft'}
+                    variant="primary"
+                    size="small"
+                    disabled={submitRessurs.status === RessursStatus.HENTER}
+                    onClick={() => endreEnhet(behandling.behandlingId)}
+                    children={'Bekreft'}
+                    loading={submitRessurs.status === RessursStatus.HENTER}
+                />
+                <Button
+                    key={'avbryt'}
+                    size="small"
+                    variant="secondary"
+                    onClick={lukkBehandlendeEnhetModal}
+                    children={'Avbryt'}
+                />
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhetNy.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhetNy.test.tsx
@@ -1,0 +1,32 @@
+import type { PropsWithChildren } from 'react';
+
+import { describe, expect } from 'vitest';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+import { EndreBehandlendeEnhetNy } from './EndreBehandlendeEnhetNy';
+import { render } from '../../../../../testutils/testrender';
+
+function Wrapper({ children }: PropsWithChildren) {
+    return (
+        <ActionMenu open={true}>
+            <ActionMenu.Content>{children}</ActionMenu.Content>
+        </ActionMenu>
+    );
+}
+
+describe('EndreBehandlendeEnhetNy', () => {
+    test('skal rendre komponent', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<EndreBehandlendeEnhetNy åpneModal={åpneModal} />, { wrapper: Wrapper });
+        expect(screen.getByRole('menuitem', { name: 'Endre behandlende enhet' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne modal', async () => {
+        const åpneModal = vi.fn();
+        const { screen, user } = render(<EndreBehandlendeEnhetNy åpneModal={åpneModal} />, { wrapper: Wrapper });
+        const knapp = screen.getByRole('menuitem', { name: 'Endre behandlende enhet' });
+        await user.click(knapp);
+        expect(åpneModal).toHaveBeenCalledOnce();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhetNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhetNy.tsx
@@ -1,0 +1,9 @@
+import { ActionMenu } from '@navikt/ds-react/ActionMenu';
+
+interface Props {
+    åpneModal: () => void;
+}
+
+export function EndreBehandlendeEnhetNy({ åpneModal }: Props) {
+    return <ActionMenu.Item onSelect={åpneModal}>Endre behandlende enhet</ActionMenu.Item>;
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstemaModal.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstemaModal.tsx
@@ -1,0 +1,59 @@
+import { Button, Fieldset, Modal } from '@navikt/ds-react';
+import { RessursStatus } from '@navikt/familie-typer';
+
+import useEndreBehandlingstema from './useEndreBehandlingstema';
+import { BehandlingstemaSelect } from '../../../../../komponenter/BehandlingstemaSelect';
+import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+interface Props {
+    lukkModal: () => void;
+}
+
+export function EndreBehandlingstemaModal({ lukkModal }: Props) {
+    const { skjema, endreBehandlingstema, ressurs, nullstillSkjema } = useEndreBehandlingstema(() => lukkModal());
+
+    const { vurderErLesevisning, behandling } = useBehandlingContext();
+
+    const lukkEndreBehandlingModal = () => {
+        nullstillSkjema();
+        lukkModal();
+    };
+
+    return (
+        <Modal
+            open
+            header={{ heading: 'Endre behandlingstema', size: 'small' }}
+            onClose={lukkEndreBehandlingModal}
+            width={'35rem'}
+            portal
+        >
+            <Modal.Body>
+                <Fieldset error={hentFrontendFeilmelding(ressurs)} legend={'Endre behandlingstema'} hideLegend>
+                    <BehandlingstemaSelect
+                        behandlingstema={skjema.felter.behandlingstema}
+                        readOnly={vurderErLesevisning()}
+                        label="Behandlingstema"
+                    />
+                </Fieldset>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    key={'bekreft'}
+                    variant="primary"
+                    size="small"
+                    onClick={() => endreBehandlingstema(behandling.behandlingId)}
+                    children={'Bekreft'}
+                    loading={ressurs.status === RessursStatus.HENTER}
+                />
+                <Button
+                    key={'avbryt'}
+                    variant="secondary"
+                    size="small"
+                    onClick={lukkEndreBehandlingModal}
+                    children={'Avbryt'}
+                />
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstemaNy.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstemaNy.test.tsx
@@ -1,0 +1,32 @@
+import type { PropsWithChildren } from 'react';
+
+import { describe, expect } from 'vitest';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+import { EndreBehandlingstemaNy } from './EndreBehandlingstemaNy';
+import { render } from '../../../../../testutils/testrender';
+
+function Wrapper({ children }: PropsWithChildren) {
+    return (
+        <ActionMenu open={true}>
+            <ActionMenu.Content>{children}</ActionMenu.Content>
+        </ActionMenu>
+    );
+}
+
+describe('EndreBehandlingstemaNy', () => {
+    test('skal rendre komponent', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<EndreBehandlingstemaNy åpneModal={åpneModal} />, { wrapper: Wrapper });
+        expect(screen.getByRole('menuitem', { name: 'Endre behandlingstema' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne modal', async () => {
+        const åpneModal = vi.fn();
+        const { screen, user } = render(<EndreBehandlingstemaNy åpneModal={åpneModal} />, { wrapper: Wrapper });
+        const knapp = screen.getByRole('menuitem', { name: 'Endre behandlingstema' });
+        await user.click(knapp);
+        expect(åpneModal).toHaveBeenCalledOnce();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstemaNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstemaNy.tsx
@@ -1,0 +1,9 @@
+import { ActionMenu } from '@navikt/ds-react';
+
+interface Props {
+    åpneModal: () => void;
+}
+
+export function EndreBehandlingstemaNy({ åpneModal }: Props) {
+    return <ActionMenu.Item onSelect={åpneModal}>Endre behandlingstema</ActionMenu.Item>;
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingNy.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingNy.test.tsx
@@ -1,0 +1,125 @@
+import type { PropsWithChildren } from 'react';
+
+import { http, HttpResponse } from 'msw';
+import { describe, expect } from 'vitest';
+
+import { ActionMenu } from '@navikt/ds-react';
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+import { HenleggBehandlingModal } from './HenleggBehandlingModal';
+import { HenleggBehandlingNy } from './HenleggBehandlingNy';
+import { ModalType } from '../../../../../context/ModalContext';
+import { useModal } from '../../../../../hooks/useModal';
+import { server } from '../../../../../testutils/mocks/node';
+import { lagBehandling } from '../../../../../testutils/testdata/behandlingTestdata';
+import { lagFagsak } from '../../../../../testutils/testdata/fagsakTestdata';
+import { render, TestProviders } from '../../../../../testutils/testrender';
+import { BehandlingStatus, BehandlingSteg, type IBehandling, SettPåVentÅrsak } from '../../../../../typer/behandling';
+import type { IMinimalFagsak } from '../../../../../typer/fagsak';
+import { ToggleNavn } from '../../../../../typer/toggles';
+import { BehandlingProvider } from '../../../Behandling/context/BehandlingContext';
+import { HentOgSettBehandlingProvider } from '../../../Behandling/context/HentOgSettBehandlingContext';
+import { FagsakProvider } from '../../../FagsakContext';
+
+function ModalWrapper() {
+    const { erModalÅpen } = useModal(ModalType.HENLEGG_BEHANDLING);
+    if (!erModalÅpen) {
+        return null;
+    }
+    return <HenleggBehandlingModal />;
+}
+
+interface WrapperProps extends PropsWithChildren {
+    fagsak?: IMinimalFagsak;
+    behandling?: IBehandling;
+}
+
+function Wrapper({ fagsak = lagFagsak(), behandling = lagBehandling(), children }: WrapperProps) {
+    return (
+        <TestProviders>
+            <FagsakProvider fagsak={fagsak}>
+                <HentOgSettBehandlingProvider fagsak={fagsak}>
+                    <BehandlingProvider behandling={behandling}>
+                        <ModalWrapper />
+                        <ActionMenu open={true}>
+                            <ActionMenu.Content>{children}</ActionMenu.Content>
+                        </ActionMenu>
+                    </BehandlingProvider>
+                </HentOgSettBehandlingProvider>
+            </FagsakProvider>
+        </TestProviders>
+    );
+}
+
+describe('HenleggBehandlingNy', () => {
+    test('skal rendre knapp', () => {
+        const { screen } = render(<HenleggBehandlingNy />, { wrapper: Wrapper });
+        expect(screen.getByRole('menuitem', { name: 'Henlegg behandling' })).toBeInTheDocument();
+    });
+
+    test('skal ikke vise knapp hvis man befinner seg i lesevisning', () => {
+        const { screen } = render(<HenleggBehandlingNy />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        behandlingPåVent: {
+                            frist: '2025-10-10',
+                            årsak: SettPåVentÅrsak.AVVENTER_BEHANDLING,
+                        },
+                        steg: BehandlingSteg.REGISTRERE_SØKNAD,
+                    })}
+                />
+            ),
+        });
+        expect(screen.queryByRole('menuitem', { name: 'Henlegg behandling' })).not.toBeInTheDocument();
+    });
+
+    test('skal ikke vise knapp hvis man befinner på et steg som ikke er henlegtbart', () => {
+        const { screen } = render(<HenleggBehandlingNy />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        status: BehandlingStatus.UTREDES,
+                        steg: BehandlingSteg.BESLUTTE_VEDTAK,
+                    })}
+                />
+            ),
+        });
+        expect(screen.queryByRole('menuitem', { name: 'Henlegg behandling' })).not.toBeInTheDocument();
+    });
+
+    test('skal vise knapp selv om det er lesevisning og på et steg som ikke er henlegtbart', async () => {
+        server.use(
+            http.post('/familie-ks-sak/api/featuretoggles', () => {
+                return HttpResponse.json(byggSuksessRessurs({ [ToggleNavn.tekniskVedlikeholdHenleggelse]: true }));
+            })
+        );
+
+        const { screen } = render(<HenleggBehandlingNy />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        status: BehandlingStatus.UTREDES,
+                        steg: BehandlingSteg.BESLUTTE_VEDTAK,
+                    })}
+                />
+            ),
+        });
+
+        const knapp = await screen.findByRole('menuitem', { name: 'Henlegg behandling' });
+
+        expect(knapp).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne modal', async () => {
+        const { screen, user } = render(<HenleggBehandlingNy />, { wrapper: Wrapper });
+
+        const knapp = screen.getByRole('menuitem', { name: 'Henlegg behandling' });
+        await user.click(knapp);
+
+        expect(screen.getByRole('dialog', { name: 'Henlegg behandling' })).toBeInTheDocument();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingNy.tsx
@@ -1,0 +1,26 @@
+import { ActionMenu } from '@navikt/ds-react';
+
+import { useAppContext } from '../../../../../context/AppContext';
+import { ModalType } from '../../../../../context/ModalContext';
+import { useModal } from '../../../../../hooks/useModal';
+import { erPåHenleggbartSteg } from '../../../../../typer/behandling';
+import { ToggleNavn } from '../../../../../typer/toggles';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+export function HenleggBehandlingNy() {
+    const { toggles } = useAppContext();
+    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const { åpneModal } = useModal(ModalType.HENLEGG_BEHANDLING);
+
+    const erLesevisning = vurderErLesevisning();
+    const harTilgangTilTekniskVedlikeholdHenleggelse = toggles[ToggleNavn.tekniskVedlikeholdHenleggelse];
+
+    const kanHenlegge =
+        harTilgangTilTekniskVedlikeholdHenleggelse || (!erLesevisning && erPåHenleggbartSteg(behandling.steg));
+
+    if (!kanHenlegge) {
+        return null;
+    }
+
+    return <ActionMenu.Item onSelect={() => åpneModal()}>Henlegg behandling</ActionMenu.Item>;
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggBehandlingPåVent/SettEllerOppdaterVentingNy.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggBehandlingPåVent/SettEllerOppdaterVentingNy.test.tsx
@@ -1,0 +1,87 @@
+import type { PropsWithChildren } from 'react';
+
+import { describe } from 'vitest';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+import { SettEllerOppdaterVentingNy } from './SettEllerOppdaterVentingNy';
+import { lagBehandling } from '../../../../../testutils/testdata/behandlingTestdata';
+import { lagFagsak } from '../../../../../testutils/testdata/fagsakTestdata';
+import { render, TestProviders } from '../../../../../testutils/testrender';
+import { BehandlingStatus, type IBehandling, SettPåVentÅrsak } from '../../../../../typer/behandling';
+import { type IMinimalFagsak } from '../../../../../typer/fagsak';
+import { BehandlingProvider } from '../../../Behandling/context/BehandlingContext';
+import { HentOgSettBehandlingProvider } from '../../../Behandling/context/HentOgSettBehandlingContext';
+import { FagsakProvider } from '../../../FagsakContext';
+
+interface WrapperProps extends PropsWithChildren {
+    fagsak?: IMinimalFagsak;
+    behandling?: IBehandling;
+}
+
+function Wrapper({ fagsak = lagFagsak(), behandling = lagBehandling(), children }: WrapperProps) {
+    return (
+        <TestProviders>
+            <FagsakProvider fagsak={fagsak}>
+                <HentOgSettBehandlingProvider fagsak={fagsak}>
+                    <BehandlingProvider behandling={behandling}>
+                        <ActionMenu open={true}>
+                            <ActionMenu.Content>{children}</ActionMenu.Content>
+                        </ActionMenu>
+                    </BehandlingProvider>
+                </HentOgSettBehandlingProvider>
+            </FagsakProvider>
+        </TestProviders>
+    );
+}
+
+describe('SettEllerOppdaterVentingNy', () => {
+    test('skal rendre komponent når behandlingen ikke er satt på vent', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<SettEllerOppdaterVentingNy åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        behandlingPåVent: undefined,
+                    })}
+                />
+            ),
+        });
+        expect(screen.getByRole('menuitem', { name: 'Sett behandling på vent' })).toBeInTheDocument();
+    });
+
+    test('skal rendre komponent når behandlingen ikke er satt på vent', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<SettEllerOppdaterVentingNy åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        behandlingPåVent: {
+                            frist: '2025-10-10',
+                            årsak: SettPåVentÅrsak.AVVENTER_DOKUMENTASJON,
+                        },
+                    })}
+                />
+            ),
+        });
+        expect(screen.getByRole('menuitem', { name: 'Endre ventende behandling' })).toBeInTheDocument();
+    });
+
+    test('skal ikke rendre komponent når behandlingenstatus er noe annet enn UTREDES', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<SettEllerOppdaterVentingNy åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        status: BehandlingStatus.AVSLUTTET,
+                        behandlingPåVent: undefined,
+                    })}
+                />
+            ),
+        });
+        expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggBehandlingPåVent/SettEllerOppdaterVentingNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggBehandlingPåVent/SettEllerOppdaterVentingNy.tsx
@@ -1,0 +1,24 @@
+import { ActionMenu } from '@navikt/ds-react';
+
+import { BehandlingStatus } from '../../../../../typer/behandling';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+interface Props {
+    åpneModal: () => void;
+}
+
+export function SettEllerOppdaterVentingNy({ åpneModal }: Props) {
+    const { behandling } = useBehandlingContext();
+
+    if (behandling.status !== BehandlingStatus.UTREDES) {
+        return null;
+    }
+
+    const erBehandlingAlleredePåVent = !!behandling.behandlingPåVent;
+
+    return (
+        <ActionMenu.Item onSelect={åpneModal}>
+            {erBehandlingAlleredePåVent ? 'Endre ventende behandling' : 'Sett behandling på vent'}
+        </ActionMenu.Item>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggBehandlingPåVent/TaBehandlingAvVentModal.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggBehandlingPåVent/TaBehandlingAvVentModal.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+
+import styled from 'styled-components';
+
+import { Alert, BodyShort, Button, Modal } from '@navikt/ds-react';
+import { useHttp } from '@navikt/familie-http';
+import type { Ressurs } from '@navikt/familie-typer';
+import { byggFeiletRessurs, byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
+
+import type { IBehandling } from '../../../../../typer/behandling';
+import { settPåVentÅrsaker } from '../../../../../typer/behandling';
+import { defaultFunksjonellFeil } from '../../../../../typer/feilmeldinger';
+import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+const StyledBodyShort = styled(BodyShort)`
+    padding-bottom: 1rem;
+`;
+
+const StyledAlert = styled(Alert)`
+    padding-bottom: 1rem;
+`;
+
+interface Props {
+    lukkModal: () => void;
+}
+
+export function TaBehandlingAvVentModal({ lukkModal }: Props) {
+    const { behandling } = useBehandlingContext();
+    const { request } = useHttp();
+
+    const [submitRessurs, settSubmitRessurs] = useState(byggTomRessurs());
+
+    const deaktiverVentingPåBehandling = () => {
+        settSubmitRessurs(byggHenterRessurs());
+
+        request<undefined, IBehandling>({
+            method: 'PUT',
+            url: `/familie-ks-sak/api/behandlinger/${behandling.behandlingId}/sett-på-vent/gjenoppta`,
+        })
+            .then((ressurs: Ressurs<IBehandling>) => {
+                settSubmitRessurs(ressurs);
+                window.location.reload();
+            })
+            .catch(() => {
+                settSubmitRessurs(byggFeiletRessurs(defaultFunksjonellFeil));
+            });
+    };
+
+    return (
+        <Modal
+            header={{ heading: 'Fortsett behandling', size: 'small' }}
+            open
+            onClose={lukkModal}
+            width={'35rem'}
+            portal
+        >
+            <Modal.Body>
+                <BodyShort>
+                    Behandlingen er satt på vent.
+                    {behandling?.behandlingPåVent &&
+                        ` Årsak: ${settPåVentÅrsaker[behandling?.behandlingPåVent?.årsak]}. `}
+                </BodyShort>
+                <StyledBodyShort>
+                    {`Frist: ${isoStringTilFormatertString({
+                        isoString: behandling?.behandlingPåVent?.frist,
+                        tilFormat: Datoformat.DATO,
+                    })}. `}
+                    Gå via meny for å endre årsak og frist på ventende behandling.
+                </StyledBodyShort>
+
+                <StyledBodyShort>Ønsker du å fortsette behandlingen?</StyledBodyShort>
+
+                {submitRessurs.status === RessursStatus.FEILET && (
+                    <StyledAlert variant="error">{submitRessurs.frontendFeilmelding}</StyledAlert>
+                )}
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    key={'Bekreft'}
+                    variant="primary"
+                    size="small"
+                    onClick={deaktiverVentingPåBehandling}
+                    children={'Ja, fortsett'}
+                    loading={submitRessurs.status === RessursStatus.HENTER}
+                />
+                <Button key={'Nei'} variant="tertiary" onClick={lukkModal} children={'Nei'} />
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggBehandlingPåVent/TaBehandlingAvVentNy.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggBehandlingPåVent/TaBehandlingAvVentNy.test.tsx
@@ -1,0 +1,71 @@
+import type { PropsWithChildren } from 'react';
+
+import { describe, expect } from 'vitest';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+import { TaBehandlingAvVentNy } from './TaBehandlingAvVentNy';
+import { lagBehandling } from '../../../../../testutils/testdata/behandlingTestdata';
+import { lagFagsak } from '../../../../../testutils/testdata/fagsakTestdata';
+import { render, TestProviders } from '../../../../../testutils/testrender';
+import { type IBehandling, SettPåVentÅrsak } from '../../../../../typer/behandling';
+import type { IMinimalFagsak } from '../../../../../typer/fagsak';
+import { BehandlingProvider } from '../../../Behandling/context/BehandlingContext';
+import { HentOgSettBehandlingProvider } from '../../../Behandling/context/HentOgSettBehandlingContext';
+import { FagsakProvider } from '../../../FagsakContext';
+
+interface WrapperProps extends PropsWithChildren {
+    fagsak?: IMinimalFagsak;
+    behandling?: IBehandling;
+}
+
+function Wrapper({ fagsak = lagFagsak(), behandling = lagBehandling(), children }: WrapperProps) {
+    return (
+        <TestProviders>
+            <FagsakProvider fagsak={fagsak}>
+                <HentOgSettBehandlingProvider fagsak={fagsak}>
+                    <BehandlingProvider behandling={behandling}>
+                        <ActionMenu open={true}>
+                            <ActionMenu.Content>{children}</ActionMenu.Content>
+                        </ActionMenu>
+                    </BehandlingProvider>
+                </HentOgSettBehandlingProvider>
+            </FagsakProvider>
+        </TestProviders>
+    );
+}
+
+describe('TaBehandlingAvVentNy', () => {
+    test('skal rendre komponent for behandling som er satt på vent', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<TaBehandlingAvVentNy åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        behandlingPåVent: {
+                            frist: '2025-10-10',
+                            årsak: SettPåVentÅrsak.AVVENTER_DOKUMENTASJON,
+                        },
+                    })}
+                />
+            ),
+        });
+        expect(screen.getByRole('menuitem', { name: 'Fortsett behandling' })).toBeInTheDocument();
+    });
+
+    test('skal ikke rendre komponent for behandling som ikke er satt på vent', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<TaBehandlingAvVentNy åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        behandlingPåVent: undefined,
+                    })}
+                />
+            ),
+        });
+        expect(screen.queryByRole('menuitem', { name: 'Fortsett behandling' })).not.toBeInTheDocument();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggBehandlingPåVent/TaBehandlingAvVentNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggBehandlingPåVent/TaBehandlingAvVentNy.tsx
@@ -1,0 +1,17 @@
+import { ActionMenu } from '@navikt/ds-react';
+
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+interface Props {
+    åpneModal: () => void;
+}
+
+export function TaBehandlingAvVentNy({ åpneModal }: Props) {
+    const { behandling } = useBehandlingContext();
+
+    if (behandling.behandlingPåVent === undefined || behandling.behandlingPåVent === null) {
+        return null;
+    }
+
+    return <ActionMenu.Item onSelect={åpneModal}>Fortsett behandling</ActionMenu.Item>;
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
@@ -1,0 +1,136 @@
+import { Alert, Button, Fieldset, Heading, HelpText, HStack, Modal, TextField } from '@navikt/ds-react';
+import { useHttp } from '@navikt/familie-http';
+import { ok, useFelt, useSkjema } from '@navikt/familie-skjema';
+import type { Ressurs } from '@navikt/familie-typer';
+import { byggFeiletRessurs, byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
+
+import type { IBehandling } from '../../../../../typer/behandling';
+import type { IPersonInfo, IRestTilgang } from '../../../../../typer/person';
+import { adressebeskyttelsestyper } from '../../../../../typer/person';
+import { erLokal } from '../../../../../utils/miljø';
+import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
+import { identValidator } from '../../../../../utils/validators';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+interface Props {
+    lukkModal: () => void;
+}
+
+export function LeggTiLBarnPåBehandlingModal({ lukkModal }: Props) {
+    const { request } = useHttp();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
+
+    const { skjema, settSubmitRessurs, kanSendeSkjema, nullstillSkjema } = useSkjema<
+        {
+            ident: string;
+        },
+        IPersonInfo
+    >({
+        felter: {
+            ident: useFelt<string>({
+                verdi: '',
+                valideringsfunksjon: erLokal() ? felt => ok(felt) : identValidator,
+            }),
+        },
+        skjemanavn: 'Legg til barn',
+    });
+
+    const onAvbryt = () => {
+        lukkModal();
+        settSubmitRessurs(byggTomRessurs());
+    };
+
+    const leggTilOnClick = () => {
+        const erSkjemaOk = kanSendeSkjema();
+        if (erSkjemaOk) {
+            settSubmitRessurs(byggHenterRessurs());
+            request<{ brukerIdent: string }, IRestTilgang>({
+                method: 'POST',
+                url: '/familie-ks-sak/api/tilgang',
+                data: { brukerIdent: skjema.felter.ident.verdi },
+            }).then((ressurs: Ressurs<IRestTilgang>) => {
+                nullstillSkjema();
+                if (ressurs.status === RessursStatus.SUKSESS) {
+                    if (ressurs.data.saksbehandlerHarTilgang) {
+                        request<{ barnIdent: string }, IBehandling>({
+                            method: 'POST',
+                            data: { barnIdent: skjema.felter.ident.verdi },
+                            url: `/familie-ks-sak/api/behandlinger/${behandling.behandlingId}/legg-til-barn`,
+                        }).then((leggTilRespons: Ressurs<IBehandling>) => {
+                            if (
+                                leggTilRespons.status === RessursStatus.FEILET ||
+                                leggTilRespons.status === RessursStatus.FUNKSJONELL_FEIL ||
+                                leggTilRespons.status === RessursStatus.IKKE_TILGANG
+                            ) {
+                                settSubmitRessurs(byggFeiletRessurs(leggTilRespons.frontendFeilmelding));
+                            } else {
+                                settÅpenBehandling(leggTilRespons);
+                                lukkModal();
+                            }
+                        });
+                    } else {
+                        settSubmitRessurs(
+                            byggFeiletRessurs(
+                                `Barnet kan ikke legges til på grunn av diskresjonskode ${
+                                    adressebeskyttelsestyper[ressurs.data.adressebeskyttelsegradering] ?? 'ukjent'
+                                }`
+                            )
+                        );
+                    }
+                } else if (
+                    [RessursStatus.FEILET, RessursStatus.FUNKSJONELL_FEIL, RessursStatus.IKKE_TILGANG].includes(
+                        ressurs.status
+                    )
+                ) {
+                    settSubmitRessurs(ressurs);
+                }
+            });
+        }
+    };
+
+    return (
+        <Modal open onClose={onAvbryt} aria-label={'Legg til barn'} width={'35rem'} portal>
+            <Modal.Header>
+                <HStack gap={'2'}>
+                    <Heading level="2" size="small">
+                        Legg til barn
+                    </Heading>
+                    <HelpText strategy={'fixed'} placement={'top'}>
+                        Her kan du, ved klage eller ettersendt dokumentasjon, legge til barn som ikke lenger ligger på
+                        behandlingen fordi vi tidligere har avslått eller opphørt.
+                    </HelpText>
+                </HStack>
+            </Modal.Header>
+            <Modal.Body>
+                <Fieldset
+                    error={hentFrontendFeilmelding(skjema.submitRessurs)}
+                    errorPropagation={false}
+                    legend="Legg til barn på behandling"
+                    hideLegend
+                >
+                    <TextField
+                        {...skjema.felter.ident.hentNavInputProps(skjema.visFeilmeldinger)}
+                        label={'Fødselsnummer'}
+                        placeholder={'11 siffer'}
+                    />
+                    <Alert variant="info" inline={true}>
+                        Du er i ferd med å legge til et barn på behandlingen. Handlingen kan ikke reverseres uten å
+                        henlegge.
+                    </Alert>
+                </Fieldset>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    key={'Legg til'}
+                    variant="primary"
+                    size="small"
+                    onClick={leggTilOnClick}
+                    children={'Legg til'}
+                    loading={skjema.submitRessurs.status === RessursStatus.HENTER}
+                    disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
+                />
+                <Button key={'Avbryt'} variant="tertiary" size="small" onClick={onAvbryt} children={'Avbryt'} />
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingNy.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingNy.test.tsx
@@ -1,0 +1,94 @@
+import type { PropsWithChildren } from 'react';
+
+import { describe, expect } from 'vitest';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+import { LeggTiLBarnPåBehandlingNy } from './LeggTilBarnPåBehandlingNy';
+import { lagBehandling } from '../../../../../testutils/testdata/behandlingTestdata';
+import { lagFagsak } from '../../../../../testutils/testdata/fagsakTestdata';
+import { render, TestProviders } from '../../../../../testutils/testrender';
+import { BehandlingÅrsak, type IBehandling, SettPåVentÅrsak } from '../../../../../typer/behandling';
+import type { IMinimalFagsak } from '../../../../../typer/fagsak';
+import { BehandlingProvider } from '../../../Behandling/context/BehandlingContext';
+import { HentOgSettBehandlingProvider } from '../../../Behandling/context/HentOgSettBehandlingContext';
+import { FagsakProvider } from '../../../FagsakContext';
+
+interface WrapperProps extends PropsWithChildren {
+    fagsak?: IMinimalFagsak;
+    behandling?: IBehandling;
+}
+
+function Wrapper({
+    fagsak = lagFagsak(),
+    behandling = lagBehandling({
+        behandlingPåVent: undefined,
+        årsak: BehandlingÅrsak.NYE_OPPLYSNINGER,
+    }),
+    children,
+}: WrapperProps) {
+    return (
+        <TestProviders>
+            <FagsakProvider fagsak={fagsak}>
+                <HentOgSettBehandlingProvider fagsak={fagsak}>
+                    <BehandlingProvider behandling={behandling}>
+                        <ActionMenu open={true}>
+                            <ActionMenu.Content>{children}</ActionMenu.Content>
+                        </ActionMenu>
+                    </BehandlingProvider>
+                </HentOgSettBehandlingProvider>
+            </FagsakProvider>
+        </TestProviders>
+    );
+}
+
+describe('LeggTilBarnPåBehandlingNy', () => {
+    test('skal rendre komponenten', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<LeggTiLBarnPåBehandlingNy åpneModal={åpneModal} />, { wrapper: Wrapper });
+        expect(screen.getByRole('menuitem', { name: 'Legg til barn' })).toBeInTheDocument();
+    });
+
+    test('skal ikke rendre komponenten i lesevisning', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<LeggTiLBarnPåBehandlingNy åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        behandlingPåVent: {
+                            frist: '2025-10-10',
+                            årsak: SettPåVentÅrsak.AVVENTER_BEHANDLING,
+                        },
+                        årsak: BehandlingÅrsak.NYE_OPPLYSNINGER,
+                    })}
+                />
+            ),
+        });
+        expect(screen.queryByRole('menuitem', { name: 'Legg til barn' })).not.toBeInTheDocument();
+    });
+
+    test('skal ikke rendre komponenten hvis behandlingsårsaken er urelevant', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<LeggTiLBarnPåBehandlingNy åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({
+                        behandlingPåVent: undefined,
+                        årsak: BehandlingÅrsak.SØKNAD,
+                    })}
+                />
+            ),
+        });
+        expect(screen.queryByRole('menuitem', { name: 'Legg til barn' })).not.toBeInTheDocument();
+    });
+
+    test('skal kunne åpne modal', async () => {
+        const åpneModal = vi.fn();
+        const { screen, user } = render(<LeggTiLBarnPåBehandlingNy åpneModal={åpneModal} />, { wrapper: Wrapper });
+        const knapp = screen.getByRole('menuitem', { name: 'Legg til barn' });
+        await user.click(knapp);
+        expect(åpneModal).toHaveBeenCalledOnce();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingNy.tsx
@@ -1,0 +1,28 @@
+import { ActionMenu } from '@navikt/ds-react';
+
+import { BehandlingÅrsak } from '../../../../../typer/behandling';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+const relevanteBehandlingsårsaker = [
+    BehandlingÅrsak.NYE_OPPLYSNINGER,
+    BehandlingÅrsak.KLAGE,
+    BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
+    BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
+];
+
+interface Props {
+    åpneModal: () => void;
+}
+
+export function LeggTiLBarnPåBehandlingNy({ åpneModal }: Props) {
+    const { behandling, vurderErLesevisning } = useBehandlingContext();
+
+    const erLesevisning = vurderErLesevisning();
+    const harRelevantBehandlingsårsak = relevanteBehandlingsårsaker.includes(behandling.årsak);
+
+    if (erLesevisning || !harRelevantBehandlingsårsak) {
+        return null;
+    }
+
+    return <ActionMenu.Item onSelect={åpneModal}>Legg til barn</ActionMenu.Item>;
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.test.tsx
@@ -1,0 +1,80 @@
+import type { PropsWithChildren } from 'react';
+
+import { describe, expect } from 'vitest';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+import { LeggTilEllerFjernBrevmottakerePåBehandling } from './LeggTilEllerFjernBrevmottakerePåBehandling';
+import { lagBehandling } from '../../../../../testutils/testdata/behandlingTestdata';
+import { lagRestBrevmottaker } from '../../../../../testutils/testdata/brevmottakerTestdata';
+import { lagFagsak } from '../../../../../testutils/testdata/fagsakTestdata';
+import { render, TestProviders } from '../../../../../testutils/testrender';
+import { type IBehandling } from '../../../../../typer/behandling';
+import { type IMinimalFagsak } from '../../../../../typer/fagsak';
+import { BehandlingProvider } from '../../../Behandling/context/BehandlingContext';
+import { HentOgSettBehandlingProvider } from '../../../Behandling/context/HentOgSettBehandlingContext';
+import { FagsakProvider } from '../../../FagsakContext';
+
+interface WrapperProps extends PropsWithChildren {
+    fagsak?: IMinimalFagsak;
+    behandling?: IBehandling;
+}
+
+function Wrapper({ fagsak = lagFagsak(), behandling = lagBehandling(), children }: WrapperProps) {
+    return (
+        <TestProviders>
+            <FagsakProvider fagsak={fagsak}>
+                <HentOgSettBehandlingProvider fagsak={fagsak}>
+                    <BehandlingProvider behandling={behandling}>
+                        <ActionMenu open={true}>
+                            <ActionMenu.Content>{children}</ActionMenu.Content>
+                        </ActionMenu>
+                    </BehandlingProvider>
+                </HentOgSettBehandlingProvider>
+            </FagsakProvider>
+        </TestProviders>
+    );
+}
+
+describe('LeggTilEllerFjernBrevmottakerePåBehandling', () => {
+    test('skal rendre komponent', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<LeggTilEllerFjernBrevmottakerePåBehandling åpneModal={åpneModal} />, {
+            wrapper: Wrapper,
+        });
+        expect(screen.getByRole('menuitem', { name: 'Legg til brevmottaker' })).toBeInTheDocument();
+    });
+
+    test('skal rendre komponent med en brevmottaker allerede lagt til', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<LeggTilEllerFjernBrevmottakerePåBehandling åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper {...props} behandling={lagBehandling({ brevmottakere: [lagRestBrevmottaker()] })} />
+            ),
+        });
+        expect(screen.getByRole('menuitem', { name: 'Legg til eller fjern brevmottaker' })).toBeInTheDocument();
+    });
+
+    test('skal rendre komponent med flere brevmottakere allerede lagt til', () => {
+        const åpneModal = vi.fn();
+        const { screen } = render(<LeggTilEllerFjernBrevmottakerePåBehandling åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    behandling={lagBehandling({ brevmottakere: [lagRestBrevmottaker(), lagRestBrevmottaker()] })}
+                />
+            ),
+        });
+        expect(screen.getByRole('menuitem', { name: 'Se eller fjern brevmottakere' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne modal', async () => {
+        const åpneModal = vi.fn();
+        const { screen, user } = render(<LeggTilEllerFjernBrevmottakerePåBehandling åpneModal={åpneModal} />, {
+            wrapper: Wrapper,
+        });
+        const knapp = screen.getByRole('menuitem', { name: 'Legg til brevmottaker' });
+        await user.click(knapp);
+        expect(åpneModal).toHaveBeenCalledOnce();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.tsx
@@ -1,0 +1,29 @@
+import { ActionMenu } from '@navikt/ds-react';
+
+import type { SkjemaBrevmottaker } from './useBrevmottakerSkjema';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+const utledLabel = (brevmottakere: SkjemaBrevmottaker[], erLesevisning: boolean) => {
+    if (erLesevisning) {
+        return brevmottakere.length === 1 ? 'Se brevmottaker' : 'Se brevmottakere';
+    }
+    if (brevmottakere.length === 0) {
+        return 'Legg til brevmottaker';
+    }
+    return brevmottakere.length === 1 ? 'Legg til eller fjern brevmottaker' : 'Se eller fjern brevmottakere';
+};
+
+interface Props {
+    åpneModal: () => void;
+}
+
+export function LeggTilEllerFjernBrevmottakerePåBehandling({ åpneModal }: Props) {
+    const { behandling, vurderErLesevisning } = useBehandlingContext();
+
+    const brevmottakere = behandling.brevmottakere;
+    const erLesevising = vurderErLesevisning();
+
+    const label = utledLabel(brevmottakere, erLesevising);
+
+    return <ActionMenu.Item onSelect={åpneModal}>{label}</ActionMenu.Item>;
+}

--- a/src/frontend/testutils/mocks/handlers/ainntektHandlers.ts
+++ b/src/frontend/testutils/mocks/handlers/ainntektHandlers.ts
@@ -1,0 +1,10 @@
+import { http, HttpResponse } from 'msw';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+export const ainntektHandlers = [
+    http.post<never, { ident: string }>('/familie-ks-sak/api/a-inntekt/hent-url', async ({ request }) => {
+        const payload = await request.json();
+        return HttpResponse.json(byggSuksessRessurs(`url/${payload.ident}`));
+    }),
+];

--- a/src/frontend/testutils/mocks/handlers/handlers.ts
+++ b/src/frontend/testutils/mocks/handlers/handlers.ts
@@ -1,3 +1,4 @@
+import { ainntektHandlers } from './ainntektHandlers';
 import { behandlingHandlers } from './behandlingHandlers';
 import { fagsakHandlers } from './fagsakHandlers';
 import { featureToggleHandlers } from './featureToggleHandlers';
@@ -14,4 +15,5 @@ export const handlers = [
     ...versionHandlers,
     ...personHandlers,
     ...fagsakHandlers,
+    ...ainntektHandlers,
 ];

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -24,6 +24,8 @@ import type { IRestPersonResultat, IRestStegTilstand } from './vilkår';
 import type { IRestBrevmottaker } from '../sider/Fagsak/Fagsaklinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import type { IsoDatoString } from '../utils/dato';
 
+export const MIDLERTIDIG_BEHANDLENDE_ENHET_ID = '4863';
+
 export interface IRestNyBehandling {
     kategori: BehandlingKategori | null;
     søkersIdent: string;
@@ -385,3 +387,7 @@ export const erBehandlingAvslått = (behandlingsResultat?: BehandlingResultat): 
 export const erBehandlingFortsattInnvilget = (behandlingsResultat?: BehandlingResultat): boolean => {
     return behandlingsResultat === BehandlingResultat.FORTSATT_INNVILGET;
 };
+
+export function sjekkErBehandleneEnhetMidlertidig(behandling: IBehandling) {
+    return behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId === MIDLERTIDIG_BEHANDLENDE_ENHET_ID;
+}


### PR DESCRIPTION
### 📮 Favro
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26760

### 💰 Hva skal gjøres, og hvorfor?
Legger til en `<BehandlingsmenyNy />` komponent som skal brukes når man befinner seg inne i en behandling. Den er foreløpig ikke tatt i bruk, det kommer i en senere PR. Tanken er å legge inn en toggle som kan bytte mellom ny og gammel løsning.

Dropdown knappenen er konvertert til en ActionMenu knapp, og de tilhørende modalene er flyttet ut i egne filer. Modalene skal være omtrent helt lik som tidligere, har ikke gjort store endringer der. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Gammel:
<img width="249" height="301" alt="image" src="https://github.com/user-attachments/assets/6f822d88-2f77-4074-9979-b5ff2c49884a" />

Ny:
<img width="249" height="282" alt="image" src="https://github.com/user-attachments/assets/a94041a3-aea4-4d3e-ad74-142f05043051" />