### PR TITLE
NAV-26302: Refaktorer styled-components til aksel og module.css

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.module.css
@@ -1,0 +1,3 @@
+.regularHeading {
+    font-weight: var(--a-font-weight-regular);
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
@@ -1,5 +1,3 @@
-import styled from 'styled-components';
-
 import {
     CalendarIcon,
     FlowerPetalFallingIcon,
@@ -8,23 +6,16 @@ import {
     HouseIcon,
     PassportIcon,
 } from '@navikt/aksel-icons';
-import { Alert, Detail, Heading } from '@navikt/ds-react';
-import { AFontWeightRegular, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
+import { Alert, Box, Detail, Heading } from '@navikt/ds-react';
+import { ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 
+import styles from './Registeropplysninger.module.css';
 import RegisteropplysningerTabell from './RegisteropplysningerTabell';
 import { useAppContext } from '../../../../../../context/AppContext';
 import type { IRestRegisterhistorikk } from '../../../../../../typer/person';
 import { Registeropplysning } from '../../../../../../typer/registeropplysning';
 import { ToggleNavn } from '../../../../../../typer/toggles';
 import { Datoformat, isoStringTilFormatertString } from '../../../../../../utils/dato';
-
-const Container = styled.div`
-    width: 32rem;
-`;
-
-const SemiBoldHeading = styled(Heading)`
-    font-weight: ${AFontWeightRegular};
-`;
 
 interface IRegisteropplysningerProps {
     opplysninger: IRestRegisterhistorikk;
@@ -39,15 +30,15 @@ const Registeropplysninger = ({ opplysninger, fødselsdato }: IRegisteropplysnin
 
     return (
         <>
-            <SemiBoldHeading level={'3'} size="medium">
+            <Heading level={'3'} className={styles.regularHeading} size="medium">
                 Registeropplysninger
-            </SemiBoldHeading>
+            </Heading>
             {manglerRegisteropplysninger ? (
                 <Alert variant="info" style={{ marginTop: ASpacing4 }}>
                     Det ble ikke hentet inn registeropplysninger på denne behandlingen.
                 </Alert>
             ) : (
-                <Container>
+                <Box width={'32rem'}>
                     <Detail
                         textColor="subtle"
                         style={{ marginBottom: ASpacing4 }}
@@ -105,7 +96,7 @@ const Registeropplysninger = ({ opplysninger, fødselsdato }: IRegisteropplysnin
                             historikk={opplysninger.oppholdsadresse}
                         />
                     )}
-                </Container>
+                </Box>
             )}
         </>
     );

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.module.css
@@ -1,0 +1,17 @@
+.table {
+    margin-left: var(--a-spacing-4);
+}
+
+.opplysningsIkon {
+    padding-top: var(--a-spacing-2);
+}
+
+.headerCell {
+    &:nth-of-type(1) {
+        width: 15rem;
+    }
+
+    &:nth-of-type(2) {
+        width: 12rem;
+    }
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.tsx
@@ -2,11 +2,11 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { differenceInMilliseconds } from 'date-fns';
-import styled from 'styled-components';
 
 import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
-import { Button, Table } from '@navikt/ds-react';
+import { Button, HStack, Table } from '@navikt/ds-react';
 
+import styles from './RegisteropplysningerTabell.module.css';
 import type { IRestRegisteropplysning } from '../../../../../../typer/person';
 import { Registeropplysning, registeropplysning } from '../../../../../../typer/registeropplysning';
 import {
@@ -16,35 +16,6 @@ import {
     isoStringTilFormatertString,
     tidenesMorgen,
 } from '../../../../../../utils/dato';
-
-const Container = styled.div`
-    display: flex;
-    margin-top: 1rem;
-    justify-content: space-between;
-    width: 100%;
-`;
-
-const StyledHeaderCell = styled(Table.HeaderCell)`
-    &:nth-of-type(1) {
-        width: 15rem;
-    }
-    &:nth-of-type(2) {
-        width: 12rem;
-    }
-`;
-
-const StyledTable = styled(Table)`
-    margin-left: 1rem;
-`;
-
-const OpplysningsIkon = styled.div`
-    padding-top: 0.5rem;
-`;
-
-const HøyrejustertKnapperad = styled.div`
-    display: flex;
-    flex-direction: row-reverse;
-`;
 
 interface IRegisteropplysningerTabellProps {
     opplysningstype: Registeropplysning;
@@ -86,16 +57,23 @@ const RegisteropplysningerTabell = ({ opplysningstype, ikon, historikk }: IRegis
 
     return (
         <>
-            <Container>
-                <OpplysningsIkon children={ikon} />
-                <StyledTable
+            <HStack wrap={false} marginBlock={'space-16 space-0'} justify={'space-between'} width={'100%'}>
+                <div className={styles.opplysningsIkon} children={ikon} />
+                <Table
+                    className={styles.table}
                     size={'small'}
                     aria-label={`Registeropplysninger for ${registeropplysning[opplysningstype]}`}
                 >
                     <Table.Header>
                         <Table.Row>
-                            <StyledHeaderCell children={registeropplysning[opplysningstype]} />
-                            <StyledHeaderCell children={hentDatoHeader(opplysningstype)} />
+                            <Table.HeaderCell
+                                className={styles.headerCell}
+                                children={registeropplysning[opplysningstype]}
+                            />
+                            <Table.HeaderCell
+                                className={styles.headerCell}
+                                children={hentDatoHeader(opplysningstype)}
+                            />
                         </Table.Row>
                     </Table.Header>
                     <Table.Body>
@@ -126,10 +104,10 @@ const RegisteropplysningerTabell = ({ opplysningstype, ikon, historikk }: IRegis
                                 </Table.Row>
                             ))}
                     </Table.Body>
-                </StyledTable>
-            </Container>
+                </Table>
+            </HStack>
             {skalVæreEkspanderbar && (
-                <HøyrejustertKnapperad>
+                <HStack justify={'end'}>
                     <Button
                         variant="tertiary"
                         size="small"
@@ -139,7 +117,7 @@ const RegisteropplysningerTabell = ({ opplysningstype, ikon, historikk }: IRegis
                     >
                         {erEkspandert ? 'Skjul' : `Vis ${historikk.length - GRENSE_FOR_EKSPANDERBAR_HISTORIKK} flere`}
                     </Button>
-                </HøyrejustertKnapperad>
+                </HStack>
             )}
         </>
     );

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Vilkårsvurdering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Vilkårsvurdering.tsx
@@ -2,11 +2,9 @@ import { useState } from 'react';
 
 import classNames from 'classnames';
 import { useNavigate } from 'react-router';
-import styled from 'styled-components';
 
 import { ArrowsSquarepathIcon } from '@navikt/aksel-icons';
-import { Alert, BodyShort, Button, Detail, ErrorMessage, ErrorSummary } from '@navikt/ds-react';
-import { ASpacing2 } from '@navikt/ds-tokens/dist/tokens';
+import { Alert, BodyShort, Button, Detail, ErrorMessage, ErrorSummary, HStack, List } from '@navikt/ds-react';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
@@ -22,22 +20,6 @@ import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/da
 import { erProd } from '../../../../../utils/miljø';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
 import { useBehandlingContext } from '../../context/BehandlingContext';
-
-const UregistrerteBarnListe = styled.ol`
-    margin: ${ASpacing2} 0;
-`;
-
-const HentetLabelOgKnappDiv = styled.div`
-    display: flex;
-    justify-content: left;
-    align-items: center;
-
-    .knapp__spinner {
-        margin: 0 !important;
-    }
-
-    margin-bottom: ${ASpacing2};
-`;
 
 interface IProps {
     åpenBehandling: IBehandling;
@@ -94,7 +76,7 @@ const Vilkårsvurdering = ({ åpenBehandling }: IProps) => {
             steg={BehandlingSteg.VILKÅRSVURDERING}
         >
             <>
-                <HentetLabelOgKnappDiv>
+                <HStack align={'center'} wrap={false} marginBlock={'space-0 space-8'}>
                     <Detail
                         textColor="subtle"
                         children={
@@ -124,7 +106,7 @@ const Vilkårsvurdering = ({ åpenBehandling }: IProps) => {
                             icon={<ArrowsSquarepathIcon fontSize={'1.5rem'} focusable="false" />}
                         />
                     )}
-                </HentetLabelOgKnappDiv>
+                </HStack>
                 {hentOpplysningerRessurs.status === RessursStatus.FEILET && (
                     <ErrorMessage>{hentOpplysningerRessurs.frontendFeilmelding}</ErrorMessage>
                 )}
@@ -136,18 +118,18 @@ const Vilkårsvurdering = ({ åpenBehandling }: IProps) => {
             {uregistrerteBarn.length > 0 && (
                 <Alert variant="info">
                     <BodyShort>Du har registrert følgende barn som ikke er registrert i Folkeregisteret:</BodyShort>
-                    <UregistrerteBarnListe>
+                    <List as={'ol'}>
                         {uregistrerteBarn.map(uregistrertBarn => (
-                            <li key={`${uregistrertBarn.navn}_${uregistrertBarn.fødselsdato}`}>
+                            <List.Item key={`${uregistrertBarn.navn}_${uregistrertBarn.fødselsdato}`}>
                                 <BodyShort>
                                     {`${uregistrertBarn.navn} - ${isoStringTilFormatertString({
                                         isoString: uregistrertBarn.fødselsdato,
                                         tilFormat: Datoformat.DATO,
                                     })}`}
                                 </BodyShort>
-                            </li>
+                            </List.Item>
                         ))}
-                    </UregistrerteBarnListe>
+                    </List>
 
                     <BodyShort>Dette vil føre til avslag for barna i listen.</BodyShort>
                 </Alert>


### PR DESCRIPTION
### 📮 Favro:NAV-26302

### 💰 Hva skal gjøres, og hvorfor?
Omskriving bort fra styled-components til å bruke Aksel eller module.css

[Tilsvarende PR i BA](https://github.com/navikt/familie-ba-sak-frontend/pull/4218)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
Visuell endring etter omskriving til Aksel
FØR
<img width="784" height="242" alt="E Du har registrert telgende barn som ikke er registrert i Folkeregisteret" src="https://github.com/user-attachments/assets/df3e8f98-040e-4743-87f1-0aea2eea45ff" />

ETTER
<img width="786" height="276" alt="• Du har registrert følgende barn som ikke er registrert i Folkeregisteret" src="https://github.com/user-attachments/assets/d7bdacee-df26-4041-924d-f59007dfaedb" />
