### PR TITLE
NAV-26563: Bytter til .yarnrc og legger til save-exact

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@navikt:registry=https://npm.pkg.github.com

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+"@navikt:registry" "https://npm.pkg.github.com"
+save-exact true


### PR DESCRIPTION
### 📮 Favro
NAV-26563

### 💰 Hva skal gjøres, og hvorfor?
Går over til `.yarnrc` da vi bruker yarn v1.
Legger til `save-exact true` for å alltid lagre eksakte versjoner når vi legger til pakker via `yarn add <package>` 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Neo

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
Ingen visuelle endringer. 