### PR TITLE
Legg til nasjonal rett differanse beregning som kompetent land, og fjern fra aktivetet #4183

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRad.tsx
@@ -62,6 +62,8 @@ const KompetanseTabellRad = ({ kompetanse, åpenBehandling, visFeilmeldinger }: 
                 return 'Primærland';
             case KompetanseResultat.NORGE_ER_SEKUNDÆRLAND:
                 return 'Sekundærland';
+            case KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING:
+                return 'Sekundærland';
             case KompetanseResultat.TO_PRIMÆRLAND:
                 return 'To primærland';
             default:

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -242,6 +242,12 @@ const KompetanseTabellRadEndre = ({
                     >
                         {kompetanseResultater[KompetanseResultat.NORGE_ER_SEKUNDÆRLAND]}
                     </option>
+                    <option
+                        key={KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING}
+                        value={KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING}
+                    >
+                        {kompetanseResultater[KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING]}
+                    </option>
                     <option key={KompetanseResultat.TO_PRIMÆRLAND} value={KompetanseResultat.TO_PRIMÆRLAND}>
                         {kompetanseResultater[KompetanseResultat.TO_PRIMÆRLAND]}
                     </option>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -55,7 +55,9 @@ const finnUtbetalingsBeløpStatusMap = (
         const barnIdent = upd.person.personIdent;
         const kompetanserForBarn = finnKompetanserForBarn(kompetanser, barnIdent);
         const norgeErSekundærland = kompetanserForBarn.some(
-            kompetanseForBarn => kompetanseForBarn.resultat === KompetanseResultat.NORGE_ER_SEKUNDÆRLAND
+            kompetanseForBarn =>
+                kompetanseForBarn.resultat === KompetanseResultat.NORGE_ER_SEKUNDÆRLAND ||
+                kompetanseForBarn.resultat === KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING
         );
         let skalViseUtbetalingsBeløp = !norgeErSekundærland;
 

--- a/src/frontend/typer/eøsPerioder.ts
+++ b/src/frontend/typer/eøsPerioder.ts
@@ -17,7 +17,6 @@ export enum SøkersAktivitet {
     MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET',
     MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET',
     MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET',
-    NASJONAL_RETT_DIFFERANSEBEREGNING = 'NASJONAL_RETT_DIFFERANSEBEREGNING',
     INAKTIV = 'INAKTIV',
 }
 
@@ -35,7 +34,6 @@ export const kompetanseAktiviteter: Record<KompetanseAktivitet, string> = {
     MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET: 'Mottar utbetaling fra NAV under opphold i utlandet',
     MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET: 'Mottar uføretrygd fra Norge under opphold i utlandet',
     MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET: 'Mottar pensjon fra Norge under opphold i utlandet',
-    NASJONAL_RETT_DIFFERANSEBEREGNING: 'Nasjonal rett-differanseberegning',
     INAKTIV: 'Inaktiv',
 
     I_ARBEID: 'I arbeid',
@@ -52,19 +50,20 @@ export enum AnnenForelderAktivitet {
     INAKTIV = 'INAKTIV',
     IKKE_AKTUELT = 'IKKE_AKTUELT',
     UTSENDT_ARBEIDSTAKER = 'UTSENDT_ARBEIDSTAKER',
-    NASJONAL_RETT_DIFFERANSEBEREGNING = 'NASJONAL_RETT_DIFFERANSEBEREGNING',
 }
 
 export enum KompetanseResultat {
     NORGE_ER_PRIMÆRLAND = 'NORGE_ER_PRIMÆRLAND',
     NORGE_ER_SEKUNDÆRLAND = 'NORGE_ER_SEKUNDÆRLAND',
     TO_PRIMÆRLAND = 'TO_PRIMÆRLAND',
+    NASJONAL_RETT_DIFFERANSEBEREGNING = 'NASJONAL_RETT_DIFFERANSEBEREGNING',
 }
 
 export const kompetanseResultater: Record<KompetanseResultat, string> = {
     NORGE_ER_PRIMÆRLAND: 'Norge er Primærland',
     NORGE_ER_SEKUNDÆRLAND: 'Norge er Sekundærland',
     TO_PRIMÆRLAND: 'To primærland',
+    NASJONAL_RETT_DIFFERANSEBEREGNING: 'Nasjonal rett-differanseberegning',
 };
 
 export enum EøsPeriodeStatus {


### PR DESCRIPTION
### 📮 Favro: NAV-26831

### 💰 Hva skal gjøres, og hvorfor?

Favrokortet var tidligere feil, og påsto at nasjonal rett differanse beregning skulle legges til som en annen forelders aktivitet i kompetanse. Dette er feil, og i henhold til bestillingen fra team nasjonalt fagansvarlige skal den legges til som kompetent land.

Den har derfor blitt lagt inn som kompetanseresultat her, og den skal oppføre seg helt som sekundærland valget.
Eneste forskjellen er at man får annerledes begrunnelser i vedtak siden.
<img width="1198" height="750" alt="Screenshot 2025-12-04 at 22 38 46" src="https://github.com/user-attachments/assets/03fcf6dc-7b36-4c8e-9457-57b49bdb2507" />
