### PR TITLE
Bare vis varsel hvis hverken søker eller annen forelder har aktivitetsland Norge

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -92,7 +92,9 @@ const KompetanseTabellRadEndre = ({
         skjema.felter.resultat?.verdi === KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING &&
         skjema.felter.barnetsBostedsland.verdi === 'NO' &&
         skjema.felter.søkersAktivitetsland.verdi != null &&
+        skjema.felter.søkersAktivitetsland.verdi != 'NO' &&
         skjema.felter.annenForeldersAktivitetsland.verdi != null &&
+        skjema.felter.annenForeldersAktivitetsland.verdi != 'NO' &&
         skjema.felter.søkersAktivitetsland.verdi !== skjema.felter.annenForeldersAktivitetsland.verdi;
 
     return (


### PR DESCRIPTION
### 📮 Favro: NAV-26982

### 💰 Hva skal gjøres, og hvorfor?
Enda et forsøk på å få #1521 riktig
Varsel skal kun vises dersom hverken søker eller annen forelder har Norge som aktivitetsland