### PR TITLE
NAV-26937: Flytter personlinje-komponenten til Komponenter pakken

### DIFF
--- a/src/frontend/komponenter/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Personlinje/Personlinje.tsx
@@ -3,36 +3,36 @@ import type { PropsWithChildren } from 'react';
 import { BodyShort, Box, CopyButton, HStack } from '@navikt/ds-react';
 import { kjønnType } from '@navikt/familie-typer';
 
-import { PersonIkon } from '../../../komponenter/PersonIkon';
-import { type IPersonInfo } from '../../../typer/person';
-import { hentAlder } from '../../../utils/formatter';
-import { erAdresseBeskyttet } from '../../../utils/validators';
+import { type IPersonInfo } from '../../typer/person';
+import { hentAlder } from '../../utils/formatter';
+import { erAdresseBeskyttet } from '../../utils/validators';
+import { PersonIkon } from '../PersonIkon';
 
-interface IProps {
+interface Props {
     bruker?: IPersonInfo;
 }
 
-const InnholdContainer = ({ children }: PropsWithChildren) => {
+function InnholdContainer({ children }: PropsWithChildren) {
     return (
-        <Box borderWidth="0 0 1 0" borderColor="border-subtle" paddingInline="4" paddingBlock="2">
+        <Box borderWidth={'0 0 1 0'} borderColor={'border-subtle'} paddingInline={'4'} paddingBlock={'2'}>
             {children}
         </Box>
     );
-};
+}
 
-const Divider = () => {
+function Divider() {
     return <div>|</div>;
-};
+}
 
-const Personlinje = ({ bruker }: IProps) => {
+export function Personlinje({ bruker }: Props) {
     if (bruker === undefined) {
         return (
             <InnholdContainer>
-                <HStack align="center" gap="3 4">
-                    <HStack align="center" gap="3 4">
+                <HStack align={'center'} gap={'3 4'}>
+                    <HStack align={'center'} gap={'3 4'}>
                         <PersonIkon kjønn={kjønnType.UKJENT} erBarn={false} />
                         <Divider />
-                        <HStack align="center" gap="1">
+                        <HStack align={'center'} gap={'1'}>
                             Personen er ikke identifisert
                         </HStack>
                     </HStack>
@@ -40,10 +40,11 @@ const Personlinje = ({ bruker }: IProps) => {
             </InnholdContainer>
         );
     }
+
     return (
         <InnholdContainer>
-            <HStack align="center" gap="3 4">
-                <HStack align="center" gap="3 4">
+            <HStack align={'center'} gap={'3 4'}>
+                <HStack align={'center'} gap={'3 4'}>
                     <PersonIkon
                         kjønn={bruker.kjønn}
                         erBarn={hentAlder(bruker.fødselsdato) < 18}
@@ -51,14 +52,14 @@ const Personlinje = ({ bruker }: IProps) => {
                         harTilgang={bruker.harTilgang}
                         erEgenAnsatt={bruker.erEgenAnsatt}
                     />
-                    <HStack align="center" gap="3 4">
-                        <BodyShort as="span" weight="semibold">
+                    <HStack align={'center'} gap={'3 4'}>
+                        <BodyShort as={'span'} weight={'semibold'}>
                             {bruker.navn} ({hentAlder(bruker.fødselsdato ?? '')} år)
                         </BodyShort>
                         <Divider />
-                        <HStack align="center" gap="1">
+                        <HStack align={'center'} gap={'1'}>
                             {bruker.personIdent}
-                            <CopyButton copyText={bruker.personIdent.replace(' ', '')} size="small" />
+                            <CopyButton copyText={bruker.personIdent.replace(' ', '')} size={'small'} />
                         </HStack>
                     </HStack>
                 </HStack>
@@ -67,6 +68,4 @@ const Personlinje = ({ bruker }: IProps) => {
             </HStack>
         </InnholdContainer>
     );
-};
-
-export default Personlinje;
+}

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -11,12 +11,12 @@ import { DokumentutsendingProvider } from './Dokumentutsending/Dokumentutsending
 import { FagsakProvider } from './FagsakContext';
 import JournalpostListe from './journalposter/JournalpostListe';
 import { ManuelleBrevmottakerePåFagsakProvider } from './ManuelleBrevmottakerePåFagsakContext';
-import Personlinje from './Personlinje/Personlinje';
 import { Saksoversikt } from './Saksoversikt/Saksoversikt';
 import { useFagsakId } from '../../hooks/useFagsakId';
 import { useHentFagsak } from '../../hooks/useHentFagsak';
 import { useHentPerson } from '../../hooks/useHentPerson';
 import { useScrollTilAnker } from '../../hooks/useScrollTilAnker';
+import { Personlinje } from '../../komponenter/Personlinje/Personlinje';
 import { Fagsaklinje } from '../../komponenter/Saklinje/Fagsaklinje';
 
 const Innhold = styled.div`

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.tsx
@@ -6,8 +6,8 @@ import { Journalstatus, RessursStatus } from '@navikt/familie-typer';
 import { DokumentPanel } from './Dokument/DokumentPanel';
 import { JournalpostSkjema } from './JournalpostSkjema';
 import { ManuellJournalføringProvider, useManuellJournalføringContext } from './ManuellJournalføringContext';
+import { Personlinje } from '../../komponenter/Personlinje/Personlinje';
 import { fagsakHeaderHøydeRem } from '../../typer/styling';
-import Personlinje from '../Fagsak/Personlinje/Personlinje';
 
 const ToKolonnerDiv = styled.div<{ $viserAlert?: boolean }>`
     display: grid;


### PR DESCRIPTION
### 📮 Favro
NAV-26937

### 💰 Hva skal gjøres, og hvorfor?
I forbindelse med fjerning av toggle flytter jeg "Saklinje" komponenten til "Komponenter" pakken (se [PR](https://github.com/navikt/familie-ks-sak-frontend/pull/1508)). Gjør det samme for "Personlinje" komponenten i denne PRen. Refaktorerte også koden litt.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Kun refaktorering/flytting av eksisterende kode. 

### 👀 Screen shots
Ingen visuelle endringer. 