### PR TITLE
NAV-26852: oppdaterer knappe-varianter til bedre samsvar med retningslinjer

### DIFF
--- a/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -314,7 +314,7 @@ export const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
             <Knapperekke>
                 <Button
                     id={'forhandsvis-vedtaksbrev'}
-                    variant={'tertiary'}
+                    variant={'secondary'}
                     size={'medium'}
                     disabled={skjemaErLåst}
                     onClick={() => {
@@ -333,7 +333,7 @@ export const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                     Forhåndsvis
                 </Button>
                 <Button
-                    variant={'secondary'}
+                    variant={'primary'}
                     size={'medium'}
                     loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                     disabled={skjemaErLåst}

--- a/src/frontend/komponenter/Hendelsesoversikt/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/komponenter/Hendelsesoversikt/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -126,7 +126,6 @@ const Totrinnskontrollskjema = ({ innsendtVedtak, sendInnVedtak, åpenBehandling
             <StyledButton
                 variant={'primary'}
                 loading={senderInn}
-                disabled={senderInn}
                 size={'small'}
                 onClick={() => {
                     if (!senderInn) {

--- a/src/frontend/komponenter/Modal/Fagsak/OpprettFagsakModalInnhold.tsx
+++ b/src/frontend/komponenter/Modal/Fagsak/OpprettFagsakModalInnhold.tsx
@@ -43,12 +43,7 @@ export function OpprettFagsakModalInnhold({ personIdent, personNavn }: Props) {
                 </VStack>
             </Modal.Body>
             <Modal.Footer>
-                <Button
-                    variant={'primary'}
-                    onClick={() => mutate({ personIdent })}
-                    disabled={isPending}
-                    loading={isPending}
-                >
+                <Button variant={'primary'} onClick={() => mutate({ personIdent })} loading={isPending}>
                     Opprett fagsak
                 </Button>
                 <Button type={'button'} variant={'tertiary'} onClick={lukkModal}>

--- a/src/frontend/komponenter/Modal/LeggTilBarn/LeggTilBarnModal.tsx
+++ b/src/frontend/komponenter/Modal/LeggTilBarn/LeggTilBarnModal.tsx
@@ -85,7 +85,6 @@ export function LeggTilBarnModal() {
                             type={'submit'}
                             size={'medium'}
                             loading={form.formState.isSubmitting}
-                            disabled={form.formState.isSubmitting}
                         >
                             Legg til
                         </Button>
@@ -94,7 +93,6 @@ export function LeggTilBarnModal() {
                             size={'medium'}
                             onClick={() => onClose()}
                             loading={form.formState.isSubmitting}
-                            disabled={form.formState.isSubmitting}
                         >
                             Avbryt
                         </Button>

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
@@ -55,7 +55,7 @@ export const LeggTilBrevmottakerModal = <T extends SkjemaBrevmottaker | IRestBre
 
     const [visSkjemaNårDetErÉnBrevmottaker, settVisSkjemaNårDetErÉnBrevmottaker] = useState(false);
 
-    const { skjema, valideringErOk } = verdierFraBrevmottakerUseSkjema;
+    const { skjema } = verdierFraBrevmottakerUseSkjema;
     const heading = utledHeading(brevmottakere.length, erLesevisning);
 
     const erSkjemaSynlig =
@@ -112,7 +112,7 @@ export const LeggTilBrevmottakerModal = <T extends SkjemaBrevmottaker | IRestBre
                 {!erLesevisning && erSkjemaSynlig ? (
                     <>
                         <Button
-                            variant={valideringErOk() ? 'primary' : 'secondary'}
+                            variant={'primary'}
                             loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                             disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                             onClick={() => lagreMottaker(verdierFraBrevmottakerUseSkjema)}

--- a/src/frontend/komponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Skjemasteg/Skjemasteg.tsx
@@ -91,7 +91,7 @@ const Skjemasteg = ({
                 {feilmelding !== '' && <StyledErrorMessage>{feilmelding}</StyledErrorMessage>}
                 <Navigering>
                     {nesteOnClick && skalViseNesteKnapp && (!vurderErLesevisning() || kanGåVidereILesevisning) && (
-                        <Button variant={'primary'} onClick={onNesteClicked} loading={senderInn} disabled={senderInn}>
+                        <Button variant={'primary'} onClick={onNesteClicked} loading={senderInn}>
                             {nesteKnappTittel}
                         </Button>
                     )}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Behandlingsresultat.tsx
@@ -24,10 +24,14 @@ import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingPar
 import Skjemasteg from '../../../../../komponenter/Skjemasteg/Skjemasteg';
 import { useTidslinjeContext } from '../../../../../komponenter/Tidslinje/TidslinjeContext';
 import { BehandlingSteg, BehandlingÅrsak, type IBehandling } from '../../../../../typer/behandling';
-import type { IRestKompetanse, IRestUtenlandskPeriodeBeløp, IRestValutakurs } from '../../../../../typer/eøsPerioder';
+import {
+    type IRestKompetanse,
+    type IRestUtenlandskPeriodeBeløp,
+    type IRestValutakurs,
+} from '../../../../../typer/eøsPerioder';
 import { formaterIdent, slåSammenListeTilStreng } from '../../../../../utils/formatter';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
-import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+import { useBehandlingContext } from '../../context/BehandlingContext';
 
 const EndretUtbetalingAndel = styled.div`
     display: flex;
@@ -149,7 +153,6 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
                     .
                 </StyledAlert>
             )}
-
             <TilkjentYtelseTidslinje grunnlagPersoner={grunnlagPersoner} tidslinjePersoner={tidslinjePersoner} />
             {!erLesevisning && (
                 <EndretUtbetalingAndel>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -66,7 +66,6 @@ const KompetanseTabellRadEndre = ({
     skjema,
     tilgjengeligeBarn,
     status,
-    valideringErOk,
     sendInnSkjema,
     toggleForm,
     slettKompetanse,
@@ -269,7 +268,7 @@ const KompetanseTabellRadEndre = ({
                             <Button
                                 onClick={() => sendInnSkjema()}
                                 size="small"
-                                variant={valideringErOk() ? 'primary' : 'secondary'}
+                                variant={'primary'}
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                             >
                                 Ferdig

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -29,6 +29,7 @@ const kompetansePeriodeFeilmeldingId = (kompetanse: ISkjema<IKompetanse, IBehand
     `kompetanse-periode_${kompetanse.felter.barnIdenter.verdi.map(barn => `${barn}-`)}_${
         kompetanse.felter.periode.verdi.fom
     }`;
+
 interface IProps {
     skjema: ISkjema<IKompetanse, IBehandling>;
     tilgjengeligeBarn: OptionType[];
@@ -270,7 +271,6 @@ const KompetanseTabellRadEndre = ({
                                 size="small"
                                 variant={valideringErOk() ? 'primary' : 'secondary'}
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                             >
                                 Ferdig
                             </Button>
@@ -292,7 +292,6 @@ const KompetanseTabellRadEndre = ({
                                     barn => `${barn}-`
                                 )}_${skjema.felter.initielFom.verdi}`}
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                                 size={'small'}
                                 icon={<TrashIcon />}
                             >

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
@@ -79,7 +79,6 @@ const UtenlandskPeriodeBeløpTabellRadEndre = ({
     skjema,
     tilgjengeligeBarn,
     status,
-    valideringErOk,
     sendInnSkjema,
     toggleForm,
     slettUtenlandskPeriodeBeløp,
@@ -194,14 +193,13 @@ const UtenlandskPeriodeBeløpTabellRadEndre = ({
                         </Select>
                     </UtbetaltBeløpRad>
                 </StyledFieldset>
-
                 {!lesevisning && (
                     <Knapperad>
                         <div>
                             <Button
                                 onClick={() => sendInnSkjema()}
                                 size="small"
-                                variant={valideringErOk() ? 'primary' : 'secondary'}
+                                variant={'primary'}
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                             >
                                 Ferdig
@@ -215,7 +213,6 @@ const UtenlandskPeriodeBeløpTabellRadEndre = ({
                                 Avbryt
                             </Button>
                         </div>
-
                         {skjema.felter.status?.verdi !== EøsPeriodeStatus.IKKE_UTFYLT && (
                             <Button
                                 variant={'tertiary'}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
@@ -203,7 +203,6 @@ const UtenlandskPeriodeBeløpTabellRadEndre = ({
                                 size="small"
                                 variant={valideringErOk() ? 'primary' : 'secondary'}
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                             >
                                 Ferdig
                             </Button>
@@ -225,7 +224,6 @@ const UtenlandskPeriodeBeløpTabellRadEndre = ({
                                     barn => `${barn}-`
                                 )}_${skjema.felter.initielFom.verdi}`}
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                                 size={'small'}
                                 icon={<TrashIcon />}
                             >

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -184,7 +184,6 @@ const ValutakursTabellRadEndre = ({
                                 size="small"
                                 variant={valideringErOk() ? 'primary' : 'secondary'}
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                             >
                                 Ferdig
                             </Button>
@@ -206,7 +205,6 @@ const ValutakursTabellRadEndre = ({
                                     barn => `${barn}-`
                                 )}_${skjema.felter.initielFom.verdi}`}
                                 loading={sletterValutakurs}
-                                disabled={sletterValutakurs}
                                 size={'small'}
                                 icon={<TrashIcon />}
                             >

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -69,7 +69,6 @@ const ValutakursTabellRadEndre = ({
     tilgjengeligeBarn,
     status,
     sendInnSkjema,
-    valideringErOk,
     toggleForm,
     slettValutakurs,
     sletterValutakurs,
@@ -182,7 +181,7 @@ const ValutakursTabellRadEndre = ({
                             <Button
                                 onClick={() => sendInnSkjema()}
                                 size="small"
-                                variant={valideringErOk() ? 'primary' : 'secondary'}
+                                variant={'primary'}
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                             >
                                 Ferdig

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/OvergangsordningAndel/OvergangsordningAndelSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/OvergangsordningAndel/OvergangsordningAndelSkjema.tsx
@@ -114,7 +114,6 @@ const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndel
                     />
                 </FlexDiv>
             </Feltmargin>
-
             <Feltmargin>
                 <Checkbox
                     checked={skjema.felter.deltBosted.verdi}
@@ -127,7 +126,6 @@ const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndel
                     {'Barnet har delt bosted'}
                 </Checkbox>
             </Feltmargin>
-
             <Feltmargin>
                 <StyledTextField
                     {...skjema.felter.antallTimer.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
@@ -144,7 +142,7 @@ const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndel
             {!erLesevisning && (
                 <Knapperekke>
                     <KnapperekkeVenstre>
-                        <StyledButton size={'small'} variant={'secondary'} onClick={oppdaterOvergangsordningAndel}>
+                        <StyledButton size={'small'} variant={'primary'} onClick={oppdaterOvergangsordningAndel}>
                             Bekreft
                         </StyledButton>
                         <Button variant="tertiary" size="small" onClick={tilbakestillOgLukkOvergangsordningAndel}>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Simulering/TilbakekrevingSkjema.tsx
@@ -302,7 +302,7 @@ const TilbakekrevingSkjema = ({
                                                 }}
                                                 size={'small'}
                                                 icon={<FileTextIcon />}
-                                                disabled={isOpprettTilbakekrevingVarselBrevPdfPending}
+                                                loading={isOpprettTilbakekrevingVarselBrevPdfPending}
                                             >
                                                 Forhåndsvis varsel
                                             </Button>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
@@ -32,7 +32,7 @@ const FeilutbetaltValutaPeriode = ({ feilutbetaltValuta, erLesevisning, behandli
     const [erRadEkspandert, settErRadEkspandert] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const { skjema, oppdaterEksisterendePeriode, fjernPeriode, valideringErOk, tilbakestillSkjemafelterTilDefault } =
+    const { skjema, oppdaterEksisterendePeriode, fjernPeriode, tilbakestillSkjemafelterTilDefault } =
         useFeilutbetaltValuta({
             behandlingId,
             feilutbetaltValuta,
@@ -65,11 +65,7 @@ const FeilutbetaltValutaPeriode = ({ feilutbetaltValuta, erLesevisning, behandli
                         key={`${feilutbetaltValuta.id}-$${erRadEkspandert ? 'ekspandert' : 'lukket'}`}
                     />
                     <FlexRowDiv>
-                        <Button
-                            size="small"
-                            onClick={oppdaterEksisterendePeriode}
-                            variant={valideringErOk() ? 'primary' : 'secondary'}
-                        >
+                        <Button size="small" onClick={oppdaterEksisterendePeriode} variant={'primary'}>
                             Lagre periode
                         </Button>
                         <Button size="small" variant="tertiary" onClick={tilbakestillOgLukkSkjema}>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/FeilutbetaltValuta/NyFeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/FeilutbetaltValuta/NyFeilutbetaltValutaPeriode.tsx
@@ -26,7 +26,7 @@ const FlexRowDiv = styled.div`
 const NyFeilutbetaltValutaPeriode = ({ lukkNyPeriode, behandlingId }: INyFeilutbetaltValutaPeriodeProps) => {
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const { skjema, lagreNyPeriode, nullstillSkjema, valideringErOk } = useFeilutbetaltValuta({
+    const { skjema, lagreNyPeriode, nullstillSkjema } = useFeilutbetaltValuta({
         behandlingId: behandlingId,
         settFeilmelding: settFeilmelding,
     });
@@ -47,7 +47,7 @@ const NyFeilutbetaltValutaPeriode = ({ lukkNyPeriode, behandlingId }: INyFeilutb
                 <FlexColumnDiv>
                     <FeilutbetaltValutaSkjema skjema={skjema} />
                     <FlexRowDiv style={{ gap: '1rem' }}>
-                        <Button size="small" onClick={lagre} variant={valideringErOk() ? 'primary' : 'secondary'}>
+                        <Button size="small" onClick={lagre} variant={'primary'}>
                             Lagre periode
                         </Button>
                         <Button size="small" variant="tertiary" onClick={avbrytLeggTilNy}>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal.tsx
@@ -95,7 +95,6 @@ export function KorrigerEtterbetalingModal({ behandling }: KorrigerEtterbetaling
                                         onClick={angreKorrigertEtterbetaling}
                                         variant={'tertiary'}
                                         loading={angreKorrigertEtterbetalingPending}
-                                        disabled={korrigerEtterbetalingPending}
                                         icon={<ArrowUndoIcon />}
                                     >
                                         Angre korrigering
@@ -107,12 +106,7 @@ export function KorrigerEtterbetalingModal({ behandling }: KorrigerEtterbetaling
                                 <Button onClick={handleLukkModal} variant={'tertiary'}>
                                     Avbryt
                                 </Button>
-                                <Button
-                                    type={'submit'}
-                                    variant={form.formState.errors ? 'primary' : 'secondary'}
-                                    loading={korrigerEtterbetalingPending}
-                                    disabled={angreKorrigertEtterbetalingPending}
-                                >
+                                <Button type={'submit'} variant={'primary'} loading={korrigerEtterbetalingPending}>
                                     {korrigertEtterbetaling ? 'Oppdater' : 'Korriger beløp'}
                                 </Button>
                             </HStack>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerEtterbetaling/useKorrigerEtterbetalingForm.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerEtterbetaling/useKorrigerEtterbetalingForm.ts
@@ -69,6 +69,10 @@ export function useKorrigerEtterbetalingForm(behandling: IBehandling) {
     } = form;
 
     async function korrigerEtterbetaling(values: KorrigerEtterbetalingFormValues) {
+        if (angreKorrigertEtterbetalingPending || korrigerEtterbetalingPending) {
+            return;
+        }
+
         const { årsak, beløp, begrunnelse } = values;
 
         const korrigerEtterbetalingParameters = {
@@ -95,6 +99,9 @@ export function useKorrigerEtterbetalingForm(behandling: IBehandling) {
     }
 
     async function angreKorrigertEtterbetaling() {
+        if (korrigerEtterbetalingPending) {
+            return;
+        }
         return angreKorrigertEtterbetalingAsync(behandling.behandlingId)
             .then(behandling => {
                 settToast(ToastTyper.ETTERBETALING_KORRIGERT, {

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerVedtakModal/KorrigerVedtakModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerVedtakModal/KorrigerVedtakModal.tsx
@@ -20,7 +20,7 @@ interface IProps {
 }
 
 const KorrigerVedtakModal = ({ lukkModal, korrigertVedtak, behandlingId, erLesevisning }: IProps) => {
-    const { skjema, valideringErOk, lagreKorrigertVedtak, angreKorrigering, restFeil } = useKorrigerVedtakSkjema({
+    const { skjema, lagreKorrigertVedtak, angreKorrigering, restFeil } = useKorrigerVedtakSkjema({
         lukkModal,
         korrigertVedtak,
         behandlingId,
@@ -68,9 +68,8 @@ const KorrigerVedtakModal = ({ lukkModal, korrigertVedtak, behandlingId, erLesev
                     <>
                         <Button
                             onClick={lagreKorrigertVedtak}
-                            variant={valideringErOk() ? 'primary' : 'secondary'}
+                            variant={'primary'}
                             loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                            disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                         >
                             {korrigertVedtak ? 'Oppdater' : 'Legg til'}
                         </Button>
@@ -83,7 +82,6 @@ const KorrigerVedtakModal = ({ lukkModal, korrigertVedtak, behandlingId, erLesev
                                 onClick={angreKorrigering}
                                 variant={'tertiary'}
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                                 icon={<ArrowUndoIcon />}
                             >
                                 Fjern korrigering

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -213,7 +213,7 @@ const OppsummeringVedtakInnhold = ({
                         />
                         <Button
                             key={'oppgavebenk'}
-                            variant={'secondary'}
+                            variant={'primary'}
                             size={'medium'}
                             onClick={() => {
                                 settVisModal(false);

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/form/RefusjonEøsForm.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/form/RefusjonEøsForm.tsx
@@ -75,8 +75,7 @@ export function RefusjonEøsForm({ type, refusjonEøs, skjulForm, readOnly }: Pr
                                     variant={'tertiary'}
                                     size={'small'}
                                     onClick={onAvbyrt}
-                                    loading={isSubmitting}
-                                    disabled={readOnly}
+                                    disabled={readOnly || isSubmitting}
                                 >
                                     Avbryt
                                 </Button>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/form/RefusjonEøsForm.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/form/RefusjonEøsForm.tsx
@@ -66,7 +66,7 @@ export function RefusjonEøsForm({ type, refusjonEøs, skjulForm, readOnly }: Pr
                                     variant={'primary'}
                                     size={'small'}
                                     loading={isSubmitting}
-                                    disabled={readOnly || isSubmitting}
+                                    disabled={readOnly}
                                 >
                                     Lagre periode
                                 </Button>
@@ -75,7 +75,8 @@ export function RefusjonEøsForm({ type, refusjonEøs, skjulForm, readOnly }: Pr
                                     variant={'tertiary'}
                                     size={'small'}
                                     onClick={onAvbyrt}
-                                    disabled={readOnly || isSubmitting}
+                                    loading={isSubmitting}
+                                    disabled={readOnly}
                                 >
                                     Avbryt
                                 </Button>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/FritekstVedtakbegrunnelser.tsx
@@ -205,9 +205,8 @@ const FritekstVedtakbegrunnelser = () => {
                                     putVedtaksperiodeMedFritekster();
                                 }}
                                 size="small"
-                                variant="secondary"
+                                variant="primary"
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                             >
                                 Lagre
                             </Button>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/FritekstVedtakbegrunnelser.tsx
@@ -132,7 +132,6 @@ const FritekstVedtakbegrunnelser = () => {
                     Skriv {målform[søkersMålform].toLowerCase()}
                 </StyledTag>
             </InfoBoks>
-
             {erLesevisning ? (
                 <StyledList id={fieldsetId}>
                     {skjema.felter.fritekster.verdi.map((fritekst: FeltState<IFritekstFelt>) => (

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/endringstidspunkt/OppdaterEndringstidspunktModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/endringstidspunkt/OppdaterEndringstidspunktModal.tsx
@@ -76,7 +76,6 @@ export const OppdaterEndringstidspunktModal = ({ åpenBehandling, lukkModal }: I
                     onClick={oppdaterEndringstidspunkt}
                     children={'Oppdater'}
                     loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                    disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                 />
                 <Button variant={'tertiary'} key={'Avbryt'} size={'small'} onClick={lukkModal} children={'Avbryt'} />
             </Modal.Footer>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingSkjema.tsx
@@ -88,7 +88,6 @@ export const AnnenVurderingSkjema = ({
                             size="small"
                             variant="secondary"
                             loading={lagrerAnnenVurdering}
-                            disabled={lagrerAnnenVurdering}
                         >
                             Ferdig
                         </Button>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
@@ -22,6 +22,7 @@ interface IProps {
 
 const Container = styled.div`
     margin-top: ${ASpacing16};
+
     &:last-child {
         margin-bottom: ${ASpacing8};
     }
@@ -80,7 +81,6 @@ const GeneriskVilkår = ({ person, vilkårFraConfig, vilkårResultater, generisk
                         }}
                         id={leggTilPeriodeKnappId}
                         loading={vilkårsvurderingApi.oppretterVilkår}
-                        disabled={vilkårsvurderingApi.oppretterVilkår}
                         variant="tertiary"
                         size="medium"
                         icon={<PlusCircleIcon />}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
@@ -211,7 +211,7 @@ export const VilkårSkjema = <T extends IVilkårSkjemaContext>({
                                 });
                             }}
                             size="medium"
-                            variant="primary"
+                            variant="secondary"
                             loading={lagrerVilkår}
                         >
                             Ferdig

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
@@ -213,7 +213,6 @@ export const VilkårSkjema = <T extends IVilkårSkjemaContext>({
                             size="medium"
                             variant="primary"
                             loading={lagrerVilkår}
-                            disabled={lagrerVilkår}
                         >
                             Ferdig
                         </Button>
@@ -239,7 +238,6 @@ export const VilkårSkjema = <T extends IVilkårSkjemaContext>({
                         }
                         id={vilkårFeilmeldingId(lagretVilkårResultat)}
                         loading={sletterVilkår}
-                        disabled={sletterVilkår}
                         size={'medium'}
                         variant={'tertiary'}
                         icon={<TrashIcon />}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
@@ -211,7 +211,7 @@ export const VilkårSkjema = <T extends IVilkårSkjemaContext>({
                                 });
                             }}
                             size="medium"
-                            variant="secondary"
+                            variant="primary"
                             loading={lagrerVilkår}
                             disabled={lagrerVilkår}
                         >

--- a/src/frontend/sider/Oppgavebenk/FilterSkjema.tsx
+++ b/src/frontend/sider/Oppgavebenk/FilterSkjema.tsx
@@ -95,7 +95,6 @@ const FilterSkjema = () => {
                             if (validerSkjema()) hentOppgaver();
                         }}
                         loading={oppgaver.status === RessursStatus.HENTER}
-                        disabled={oppgaver.status === RessursStatus.HENTER}
                         children={'Hent oppgaver'}
                     />
                     <Button


### PR DESCRIPTION
### 📮 Favro: NAV-26852

### 💰 Hva skal gjøres, og hvorfor?
Oppdaterer knappe-varianter til å passe med Aksel retningslinjer.
Fjerner bruker av knappe-variant endring basert på skjema-validering, det burde bare være skjema-validering i stedet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Flere steder ser det ut som vi har en hovedskjema og kan åpne nedtrekksdel som har et mindre skjema innenfor. Disse har blitt vurdert til å være primærknapper i underskjema.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots