### PR TITLE
NAV-27344: Fjerner bruken av Fagsak og Bruker som props i Dokumentutsending og går over til context

### DIFF
--- a/src/frontend/sider/Fagsak/Dokumentutsending/Dokumentutsending.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/Dokumentutsending.tsx
@@ -5,13 +5,9 @@ import { Button, Modal } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useDokumentutsendingContext } from './DokumentutsendingContext';
-import DokumentutsendingSkjema from './DokumentutsendingSkjema';
-import type { IPersonInfo } from '../../../typer/person';
+import { DokumentutsendingSkjema } from './DokumentutsendingSkjema';
 import { fagsakHeaderHøydeRem } from '../../../typer/styling';
-
-interface Props {
-    bruker: IPersonInfo;
-}
+import { useFagsakContext } from '../FagsakContext';
 
 const Container = styled.div`
     display: grid;
@@ -20,10 +16,11 @@ const Container = styled.div`
     height: calc(100vh - ${fagsakHeaderHøydeRem}rem);
 `;
 
-const Dokumentutsending = ({ bruker }: Props) => {
+export function Dokumentutsending() {
+    const { fagsak } = useFagsakContext();
     const navigate = useNavigate();
 
-    const { fagsakId, hentetDokument, settVisInnsendtBrevModal, visInnsendtBrevModal } = useDokumentutsendingContext();
+    const { hentetDokument, settVisInnsendtBrevModal, visInnsendtBrevModal } = useDokumentutsendingContext();
 
     return (
         <Container>
@@ -40,7 +37,7 @@ const Dokumentutsending = ({ bruker }: Props) => {
                             key={'til saksoversikt'}
                             size={'medium'}
                             onClick={() => {
-                                navigate(`/fagsak/${fagsakId}/saksoversikt`);
+                                navigate(`/fagsak/${fagsak.id}/saksoversikt`);
                                 settVisInnsendtBrevModal(false);
                             }}
                             children={'Se saksoversikt'}
@@ -57,7 +54,7 @@ const Dokumentutsending = ({ bruker }: Props) => {
                     </Modal.Footer>
                 </Modal>
             )}
-            <DokumentutsendingSkjema bruker={bruker} />
+            <DokumentutsendingSkjema />
 
             <iframe
                 title={'dokument'}
@@ -67,6 +64,4 @@ const Dokumentutsending = ({ bruker }: Props) => {
             />
         </Container>
     );
-};
-
-export default Dokumentutsending;
+}

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingContext.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingContext.tsx
@@ -15,6 +15,7 @@ import { type IBarnMedOpplysninger, Målform } from '../../../typer/søknad';
 import { Datoformat, isoStringTilFormatertString } from '../../../utils/dato';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
 import { useBrukerContext } from '../BrukerContext';
+import { useFagsakContext } from '../FagsakContext';
 import { useManuelleBrevmottakerePåFagsakContext } from '../ManuelleBrevmottakerePåFagsakContext';
 
 export enum DokumentÅrsak {
@@ -57,10 +58,6 @@ const hentBarnMedOpplysningerFraBruker = () => {
     );
 };
 
-interface Props extends PropsWithChildren {
-    fagsakId: number;
-}
-
 interface DokumentutsendingSkjema {
     årsak: DokumentÅrsak | undefined;
     målform: Målform | undefined;
@@ -69,7 +66,6 @@ interface DokumentutsendingSkjema {
 }
 
 interface DokumentutsendingContextValue {
-    fagsakId: number;
     hentForhåndsvisningPåFagsak: () => void;
     hentBarnMedOpplysningerFraBruker: () => IBarnMedOpplysninger[];
     hentSkjemaFeilmelding: () => string | undefined;
@@ -87,7 +83,8 @@ interface DokumentutsendingContextValue {
 
 const DokumentutsendingContext = createContext<DokumentutsendingContextValue | undefined>(undefined);
 
-export const DokumentutsendingProvider = ({ fagsakId, children }: Props) => {
+export function DokumentutsendingProvider({ children }: PropsWithChildren) {
+    const { fagsak } = useFagsakContext();
     const { bruker } = useBrukerContext();
     const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } =
         useManuelleBrevmottakerePåFagsakContext();
@@ -221,7 +218,7 @@ export const DokumentutsendingProvider = ({ fagsakId, children }: Props) => {
         hentForhåndsvisning<IManueltBrevRequestPåFagsak>({
             method: 'POST',
             data: skjemaData,
-            url: `/familie-ks-sak/api/brev/fagsak/${fagsakId}/forhaandsvis-brev`,
+            url: `/familie-ks-sak/api/brev/fagsak/${fagsak.id}/forhaandsvis-brev`,
         });
     };
 
@@ -231,7 +228,7 @@ export const DokumentutsendingProvider = ({ fagsakId, children }: Props) => {
                 {
                     method: 'POST',
                     data: hentSkjemaData(),
-                    url: `/familie-ks-sak/api/brev/fagsak/${fagsakId}/send-brev`,
+                    url: `/familie-ks-sak/api/brev/fagsak/${fagsak.id}/send-brev`,
                 },
                 () => {
                     settVisInnsendtBrevModal(true);
@@ -283,7 +280,6 @@ export const DokumentutsendingProvider = ({ fagsakId, children }: Props) => {
     return (
         <DokumentutsendingContext.Provider
             value={{
-                fagsakId,
                 hentForhåndsvisningPåFagsak,
                 hentBarnMedOpplysningerFraBruker,
                 hentSkjemaFeilmelding,
@@ -302,12 +298,12 @@ export const DokumentutsendingProvider = ({ fagsakId, children }: Props) => {
             {children}
         </DokumentutsendingContext.Provider>
     );
-};
+}
 
-export const useDokumentutsendingContext = () => {
+export function useDokumentutsendingContext() {
     const context = useContext(DokumentutsendingContext);
     if (context === undefined) {
         throw new Error('useDokumentutsendingContext må brukes innenfor en DokumentutsendingProvider');
     }
     return context;
-};
+}

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -15,13 +15,9 @@ import FritekstAvsnitt from '../../../komponenter/FritekstAvsnitt';
 import { LeggTilBarnModal } from '../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
 import { LeggTilBarnModalContextProvider } from '../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
 import MålformVelger from '../../../komponenter/MålformVelger';
-import type { IPersonInfo } from '../../../typer/person';
 import type { IBarnMedOpplysninger } from '../../../typer/søknad';
+import { useBrukerContext } from '../BrukerContext';
 import { useManuelleBrevmottakerePåFagsakContext } from '../ManuelleBrevmottakerePåFagsakContext';
-
-interface Props {
-    bruker: IPersonInfo;
-}
 
 const Container = styled.div`
     padding: 2rem;
