### PR TITLE
NAV-26760: Legger til toggle og splitter fagsaklinje opp i en komponent for fagsak og en komponent for behandling

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
@@ -15,6 +15,9 @@ import { Venstremeny } from './Venstremeny/Venstremeny';
 import { HenleggBehandlingModal } from '../Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal';
 import { HenleggBehandlingVeivalgModal } from '../Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingVeivalgModal';
 import { KorrigerEtterbetalingModal } from './sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal';
+import { useAppContext } from '../../../context/AppContext';
+import { ToggleNavn } from '../../../typer/toggles';
+import { Behandlingslinje } from '../Fagsaklinje/Behandlingslinje';
 
 const FlexContainer = styled.div`
     display: flex;
@@ -48,6 +51,7 @@ interface Props {
 }
 
 const BehandlingContainer = ({ bruker, minimalFagsak }: Props) => {
+    const { toggles } = useAppContext();
     const { behandlingRessurs } = useHentOgSettBehandlingContext();
 
     switch (behandlingRessurs.status) {
@@ -57,7 +61,11 @@ const BehandlingContainer = ({ bruker, minimalFagsak }: Props) => {
                     <HenleggBehandlingModal />
                     <HenleggBehandlingVeivalgModal />
                     <KorrigerEtterbetalingModal behandling={behandlingRessurs.data} />
-                    <Fagsaklinje minimalFagsak={minimalFagsak} behandling={behandlingRessurs.data} />
+                    {toggles[ToggleNavn.brukNyActionMenu] ? (
+                        <Behandlingslinje />
+                    ) : (
+                        <Fagsaklinje minimalFagsak={minimalFagsak} behandling={behandlingRessurs.data} />
+                    )}
                     <FlexContainer>
                         <VenstremenyContainer>
                             <Venstremeny />

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -9,15 +9,18 @@ import Dokumentutsending from './Dokumentutsending/Dokumentutsending';
 import { DokumentutsendingProvider } from './Dokumentutsending/DokumentutsendingContext';
 import { FagsakProvider } from './FagsakContext';
 import { Fagsaklinje } from './Fagsaklinje/Fagsaklinje';
+import { FagsaklinjeNy } from './Fagsaklinje/FagsaklinjeNy';
 import JournalpostListe from './journalposter/JournalpostListe';
 import { ManuelleBrevmottakerePåFagsakProvider } from './ManuelleBrevmottakerePåFagsakContext';
 import Personlinje from './Personlinje/Personlinje';
 import { Saksoversikt } from './Saksoversikt/Saksoversikt';
+import { useAppContext } from '../../context/AppContext';
 import { useFagsakId } from '../../hooks/useFagsakId';
 import { useHentFagsak } from '../../hooks/useHentFagsak';
 import { useScrollTilAnker } from '../../hooks/useScrollTilAnker';
 import { HentOgSettBehandlingProvider } from './Behandling/context/HentOgSettBehandlingContext';
 import { useHentPerson } from '../../hooks/useHentPerson';
+import { ToggleNavn } from '../../typer/toggles';
 
 const Innhold = styled.div`
     height: calc(100vh - 3rem);
@@ -29,7 +32,9 @@ const Hovedinnhold = styled.div`
     overflow: auto;
 `;
 
