### PR TITLE
NAV-26969: Øker margin på skjemasteg slik at får mer plass på bunnen

### DIFF
--- a/src/frontend/komponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Skjemasteg/Skjemasteg.tsx
@@ -80,29 +80,31 @@ const Skjemasteg = ({
     }
 
     return (
-        <VStack id={'skjemasteg'} paddingInline={'space-32'} paddingBlock={'space-24'} gap={'space-16'}>
-            <BehandlingPåVentAlert />
-            <MidlertidigEnhetAlert />
-            <Box position={'relative'} marginBlock={'space-8'} className={className} maxWidth={maxWidthStyle}>
-                <Heading size={'large'} level={'1'} spacing={true}>
-                    {tittel}
-                </Heading>
-                {children}
-                {feilmelding !== '' && <StyledErrorMessage>{feilmelding}</StyledErrorMessage>}
-                <Navigering>
-                    {nesteOnClick && skalViseNesteKnapp && (!vurderErLesevisning() || kanGåVidereILesevisning) && (
-                        <Button variant={'primary'} onClick={onNesteClicked} loading={senderInn}>
-                            {nesteKnappTittel}
-                        </Button>
-                    )}
-                    {forrigeOnClick && skalViseForrigeKnapp && (
-                        <Button variant={'secondary'} onClick={onForrigeClicked}>
-                            {forrigeKnappTittel}
-                        </Button>
-                    )}
-                </Navigering>
-            </Box>
-        </VStack>
+        <Box marginBlock={'space-0 space-128'}>
+            <VStack id={'skjemasteg'} paddingInline={'space-32'} paddingBlock={'space-24'} gap={'space-16'}>
+                <BehandlingPåVentAlert />
+                <MidlertidigEnhetAlert />
+                <Box position={'relative'} marginBlock={'space-8'} className={className} maxWidth={maxWidthStyle}>
+                    <Heading size={'large'} level={'1'} spacing={true}>
+                        {tittel}
+                    </Heading>
+                    {children}
+                    {feilmelding !== '' && <StyledErrorMessage>{feilmelding}</StyledErrorMessage>}
+                    <Navigering>
+                        {nesteOnClick && skalViseNesteKnapp && (!vurderErLesevisning() || kanGåVidereILesevisning) && (
+                            <Button variant={'primary'} onClick={onNesteClicked} loading={senderInn}>
+                                {nesteKnappTittel}
+                            </Button>
+                        )}
+                        {forrigeOnClick && skalViseForrigeKnapp && (
+                            <Button variant={'secondary'} onClick={onForrigeClicked}>
+                                {forrigeKnappTittel}
+                            </Button>
+                        )}
+                    </Navigering>
+                </Box>
+            </VStack>
+        </Box>
     );
 };
 


### PR DESCRIPTION
### 📮 Favro
NAV-26969

### 💰 Hva skal gjøres, og hvorfor?
Øker margin på `<Skjemasteg />` slik at får mer plass på bunnen. Da vil man ikke trenge å skrolle mer ned hvis man åpner en `<DatePicker />` / `<MonthPicker />` som befinner seg langt nede på skjermen i steget.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
<img width="964" height="466" alt="image" src="https://github.com/user-attachments/assets/7e17e3e2-6688-45e0-877d-b427a3612dde" />

<img width="964" height="481" alt="image" src="https://github.com/user-attachments/assets/313cdc2e-ea4f-41ff-9e5b-5134bb5df659" />
