### PR TITLE
NAV-27342: Opprydning av props for saksoversikt

### DIFF
--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -81,7 +81,7 @@ export function FagsakContainer() {
                                     element={
                                         <>
                                             <Fagsaklinje />
-                                            <Saksoversikt minimalFagsak={fagsak} />
+                                            <Saksoversikt />
                                         </>
                                     }
                                 />

--- a/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
@@ -8,17 +8,8 @@ import type { VisningBehandling } from './visningBehandling';
 import { BehandlingStatus } from '../../../typer/behandling';
 import type { IBehandlingstema } from '../../../typer/behandlingstema';
 import { tilBehandlingstema } from '../../../typer/behandlingstema';
-import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { hentAktivBehandlingPåMinimalFagsak, hentFagsakStatusVisning } from '../../../utils/fagsak';
-
-interface IFagsakLinkPanel {
-    minimalFagsak: IMinimalFagsak;
-}
-
-interface IInnholdstabell {
-    minimalFagsak: IMinimalFagsak;
-    behandling?: VisningBehandling;
-}
+import { useFagsakContext } from '../FagsakContext';
 
 const HeaderTekst = styled(BodyShort)`
     font-size: ${AFontSizeXlarge};
@@ -28,9 +19,10 @@ const BodyTekst = styled(BodyShort)`
     font-size: ${AFontSizeHeadingMedium};
 `;
 
-const Innholdstabell = ({ minimalFagsak }: IInnholdstabell) => {
+function Innholdstabell() {
+    const { fagsak } = useFagsakContext();
     const behandlingstema: IBehandlingstema | undefined =
-        minimalFagsak.løpendeKategori && tilBehandlingstema(minimalFagsak.løpendeKategori);
+        fagsak.løpendeKategori && tilBehandlingstema(fagsak.løpendeKategori);
 
     return (
         <HStack gap="20">
@@ -47,12 +39,13 @@ const Innholdstabell = ({ minimalFagsak }: IInnholdstabell) => {
                     Status
                 </HeaderTekst>
                 <BodyTekst name={'status'} weight="semibold">
-                    {hentFagsakStatusVisning(minimalFagsak)}
+                    {hentFagsakStatusVisning(fagsak)}
                 </BodyTekst>
             </div>
         </HStack>
     );
-};
+}
+
 export const SaksoversiktPanelBredde = `calc(10 * ${ASpacing16})`;
 
 const FagsakPanel = styled(Box)`
@@ -64,31 +57,30 @@ const genererLinkTekst = (behandling: VisningBehandling) => {
     return behandling.status === BehandlingStatus.AVSLUTTET ? 'Gå til gjeldende vedtak' : 'Gå til åpen behandling';
 };
 
-const FagsakLenkepanel = ({ minimalFagsak }: IFagsakLinkPanel) => {
-    const aktivBehandling: VisningBehandling | undefined = hentAktivBehandlingPåMinimalFagsak(minimalFagsak);
+export function FagsakLenkepanel() {
+    const { fagsak } = useFagsakContext();
+    const aktivBehandling: VisningBehandling | undefined = hentAktivBehandlingPåMinimalFagsak(fagsak);
 
     return aktivBehandling ? (
         <Box width={SaksoversiktPanelBredde} marginBlock={'8 0'}>
             <LinkCard>
                 <LinkCard.Title>
                     <LinkCard.Anchor asChild={true}>
-                        <Link as={ReactRouterLink} to={`/fagsak/${minimalFagsak.id}/${aktivBehandling.behandlingId}`}>
+                        <Link as={ReactRouterLink} to={`/fagsak/${fagsak.id}/${aktivBehandling.behandlingId}`}>
                             {genererLinkTekst(aktivBehandling)}
                         </Link>
                     </LinkCard.Anchor>
                 </LinkCard.Title>
                 <LinkCard.Description>
                     <VStack paddingBlock={'4 0'}>
-                        <Innholdstabell minimalFagsak={minimalFagsak} />
+                        <Innholdstabell />
                     </VStack>
                 </LinkCard.Description>
             </LinkCard>
         </Box>
     ) : (
         <FagsakPanel borderColor="border-strong" borderWidth="1" borderRadius="small" padding="8">
-            <Innholdstabell minimalFagsak={minimalFagsak} />
+            <Innholdstabell />
         </FagsakPanel>
     );
-};
-
-export default FagsakLenkepanel;
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -4,13 +4,12 @@ import { Link as ReactRouterLink } from 'react-router';
 import { Alert, Box, Heading, Link, VStack } from '@navikt/ds-react';
 
 import { Behandlinger } from './Behandlinger';
-import FagsakLenkepanel, { SaksoversiktPanelBredde } from './FagsakLenkepanel';
+import { FagsakLenkepanel, SaksoversiktPanelBredde } from './FagsakLenkepanel';
 import Utbetalinger from './Utbetalinger';
 import type { VisningBehandling } from './visningBehandling';
 import type { IBehandling } from '../../../typer/behandling';
 import { BehandlingStatus, erBehandlingHenlagt } from '../../../typer/behandling';
 import { behandlingKategori, BehandlingKategori } from '../../../typer/behandlingstema';
-import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { FagsakStatus } from '../../../typer/fagsak';
 import { Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
 import {
@@ -21,13 +20,12 @@ import {
     periodeOverlapperMedValgtDato,
 } from '../../../utils/dato';
 import { hentAktivBehandlingPåMinimalFagsak } from '../../../utils/fagsak';
+import { useFagsakContext } from '../FagsakContext';
 
-interface IProps {
-    minimalFagsak: IMinimalFagsak;
-}
+export function Saksoversikt() {
+    const { fagsak } = useFagsakContext();
 
-export function Saksoversikt({ minimalFagsak }: IProps) {
-    const iverksatteBehandlinger = minimalFagsak.behandlinger.filter(
+    const iverksatteBehandlinger = fagsak.behandlinger.filter(
         (behandling: VisningBehandling) =>
             behandling.status === BehandlingStatus.AVSLUTTET && !erBehandlingHenlagt(behandling.resultat)
     );
@@ -42,13 +40,13 @@ export function Saksoversikt({ minimalFagsak }: IProps) {
               )[0]
             : undefined;
 
-    const aktivBehandling = hentAktivBehandlingPåMinimalFagsak(minimalFagsak);
+    const aktivBehandling = hentAktivBehandlingPåMinimalFagsak(fagsak);
 
     if (!gjeldendeBehandling) {
         gjeldendeBehandling = aktivBehandling;
     }
 
-    const gjeldendeUtbetalingsperioder = minimalFagsak.gjeldendeUtbetalingsperioder;
+    const gjeldendeUtbetalingsperioder = fagsak.gjeldendeUtbetalingsperioder;
     const utbetalingsperiodeInneværendeMåned = gjeldendeUtbetalingsperioder.find(periode =>
         periodeOverlapperMedValgtDato(periode.periodeFom, periode.periodeTom, new Date())
     );
@@ -60,10 +58,7 @@ export function Saksoversikt({ minimalFagsak }: IProps) {
 
     const lenkeTilBehandlingsresultat = () => {
         return aktivBehandling ? (
-            <Link
-                as={ReactRouterLink}
-                to={`/fagsak/${minimalFagsak.id}/${aktivBehandling.behandlingId}/tilkjent-ytelse`}
-            >
+            <Link as={ReactRouterLink} to={`/fagsak/${fagsak.id}/${aktivBehandling.behandlingId}/tilkjent-ytelse`}>
                 Se detaljer
             </Link>
         ) : null;
@@ -132,8 +127,8 @@ export function Saksoversikt({ minimalFagsak }: IProps) {
                 Saksoversikt
             </Heading>
             <VStack gap="14">
-                <FagsakLenkepanel minimalFagsak={minimalFagsak} />
-                {minimalFagsak.status === FagsakStatus.LØPENDE && (
+                <FagsakLenkepanel />
+                {fagsak.status === FagsakStatus.LØPENDE && (
                     <div>
                         <Heading size={'medium'} level={'2'} spacing>
                             Løpende månedlig utbetaling


### PR DESCRIPTION
### 📮 Favro
NAV-27342

### 💰 Hva skal gjøres, og hvorfor?
Fjerner bruken av Fagsak og Bruker som props og går over til context

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
Ingen visuelle endringer.