@@ -60,7 +56,8 @@ enum BarnIBrevÅrsak {
     BARN_BOSATT_MED_SØKER,
 }
 
-const DokumentutsendingSkjema = ({ bruker }: Props) => {
+export function DokumentutsendingSkjema() {
+    const { bruker } = useBrukerContext();
     const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
 
     const {
@@ -219,6 +216,4 @@ const DokumentutsendingSkjema = ({ bruker }: Props) => {
             </Container>
         </LeggTilBarnModalContextProvider>
     );
-};
-
-export default DokumentutsendingSkjema;
+}

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -6,7 +6,7 @@ import { Alert, HStack, Loader } from '@navikt/ds-react';
 import BehandlingContainer from './Behandling/BehandlingContainer';
 import { HentOgSettBehandlingProvider } from './Behandling/context/HentOgSettBehandlingContext';
 import { BrukerProvider } from './BrukerContext';
-import Dokumentutsending from './Dokumentutsending/Dokumentutsending';
+import { Dokumentutsending } from './Dokumentutsending/Dokumentutsending';
 import { DokumentutsendingProvider } from './Dokumentutsending/DokumentutsendingContext';
 import { FagsakProvider } from './FagsakContext';
 import JournalpostListe from './journalposter/JournalpostListe';
@@ -91,8 +91,8 @@ export function FagsakContainer() {
                                     element={
                                         <>
                                             <Fagsaklinje />
-                                            <DokumentutsendingProvider fagsakId={fagsak.id}>
-                                                <Dokumentutsending bruker={bruker} />
+                                            <DokumentutsendingProvider>
+                                                <Dokumentutsending />
                                             </DokumentutsendingProvider>
                                         </>
                                     }


### PR DESCRIPTION
### 📮 Favro
NAV-27344

### 💰 Hva skal gjøres, og hvorfor?
Fjerner bruken av Fagsak og Bruker som props i Dokumentutsending og går over til context

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
Ingen visuelle endringer.