### PR TITLE
NAV-26885: Ikke tilbakestill erAnnenForelderOmfattetAvNorskLovgivning ved oppdatering av kompetanse

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/useKompetansePeriodeSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/useKompetansePeriodeSkjema.ts
@@ -119,6 +119,7 @@ const useKompetansePeriodeSkjema = ({ barnIKompetanse, kompetanse }: IProps) => 
                         annenForeldersAktivitetsland: skjema.felter.annenForeldersAktivitetsland.verdi,
                         barnetsBostedsland: skjema.felter.barnetsBostedsland.verdi,
                         resultat: skjema.felter.resultat.verdi,
+                        erAnnenForelderOmfattetAvNorskLovgivning: kompetanse.erAnnenForelderOmfattetAvNorskLovgivning,
                     },
                     url: `/familie-ks-sak/api/behandlinger/${behandlingId}/kompetanse`,
                 },

--- a/src/frontend/typer/eøsPerioder.ts
+++ b/src/frontend/typer/eøsPerioder.ts
@@ -90,7 +90,7 @@ export interface IRestKompetanse extends IRestEøsPeriode {
     annenForeldersAktivitetsland?: string;
     barnetsBostedsland?: string;
     resultat?: KompetanseResultat;
-    erAnnenForelderOmfattetAvNorskLovgivning?: boolean;
+    erAnnenForelderOmfattetAvNorskLovgivning: boolean;
 }
 
 export interface IKompetanse extends IEøsPeriodeStatus {


### PR DESCRIPTION
### 📮 Favro: [NAV-26885](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-26885)

### 💰 Hva skal gjøres, og hvorfor?
Ved oppdatering av kompetanse sender vi ikke med informasjon om `erAnnenForelderOmfattetAvNorskLovgivning` noe som fører til at feltet tilbakestilles til `false`. Da blir feil kompetanse-skjema vist til saksbehandler. 

Sørger for at vi sender med verdier for `erAnnenForelderOmfattetAvNorskLovgivning` ved oppdatering slik at dette ikke skjer.
