### PR TITLE
NAV-26957: Støtte for merking av falsk identitet i Personlinje

### DIFF
--- a/src/frontend/komponenter/Personlinje/Personlinje.module.css
+++ b/src/frontend/komponenter/Personlinje/Personlinje.module.css
@@ -1,0 +1,5 @@
+.falskIdentitet {
+    background-color: var(--a-surface-warning-moderate);
+    color: var(--a-text-on-warning);
+    padding: 0 var(--a-spacing-05);
+}

--- a/src/frontend/komponenter/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Personlinje/Personlinje.tsx
@@ -4,9 +4,10 @@ import { BodyShort, Box, CopyButton, HStack } from '@navikt/ds-react';
 import { kjønnType } from '@navikt/familie-typer';
 
 import { type IPersonInfo } from '../../typer/person';
-import { hentAlder } from '../../utils/formatter';
+import { formaterIdent, hentAlder } from '../../utils/formatter';
 import { erAdresseBeskyttet } from '../../utils/validators';
 import { PersonIkon } from '../PersonIkon';
+import styles from './Personlinje.module.css';
 
 interface Props {
     bruker?: IPersonInfo;
@@ -47,7 +48,7 @@ export function Personlinje({ bruker }: Props) {
                 <HStack align={'center'} gap={'3 4'}>
                     <PersonIkon
                         kjønn={bruker.kjønn}
-                        erBarn={hentAlder(bruker.fødselsdato) < 18}
+                        erBarn={hentAlder(bruker.fødselsdato ?? '') < 18}
                         erAdresseBeskyttet={erAdresseBeskyttet(bruker.adressebeskyttelseGradering)}
                         harTilgang={bruker.harTilgang}
                         erEgenAnsatt={bruker.erEgenAnsatt}
@@ -55,10 +56,16 @@ export function Personlinje({ bruker }: Props) {
                     <HStack align={'center'} gap={'3 4'}>
                         <BodyShort as={'span'} weight={'semibold'}>
                             {bruker.navn} ({hentAlder(bruker.fødselsdato ?? '')} år)
+                            {bruker.harFalskIdentitet && (
+                                <BodyShort as={'span'} weight={'semibold'}>
+                                    {' '}
+                                    - <mark className={styles.falskIdentitet}>Falsk identitet</mark>
+                                </BodyShort>
+                            )}
                         </BodyShort>
                         <Divider />
                         <HStack align={'center'} gap={'1'}>
-                            {bruker.personIdent}
+                            {formaterIdent(bruker.personIdent)}
                             <CopyButton copyText={bruker.personIdent.replace(' ', '')} size={'small'} />
                         </HStack>
                     </HStack>

--- a/src/frontend/testutils/testdata/personTestdata.ts
+++ b/src/frontend/testutils/testdata/personTestdata.ts
@@ -17,6 +17,7 @@ export function lagPerson(person: Partial<IPersonInfo> = {}): IPersonInfo {
         dødsfallDato: undefined,
         bostedsadresse: undefined,
         erEgenAnsatt: false,
+        harFalskIdentitet: false,
         ...person,
     };
 }

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -58,6 +58,7 @@ export interface IPersonInfo {
     fagsakId?: number;
     bostedsadresse?: IBostedsadresse;
     erEgenAnsatt?: boolean;
+    harFalskIdentitet: boolean;
 }
 
 export interface IForelderBarnRelasjon {


### PR DESCRIPTION
### 📮 Favro: [NAV-26957](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-26957)

### 💰 Hva skal gjøres, og hvorfor?

Sørger for at vi markerer søker med "Falsk identitet" i `Personlinje` dersom søker har falsk identitet.

Merkingen av fagsaker og behandlinger som inneholder falske identiteter må vi nok gjøre en større jobb med så dette er kun en liten start slik at vi har noe merking i det hele tatt når denne tilhørende backend-endringen rulles ut:
* https://github.com/navikt/familie-ks-sak/pull/1568

Har foreløpig valgt å "merke" personlinja med teksten "Falsk identitet" med varsel-farge som bakgrunn etter inspirasjon fra denne diskusjonen: https://nav-it.slack.com/archives/CK91TN67R/p1763038304159139

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

Jeg har ikke skrevet tester fordi: Kun liten visuell endring.

### 👀 Screen shots
<img width="780" height="175" alt="image" src="https://github.com/user-attachments/assets/8908e169-25ff-4a5b-8023-df399ac10ee1" />
