### PR TITLE
NAV-26760: Skal vise TilbakekrevingsbehandlingOpprettetModal ved oppretting av tilbakekrevingsbehandlinger

### DIFF
--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/BehandlingsmenyNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/BehandlingsmenyNy.tsx
@@ -20,6 +20,7 @@ import { LeggTilBrevmottakerModalBehandling } from './LeggTilEllerFjernBrevmotta
 import { LeggTilEllerFjernBrevmottakerePåBehandling } from './LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling';
 import { OpprettBehandlingModal } from './OpprettBehandling/OpprettBehandlingModal';
 import { OpprettBehandlingNy } from './OpprettBehandling/OpprettBehandlingNy';
+import { TilbakekrevingsbehandlingOpprettetModal } from './OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal';
 import { SendInformasjonsbrev } from './SendInformasjonsbrev/SendInformasjonsbrev';
 import { sjekkErBehandleneEnhetMidlertidig } from '../../../../typer/behandling';
 import { useBehandlingContext } from '../../Behandling/context/BehandlingContext';
@@ -31,6 +32,8 @@ export function BehandlingsmenyNy() {
     const erBehandlingPåVent = !!behandling.behandlingPåVent;
 
     const [visOpprettBehandlingModal, settVisOpprettBehandlingModal] = useState(false);
+    const [visTilbakekrevingsbehandlingOpprettetModal, settVisTilbakekrevingsbehandlingOpprettetModal] =
+        useState(false);
     const [visEndreBehandlendeEnhetModal, settVisEndreBehandlendeEnhetModal] = useState(erBehandleneEnhetMidlertidig);
     const [visEndreBehandlingstemaModal, settVisEndreBehandlingstemaModal] = useState(false);
     const [visLeggTilBarnPåBehandlingaModal, settVisLeggTilBarnPåBehandlingaModal] = useState(false);
@@ -41,7 +44,15 @@ export function BehandlingsmenyNy() {
     return (
         <>
             {visOpprettBehandlingModal && (
-                <OpprettBehandlingModal lukkModal={() => settVisOpprettBehandlingModal(false)} />
+                <OpprettBehandlingModal
+                    lukkModal={() => settVisOpprettBehandlingModal(false)}
+                    onTilbakekrevingsbehandlingOpprettet={() => settVisTilbakekrevingsbehandlingOpprettetModal(true)}
+                />
+            )}
+            {visTilbakekrevingsbehandlingOpprettetModal && (
+                <TilbakekrevingsbehandlingOpprettetModal
+                    lukkModal={() => settVisTilbakekrevingsbehandlingOpprettetModal(false)}
+                />
             )}
             {visEndreBehandlendeEnhetModal && (
                 <EndreBehandlendeEnhetModal lukkModal={() => settVisEndreBehandlendeEnhetModal(false)} />

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/Fagsakmeny.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/Fagsakmeny.tsx
@@ -8,16 +8,27 @@ import { LeggTilBrevmottakerModalFagsak } from './LeggTilEllerFjernBrevmottakere
 import { LeggTilEllerFjernBrevmottakerePåFagsak } from './LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak';
 import { OpprettBehandlingModal } from './OpprettBehandling/OpprettBehandlingModal';
 import { OpprettBehandlingNy } from './OpprettBehandling/OpprettBehandlingNy';
+import { TilbakekrevingsbehandlingOpprettetModal } from './OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal';
 import { SendInformasjonsbrev } from './SendInformasjonsbrev/SendInformasjonsbrev';
 
 export function Fagsakmeny() {
     const [visOpprettBehandlingModal, settVisOpprettBehandlingModal] = useState(false);
+    const [visTilbakekrevingsbehandlingOpprettetModal, settVisTilbakekrevingsbehandlingOpprettetModal] =
+        useState(false);
     const [visLeggTilBrevmottakerModal, settVisLeggTilBrevmottakerModal] = useState(false);
 
     return (
         <>
             {visOpprettBehandlingModal && (
-                <OpprettBehandlingModal lukkModal={() => settVisOpprettBehandlingModal(false)} />
+                <OpprettBehandlingModal
+                    lukkModal={() => settVisOpprettBehandlingModal(false)}
+                    onTilbakekrevingsbehandlingOpprettet={() => settVisTilbakekrevingsbehandlingOpprettetModal(true)}
+                />
+            )}
+            {visTilbakekrevingsbehandlingOpprettetModal && (
+                <TilbakekrevingsbehandlingOpprettetModal
+                    lukkModal={() => settVisTilbakekrevingsbehandlingOpprettetModal(false)}
+                />
             )}
             {visLeggTilBrevmottakerModal && (
                 <LeggTilBrevmottakerModalFagsak lukkModal={() => settVisLeggTilBrevmottakerModal(false)} />

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingModal.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingModal.tsx
@@ -25,12 +25,19 @@ const StyledAlert = styled(Alert)`
 
 interface Props {
     lukkModal: () => void;
+    onTilbakekrevingsbehandlingOpprettet: () => void;
 }
 
-export function OpprettBehandlingModal({ lukkModal }: Props) {
+export function OpprettBehandlingModal({ lukkModal, onTilbakekrevingsbehandlingOpprettet }: Props) {
     const { fagsak } = useFagsakContext();
 
-    const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus } = useOpprettBehandling({ lukkModal });
+    const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus } = useOpprettBehandling({
+        lukkModal,
+        onOpprettTilbakekrevingSuccess: () => {
+            lukkModal();
+            onTilbakekrevingsbehandlingOpprettet();
+        },
+    });
 
     const lukkOpprettBehandlingModal = () => {
         nullstillSkjemaStatus();

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal.test.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal.test.tsx
@@ -1,0 +1,81 @@
+import type { PropsWithChildren } from 'react';
+
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, expect } from 'vitest';
+
+import { TilbakekrevingsbehandlingOpprettetModal } from './TilbakekrevingsbehandlingOpprettetModal';
+import { lagFagsak } from '../../../../../testutils/testdata/fagsakTestdata';
+import { render } from '../../../../../testutils/testrender';
+import type { IMinimalFagsak } from '../../../../../typer/fagsak';
+import { FagsakProvider } from '../../../FagsakContext';
+
+interface WrapperProps extends PropsWithChildren {
+    fagsak?: IMinimalFagsak;
+}
+
+function Wrapper({ fagsak = lagFagsak(), children }: WrapperProps) {
+    return (
+        <MemoryRouter>
+            <Routes>
+                <Route path={'/'} element={<FagsakProvider fagsak={fagsak}>{children}</FagsakProvider>} />
+                <Route path={'/oppgaver'} element={<h1>Oppgaver</h1>} />
+                <Route path={`/fagsak/${fagsak.id}/saksoversikt`} element={<h1>Saksoversikt</h1>} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+describe('TilbakekrevingsbehandlingOpprettetModal', () => {
+    test('skal rendre modalen som forventet', () => {
+        const lukkModal = vi.fn();
+
+        const { screen } = render(<TilbakekrevingsbehandlingOpprettetModal lukkModal={lukkModal} />, {
+            wrapper: Wrapper,
+        });
+
+        expect(screen.getByRole('dialog', { name: 'Tilbakekrevingsbehandling opprettes' })).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Tilbakekrevingsbehandling opprettes, men det kan ta litt tid (ca 30 sekunder) før den blir tilgjengelig i saksoversikten og oppgavebenken.'
+            )
+        ).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Gå til oppgavebenken' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Gå til saksoversikten' })).toBeInTheDocument();
+    });
+
+    test('skal kunne navigere til oppgavebenken', async () => {
+        const lukkModal = vi.fn();
+
+        const { screen, user } = render(<TilbakekrevingsbehandlingOpprettetModal lukkModal={lukkModal} />, {
+            wrapper: Wrapper,
+        });
+
+        await user.click(screen.getByRole('button', { name: 'Gå til oppgavebenken' }));
+
+        expect(screen.getByRole('heading', { name: 'Oppgaver' })).toBeInTheDocument();
+    });
+
+    test('skal kunne navigere til saksoversikten', async () => {
+        const lukkModal = vi.fn();
+
+        const { screen, user } = render(<TilbakekrevingsbehandlingOpprettetModal lukkModal={lukkModal} />, {
+            wrapper: Wrapper,
+        });
+
+        await user.click(screen.getByRole('button', { name: 'Gå til saksoversikten' }));
+
+        expect(screen.getByRole('heading', { name: 'Saksoversikt' })).toBeInTheDocument();
+    });
+
+    test('skal kunne lukke modalen', async () => {
+        const lukkModal = vi.fn();
+
+        const { screen, user } = render(<TilbakekrevingsbehandlingOpprettetModal lukkModal={lukkModal} />, {
+            wrapper: Wrapper,
+        });
+
+        await user.click(screen.getByRole('button', { name: 'Lukk' }));
+
+        expect(lukkModal).toHaveBeenCalledOnce();
+    });
+});

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal.tsx
@@ -1,0 +1,49 @@
+import { useNavigate } from 'react-router';
+
+import { BodyLong, Button, Modal } from '@navikt/ds-react';
+
+import { useFagsakContext } from '../../../FagsakContext';
+
+interface Props {
+    lukkModal: () => void;
+}
+
+export function TilbakekrevingsbehandlingOpprettetModal({ lukkModal }: Props) {
+    const { fagsak } = useFagsakContext();
+    const navigate = useNavigate();
+
+    function navigerTilOppgaver() {
+        lukkModal();
+        navigate('/oppgaver');
+    }
+
+    function navigerTilSaksoversikt() {
+        lukkModal();
+        navigate(`/fagsak/${fagsak.id}/saksoversikt`);
+    }
+
+    return (
+        <Modal
+            open={true}
+            width={'45rem'}
+            portal={true}
+            header={{ heading: 'Tilbakekrevingsbehandling opprettes' }}
+            onClose={() => lukkModal()}
+        >
+            <Modal.Body>
+                <BodyLong>
+                    Tilbakekrevingsbehandling opprettes, men det kan ta litt tid (ca 30 sekunder) før den blir
+                    tilgjengelig i saksoversikten og oppgavebenken.
+                </BodyLong>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant={'primary'} onClick={navigerTilOppgaver}>
+                    Gå til oppgavebenken
+                </Button>
+                <Button variant={'secondary'} onClick={navigerTilSaksoversikt}>
+                    Gå til saksoversikten
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -36,7 +36,7 @@ const useOpprettBehandling = ({
     onOpprettTilbakekrevingSuccess,
 }: {
     lukkModal: () => void;
-    onOpprettTilbakekrevingSuccess?: () => void;
+    onOpprettTilbakekrevingSuccess: () => void;
 }) => {
     const { fagsakId } = useSakOgBehandlingParams();
     const { fagsak } = useFagsakContext();
@@ -154,7 +154,7 @@ const useOpprettBehandling = ({
             response => {
                 if (response.status === RessursStatus.SUKSESS) {
                     nullstillSkjemaStatus();
-                    onOpprettTilbakekrevingSuccess?.();
+                    onOpprettTilbakekrevingSuccess();
                     queryClient.invalidateQueries({
                         queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.tilbakekrevingsbehandlinger(fagsak.id),
                     });


### PR DESCRIPTION
### 📮 Favro
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26760

### 💰 Hva skal gjøres, og hvorfor?
Siden oppretting av tilbakekrevingsbehandlinger blir gjort i en task gir det mening å vise modalen som forteller saksbehandler at oppretting tar litt tid. Hadde ikke tatt den med tidligere da jeg var usikker på om den var nødvendig. Dette er funksjonalitet som allerede ligger inne, men tilpasser det nå de nye `<ActionMenu />` komponentene.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
<img width="589" height="212" alt="image" src="https://github.com/user-attachments/assets/d6ca6e25-aad6-48bf-9d8b-6a1c1b68dad6" />