-export const FagsakContainer = () => {
+export function FagsakContainer() {
+    const { toggles } = useAppContext();
+
     const fagsakId = useFagsakId();
 
     const { data: fagsak, isPending: isPendingFagsak, error: fagsakError } = useHentFagsak(fagsakId);
@@ -80,7 +85,11 @@ export const FagsakContainer = () => {
                                     path="/saksoversikt"
                                     element={
                                         <>
-                                            <Fagsaklinje minimalFagsak={fagsak} />
+                                            {toggles[ToggleNavn.brukNyActionMenu] ? (
+                                                <FagsaklinjeNy />
+                                            ) : (
+                                                <Fagsaklinje minimalFagsak={fagsak} />
+                                            )}
                                             <Saksoversikt minimalFagsak={fagsak} />
                                         </>
                                     }
@@ -90,7 +99,11 @@ export const FagsakContainer = () => {
                                     path="/dokumentutsending"
                                     element={
                                         <>
-                                            <Fagsaklinje minimalFagsak={fagsak} />
+                                            {toggles[ToggleNavn.brukNyActionMenu] ? (
+                                                <FagsaklinjeNy />
+                                            ) : (
+                                                <Fagsaklinje minimalFagsak={fagsak} />
+                                            )}
                                             <DokumentutsendingProvider fagsakId={fagsak.id}>
                                                 <Dokumentutsending bruker={bruker} />
                                             </DokumentutsendingProvider>
@@ -102,7 +115,11 @@ export const FagsakContainer = () => {
                                     path="/dokumenter"
                                     element={
                                         <>
-                                            <Fagsaklinje minimalFagsak={fagsak} />
+                                            {toggles[ToggleNavn.brukNyActionMenu] ? (
+                                                <FagsaklinjeNy />
+                                            ) : (
+                                                <Fagsaklinje minimalFagsak={fagsak} />
+                                            )}
                                             <JournalpostListe bruker={bruker} />
                                         </>
                                     }
@@ -124,4 +141,4 @@ export const FagsakContainer = () => {
             </BrukerProvider>
         </FagsakProvider>
     );
-};
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingslinje.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingslinje.test.tsx
@@ -1,0 +1,113 @@
+import type { PropsWithChildren } from 'react';
+
+import { Route, Routes } from 'react-router';
+import { describe, expect, test } from 'vitest';
+
+import type { ISaksbehandler } from '@navikt/familie-typer';
+
+import { lagBehandling, lagVisningBehandling } from '../../../testutils/testdata/behandlingTestdata';
+import { lagFagsak } from '../../../testutils/testdata/fagsakTestdata';
+import { lagSaksbehandler } from '../../../testutils/testdata/saksbehandlerTestdata';
+import { render, TestProviders } from '../../../testutils/testrender';
+import type { IBehandling } from '../../../typer/behandling';
+import type { IMinimalFagsak } from '../../../typer/fagsak';
+import { FagsakProvider } from '../FagsakContext';
+import { ManuelleBrevmottakerePåFagsakProvider } from '../ManuelleBrevmottakerePåFagsakContext';
+import { Behandlingslinje } from './Behandlingslinje';
+import { BehandlingProvider } from '../Behandling/context/BehandlingContext';
+import { HentOgSettBehandlingProvider } from '../Behandling/context/HentOgSettBehandlingContext';
+
+interface WrapperProps extends PropsWithChildren {
+    saksbehandler?: ISaksbehandler;
+    fagsak?: IMinimalFagsak;
+    behandling?: IBehandling;
+}
+
+function Wrapper({
+    saksbehandler = lagSaksbehandler(),
+    behandling = lagBehandling(),
+    fagsak = lagFagsak({ behandlinger: [lagVisningBehandling({ behandlingId: behandling?.behandlingId })] }),
+    children,
+}: WrapperProps) {
+    return (
+        <TestProviders
+            initialEntries={[{ pathname: '/fagsak/:fagsakId/:behandlingId/*' }]}
+            saksbehandler={saksbehandler}
+        >
+            <Routes>
+                <Route
+                    path={'/fagsak/:fagsakId/:behandlingId/*'}
+                    element={
+                        <FagsakProvider fagsak={fagsak}>
+                            <ManuelleBrevmottakerePåFagsakProvider>
+                                <HentOgSettBehandlingProvider fagsak={fagsak}>
+                                    <BehandlingProvider behandling={behandling}>{children}</BehandlingProvider>
+                                </HentOgSettBehandlingProvider>
+                            </ManuelleBrevmottakerePåFagsakProvider>
+                        </FagsakProvider>
+                    }
+                />
+                <Route path={`/fagsak/:fagsakId/saksoversikt`} element={<h1>Saksoversikt</h1>} />
+                <Route path={`/fagsak/:fagsakId/dokumenter`} element={<h1>Dokumenter</h1>} />
+            </Routes>
+        </TestProviders>
+    );
+}
+
+describe('Behandlingslinje', () => {
+    test('skal rendre komponenten som forventet', () => {
+        const { screen } = render(<Behandlingslinje />, { wrapper: Wrapper });
+
+        expect(screen.getByRole('button', { name: 'Saksoversikt' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Dokumenter' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Meny' })).toBeInTheDocument();
+    });
+
+    test('skal kunne navigere til saksoversikt', async () => {
+        const { screen, user } = render(<Behandlingslinje />, { wrapper: Wrapper });
+
+        await user.click(screen.getByRole('button', { name: 'Saksoversikt' }));
+
+        expect(screen.getByRole('heading', { name: 'Saksoversikt' })).toBeInTheDocument();
+    });
+
+    test('skal kunne navigere til dokumenter', async () => {
+        const { screen, user } = render(<Behandlingslinje />, { wrapper: Wrapper });
+
+        await user.click(screen.getByRole('button', { name: 'Dokumenter' }));
+
+        expect(screen.getByRole('heading', { name: 'Dokumenter' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne fagsakmeny', async () => {
+        const { screen, user } = render(<Behandlingslinje />, { wrapper: Wrapper });
+
+        await user.click(screen.getByRole('button', { name: 'Meny' }));
+
+        expect(screen.getByRole('menuitem', { name: 'Opprett behandling' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Send informasjonsbrev' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Henlegg behandling' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Endre behandlende enhet' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Endre behandlingstema' })).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Legg til barn' })).not.toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Sett behandling på vent' })).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Fortsett behandling' })).not.toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Legg til brevmottaker' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'A-Inntekt' })).toBeInTheDocument();
+    });
+
+    test('skal ikke vise fagsakmeny hvis saksbehandler ikke har tilgang', async () => {
+        const { screen } = render(<Behandlingslinje />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    saksbehandler={lagSaksbehandler({ groups: ['71f503a2-c28f-4394-a05a-8da263ceca4a'] })}
+                />
+            ),
+        });
+
+        expect(screen.getByRole('button', { name: 'Saksoversikt' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Dokumenter' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Meny' })).not.toBeInTheDocument();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingslinje.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingslinje.tsx
@@ -1,0 +1,50 @@
+import { Link as ReactRouterLink, useLocation } from 'react-router';
+
+import { FileTextIcon, HouseIcon } from '@navikt/aksel-icons';
+import { Box, Button, HStack } from '@navikt/ds-react';
+
+import { useAppContext } from '../../../context/AppContext';
+import { useFagsakContext } from '../FagsakContext';
+import { BehandlingsmenyNy } from './Behandlingsmeny/BehandlingsmenyNy';
+
+function lagAktivFaneStyle(fanenavn: string, pathname: string) {
+    const urlSplit = pathname.split('/');
+    const sluttenPåUrl = urlSplit[urlSplit.length - 1];
+    return sluttenPåUrl === fanenavn ? { textDecoration: 'underline' } : {};
+}
+
+export function Behandlingslinje() {
+    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
+    const { fagsak } = useFagsakContext();
+    const { pathname } = useLocation();
+
+    return (
+        <Box borderWidth={'0 0 1 0'} borderColor={'border-subtle'}>
+            <HStack paddingInline={'2 4'} paddingBlock={'2'} justify={'space-between'}>
+                <HStack>
+                    <Button
+                        as={ReactRouterLink}
+                        size={'small'}
+                        variant={'tertiary'}
+                        icon={<HouseIcon />}
+                        to={`/fagsak/${fagsak.id}/saksoversikt`}
+                        style={lagAktivFaneStyle('saksoversikt', pathname)}
+                    >
+                        Saksoversikt
+                    </Button>
+                    <Button
+                        as={ReactRouterLink}
+                        size={'small'}
+                        variant={'tertiary'}
+                        icon={<FileTextIcon />}
+                        to={`/fagsak/${fagsak.id}/dokumenter`}
+                        style={lagAktivFaneStyle('dokumenter', pathname)}
+                    >
+                        Dokumenter
+                    </Button>
+                </HStack>
+                {harInnloggetSaksbehandlerSkrivetilgang() && <BehandlingsmenyNy />}
+            </HStack>
+        </Box>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/FagsaklinjeNy.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/FagsaklinjeNy.test.tsx
@@ -1,0 +1,90 @@
+import type { PropsWithChildren } from 'react';
+
+import { Route, Routes } from 'react-router';
+import { describe, expect, test } from 'vitest';
+
+import type { ISaksbehandler } from '@navikt/familie-typer';
+
+import { FagsaklinjeNy } from './FagsaklinjeNy';
+import { lagFagsak } from '../../../testutils/testdata/fagsakTestdata';
+import { lagSaksbehandler } from '../../../testutils/testdata/saksbehandlerTestdata';
+import { render, TestProviders } from '../../../testutils/testrender';
+import type { IMinimalFagsak } from '../../../typer/fagsak';
+import { FagsakProvider } from '../FagsakContext';
+import { ManuelleBrevmottakerePåFagsakProvider } from '../ManuelleBrevmottakerePåFagsakContext';
+
+interface WrapperProps extends PropsWithChildren {
+    saksbehandler?: ISaksbehandler;
+    fagsak?: IMinimalFagsak;
+}
+
+function Wrapper({ saksbehandler = lagSaksbehandler(), fagsak = lagFagsak(), children }: WrapperProps) {
+    return (
+        <TestProviders saksbehandler={saksbehandler}>
+            <Routes>
+                <Route
+                    path={'/'}
+                    element={
+                        <FagsakProvider fagsak={fagsak}>
+                            <ManuelleBrevmottakerePåFagsakProvider>{children}</ManuelleBrevmottakerePåFagsakProvider>
+                        </FagsakProvider>
+                    }
+                />
+                <Route path={`/fagsak/:fagsakId/saksoversikt`} element={<h1>Saksoversikt</h1>} />
+                <Route path={`/fagsak/:fagsakId/dokumenter`} element={<h1>Dokumenter</h1>} />
+            </Routes>
+        </TestProviders>
+    );
+}
+
+describe('FagsaklinjeNy', () => {
+    test('skal rendre komponenten som forventet', () => {
+        const { screen } = render(<FagsaklinjeNy />, { wrapper: Wrapper });
+
+        expect(screen.getByRole('button', { name: 'Saksoversikt' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Dokumenter' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Meny' })).toBeInTheDocument();
+    });
+
+    test('skal kunne navigere til saksoversikt', async () => {
+        const { screen, user } = render(<FagsaklinjeNy />, { wrapper: Wrapper });
+
+        await user.click(screen.getByRole('button', { name: 'Saksoversikt' }));
+
+        expect(screen.getByRole('heading', { name: 'Saksoversikt' })).toBeInTheDocument();
+    });
+
+    test('skal kunne navigere til dokumenter', async () => {
+        const { screen, user } = render(<FagsaklinjeNy />, { wrapper: Wrapper });
+
+        await user.click(screen.getByRole('button', { name: 'Dokumenter' }));
+
+        expect(screen.getByRole('heading', { name: 'Dokumenter' })).toBeInTheDocument();
+    });
+
+    test('skal kunne åpne fagsakmeny', async () => {
+        const { screen, user } = render(<FagsaklinjeNy />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        expect(screen.getByRole('menuitem', { name: 'Opprett behandling' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Send informasjonsbrev' })).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Legg til brevmottaker' })).not.toBeInTheDocument();
+    });
+
+    test('skal ikke vise fagsakmeny hvis saksbehandler ikke har tilgang', async () => {
+        const { screen } = render(<FagsaklinjeNy />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    saksbehandler={lagSaksbehandler({ groups: ['71f503a2-c28f-4394-a05a-8da263ceca4a'] })}
+                />
+            ),
+        });
+
+        expect(screen.getByRole('button', { name: 'Saksoversikt' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Dokumenter' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Meny' })).not.toBeInTheDocument();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/FagsaklinjeNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/FagsaklinjeNy.tsx
@@ -1,0 +1,50 @@
+import { Link as ReactRouterLink, useLocation } from 'react-router';
+
+import { FileTextIcon, HouseIcon } from '@navikt/aksel-icons';
+import { Box, Button, HStack } from '@navikt/ds-react';
+
+import { useAppContext } from '../../../context/AppContext';
+import { useFagsakContext } from '../FagsakContext';
+import { Fagsakmeny } from './Behandlingsmeny/Fagsakmeny';
+
+function lagAktivFaneStyle(fanenavn: string, pathname: string) {
+    const urlSplit = pathname.split('/');
+    const sluttenPåUrl = urlSplit[urlSplit.length - 1];
+    return sluttenPåUrl === fanenavn ? { textDecoration: 'underline' } : {};
+}
+
+export function FagsaklinjeNy() {
+    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
+    const { fagsak } = useFagsakContext();
+    const { pathname } = useLocation();
+
+    return (
+        <Box borderWidth={'0 0 1 0'} borderColor={'border-subtle'}>
+            <HStack paddingInline={'2 4'} paddingBlock={'2'} justify={'space-between'}>
+                <HStack>
+                    <Button
+                        as={ReactRouterLink}
+                        size={'small'}
+                        variant={'tertiary'}
+                        icon={<HouseIcon />}
+                        to={`/fagsak/${fagsak.id}/saksoversikt`}
+                        style={lagAktivFaneStyle('saksoversikt', pathname)}
+                    >
+                        Saksoversikt
+                    </Button>
+                    <Button
+                        as={ReactRouterLink}
+                        size={'small'}
+                        variant={'tertiary'}
+                        icon={<FileTextIcon />}
+                        to={`/fagsak/${fagsak.id}/dokumenter`}
+                        style={lagAktivFaneStyle('dokumenter', pathname)}
+                    >
+                        Dokumenter
+                    </Button>
+                </HStack>
+                {harInnloggetSaksbehandlerSkrivetilgang() && <Fagsakmeny />}
+            </HStack>
+        </Box>
+    );
+}

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -11,6 +11,7 @@ export enum ToggleNavn {
     kanOppretteRevurderingMedAarsakIverksetteKaVedtak = 'familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak',
     skalAlltidViseAlleVedtaksperioder = 'familie-ks-sak-frontend.alltid-vis-alle-vedtaksperioder',
     skalViseOppholdsadresse = 'familie-ks-sak.skal-vise-oppholdsadresse',
+    brukNyActionMenu = 'familie-ks-sak.bruk-ny-action-meny',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 📮 Favro
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26760

### 💰 Hva skal gjøres, og hvorfor?
Legger til en toggle for å vise den ny `<ActionMenu />` komponenten.

Deler opp den tidligere `<Fagsaklinje />` i to komponenter, en for behandling kalt `<Behandlingslinje />` og en fagsak kalt `<FagsaklinjeNy />`. Legger til tester.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer.
