### PR TITLE
NAV-26954: Flytter UtdatertVersjonModal ut i egen komponent og tar i bruk react-query

### DIFF
--- a/src/frontend/Container.tsx
+++ b/src/frontend/Container.tsx
@@ -7,6 +7,7 @@ import AppInfoModal from './komponenter/Modal/AppInfoModal';
 import OpprettFagsakModal from './komponenter/Modal/Fagsak/OpprettFagsakModal';
 import { FeilmeldingModal } from './komponenter/Modal/FeilmeldingModal';
 import UgyldigSesjon from './komponenter/Modal/SesjonUtløpt';
+import { UtdatertAppVersjonModal } from './komponenter/Modal/UtdatertAppVersjonModal/UtdatertAppVersjonModal';
 import { ForhåndsvisOpprettingAvPdfModal } from './komponenter/PdfVisningModal/ForhåndsvisOpprettingAvPdfModal';
 import SystemetLaster from './komponenter/SystemetLaster/SystemetLaster';
 import { TidslinjeProvider } from './komponenter/Tidslinje/TidslinjeContext';
@@ -44,6 +45,7 @@ const Container = () => {
                         <Toasts />
 
                         <Main $systemetLaster={systemetLaster()}>
+                            <UtdatertAppVersjonModal />
                             <OpprettFagsakModal />
                             <FeilmeldingModal />
                             <ForhåndsvisOpprettingAvPdfModal />

--- a/src/frontend/api/hentAppVersjon.ts
+++ b/src/frontend/api/hentAppVersjon.ts
@@ -1,0 +1,11 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import { RessursResolver } from '../utils/ressursResolver';
+
+export async function hentAppVersjon(request: FamilieRequest) {
+    const ressurs = await request<void, string>({
+        url: '/version',
+        method: 'GET',
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -25,8 +25,6 @@ import { alleTogglerAv, ToggleNavn } from '../typer/toggles';
 import { gruppeIdTilRolle, gruppeIdTilSuperbrukerRolle } from '../utils/behandling';
 import { tilFeilside } from '../utils/commons';
 
-const FEM_MINUTTER = 300000;
-
 export type FamilieAxiosRequestConfig<D> = AxiosRequestConfig & {
     data?: D;
     påvirkerSystemLaster?: boolean;
@@ -76,66 +74,10 @@ const AppProvider = (props: PropsWithChildren) => {
     const { request, systemetLaster } = useHttp();
 
     const [toggles, settToggles] = useState<IToggles>(alleTogglerAv());
-    const [appVersjon, settAppVersjon] = useState('');
 
     const [appInfoModal, settAppInfoModal] = useState<IModal>(initalState);
     const [toasts, settToasts] = useState<{ [toastId: string]: IToast }>({});
     const [erTogglesHentet, settErTogglesHentet] = useState(false);
-
-    const verifiserVersjon = () => {
-        request<void, string>({
-            url: '/version',
-            method: 'GET',
-        }).then((versjon: Ressurs<string>) => {
-            if (versjon.status === RessursStatus.SUKSESS) {
-                if (appVersjon !== '' && appVersjon !== versjon.data) {
-                    settAppInfoModal({
-                        tittel: 'Løsningen er utdatert',
-                        innhold: () => {
-                            return (
-                                <div className={'utdatert-losning'}>
-                                    <Alert variant={'info'} inline>
-                                        <BodyShort>
-                                            Det finnes en oppdatert versjon av løsningen. Det anbefales at du oppdaterer
-                                            med en gang.
-                                        </BodyShort>
-                                    </Alert>
-                                </div>
-                            );
-                        },
-                        visModal: true,
-                        onClose: () => lukkModal(),
-                        actions: [
-                            <Button
-                                key={'oppdater'}
-                                variant={'primary'}
-                                size={'small'}
-                                onClick={() => {
-                                    window.location.reload();
-                                }}
-                                children={'Ok, oppdater'}
-                            />,
-                            <Button
-                                key={'avbryt'}
-                                size={'small'}
-                                variant={'tertiary'}
-                                onClick={() => lukkModal()}
-                                children={'Avbryt'}
-                            />,
-                        ],
-                    });
-                }
-
-                settAppVersjon(versjon.data);
-            }
-        });
-
-        setTimeout(() => {
-            verifiserVersjon();
-        }, FEM_MINUTTER);
-    };
-
-    useEffect(() => verifiserVersjon(), []);
 
     useEffect(() => {
         request<string[], IToggles>({

--- a/src/frontend/hooks/useHentAppVersjon.ts
+++ b/src/frontend/hooks/useHentAppVersjon.ts
@@ -1,0 +1,26 @@
+import { type DefaultError, useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { hentAppVersjon } from '../api/hentAppVersjon';
+
+const FEM_MINUTTER = 300_000;
+
+export const HentVersjonQueryKeyFactory = {
+    versjon: () => ['versjon'],
+};
+
+type Options = Omit<UseQueryOptions<string, DefaultError, string>, 'queryKey' | 'queryFn' | 'gcTime' | 'staleTime'>;
+
+export function useHentAppVersjon(options?: Options) {
+    const { request } = useHttp();
+    return useQuery({
+        queryKey: HentVersjonQueryKeyFactory.versjon(),
+        queryFn: () => hentAppVersjon(request),
+        gcTime: 0,
+        staleTime: 0,
+        refetchIntervalInBackground: true,
+        refetchInterval: FEM_MINUTTER,
+        ...options,
+    });
+}

--- a/src/frontend/komponenter/Modal/UtdatertAppVersjonModal/UtdatertAppVersjonModal.tsx
+++ b/src/frontend/komponenter/Modal/UtdatertAppVersjonModal/UtdatertAppVersjonModal.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+import { useNavigate } from 'react-router';
+
+import { BodyLong, Button, Modal } from '@navikt/ds-react';
+
+import { useHentAppVersjon } from '../../../hooks/useHentAppVersjon';
+
+export function UtdatertAppVersjonModal() {
+    const navigate = useNavigate();
+
+    const [visModal, settVisModal] = useState(false);
+    const [forrigeVersjon, settForrigeVersjon] = useState<string | undefined>(undefined);
+
+    const { data: versjon } = useHentAppVersjon();
+
+    if (versjon !== undefined && versjon !== forrigeVersjon) {
+        if (forrigeVersjon !== undefined) {
+            settVisModal(true);
+        }
+        settForrigeVersjon(versjon);
+    }
+
+    function refreshCurrentRoute() {
+        navigate(0);
+    }
+
+    return (
+        <Modal
+            open={visModal}
+            portal={true}
+            header={{ heading: 'Løsningen er utdatert' }}
+            onClose={() => settVisModal(false)}
+            width={'35rem'}
+        >
+            <Modal.Body>
+                <BodyLong>
+                    Det finnes en oppdatert versjon av løsningen. Det anbefales at du oppdaterer med en gang.
+                </BodyLong>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant={'primary'} onClick={refreshCurrentRoute}>
+                    Oppdater
+                </Button>
+                <Button variant={'tertiary'} onClick={() => settVisModal(false)}>
+                    Lukk
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}


### PR DESCRIPTION
### 📮 Favro
NAV-26954

### 💰 Hva skal gjøres, og hvorfor?
Flytter ut modal for utdatert versjon i en egen komponent og tar i bruk react-query for å hente versjon fra backend. Ved å flytte det ut fra AppContext vil ikke alle testene som tar i bruk AppContext trenge å gjøre /GET request på versionen. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Syns ikke det var verdt det for denne komponenten. 

### 👀 Screen shots
<img width="527" height="250" alt="image" src="https://github.com/user-attachments/assets/5b371685-e775-4f0b-92fb-619ea8b3c0c4" />
