### PR TITLE
Sletter toggles

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
@@ -9,9 +9,7 @@ import { filtrerOgSorterPerioderMedBegrunnelseBehov } from './utils';
 import { useVedtakBegrunnelser } from './VedtakBegrunnelserContext';
 import Vedtaksperiode from './Vedtaksperiode';
 import { VedtaksperiodeProvider } from './VedtaksperiodeContext';
-import { useFeatureToggles } from '../../../../../../hooks/useFeatureToggles';
 import type { IBehandling } from '../../../../../../typer/behandling';
-import { FeatureToggle } from '../../../../../../typer/featureToggles';
 import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../../typer/vedtaksperiode';
 import { Vedtaksperiodetype } from '../../../../../../typer/vedtaksperiode';
 import { partition } from '../../../../../../utils/commons';
@@ -36,14 +34,12 @@ interface VedtaksperioderProps {
 
 const Vedtaksperioder = ({ åpenBehandling }: VedtaksperioderProps) => {
     const { alleBegrunnelserRessurs } = useVedtakBegrunnelser();
-    const toggles = useFeatureToggles();
 
     const sorterteVedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
         åpenBehandling.vedtak?.vedtaksperioderMedBegrunnelser ?? [],
         åpenBehandling.resultat,
         åpenBehandling.status,
-        åpenBehandling.sisteVedtaksperiodeVisningDato,
-        toggles[FeatureToggle.skalAlltidViseAlleVedtaksperioder]
+        åpenBehandling.sisteVedtaksperiodeVisningDato
     );
 
     if (

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/utils.test.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/utils.test.ts
@@ -26,8 +26,7 @@ describe('Vedtak utils', () => {
                 vedtaksperioder,
                 BehandlingResultat.AVSLÅTT_ENDRET_OG_OPPHØRT,
                 BehandlingStatus.UTREDES,
-                undefined,
-                true
+                undefined
             );
             expect(perioder.length).toBe(3);
             expect(perioder[0].type).toBe(Vedtaksperiodetype.UTBETALING);
@@ -45,8 +44,7 @@ describe('Vedtak utils', () => {
                     vedtaksperioder,
                     BehandlingResultat.INNVILGET_OG_OPPHØRT,
                     BehandlingStatus.AVSLUTTET,
-                    undefined,
-                    true
+                    undefined
                 );
                 expect(perioder.length).toBe(1);
                 expect(perioder[0].type).toEqual(Vedtaksperiodetype.OPPHØR);
@@ -66,8 +64,7 @@ describe('Vedtak utils', () => {
                     ],
                     BehandlingResultat.INNVILGET,
                     BehandlingStatus.UTREDES,
-                    undefined,
-                    false
+                    undefined
                 );
                 expect(perioder.length).toBe(1);
             });
@@ -84,8 +81,7 @@ describe('Vedtak utils', () => {
                     ],
                     BehandlingResultat.INNVILGET,
                     BehandlingStatus.UTREDES,
-                    undefined,
-                    false
+                    undefined
                 );
                 expect(perioder.length).toBe(0);
             });
@@ -99,8 +95,7 @@ describe('Vedtak utils', () => {
                     vedtaksperioder,
                     BehandlingResultat.OPPHØRT,
                     BehandlingStatus.UTREDES,
-                    undefined,
-                    true
+                    undefined
                 );
                 expect(perioder.length).toBe(1);
                 expect(perioder[0].type).toBe(Vedtaksperiodetype.OPPHØR);

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/utils.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/utils.ts
@@ -117,8 +117,7 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
     vedtaksperioder: IVedtaksperiodeMedBegrunnelser[],
     behandlingResultat: BehandlingResultat,
     behandlingStatus: BehandlingStatus,
-    sisteVedtaksperiodeVisningDato: IsoDatoString | undefined,
-    skalAlltidViseAlleVedtaksperioder: boolean
+    sisteVedtaksperiodeVisningDato: IsoDatoString | undefined
 ): IVedtaksperiodeMedBegrunnelser[] => {
     const sorterteOgFiltrertePerioder = vedtaksperioder
         .slice()
@@ -131,8 +130,6 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
         .filter((vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {
             if (behandlingStatus === BehandlingStatus.AVSLUTTET) {
                 return harPeriodeBegrunnelse(vedtaksperiode);
-            } else if (skalAlltidViseAlleVedtaksperioder) {
-                return true;
             } else {
                 return (
                     (sisteVedtaksperiodeVisningDato &&

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
@@ -11,8 +11,6 @@ import { ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 
 import styles from './Registeropplysninger.module.css';
 import RegisteropplysningerTabell from './RegisteropplysningerTabell';
-import { useFeatureToggles } from '../../../../../../hooks/useFeatureToggles';
-import { FeatureToggle } from '../../../../../../typer/featureToggles';
 import type { IRestRegisterhistorikk } from '../../../../../../typer/person';
 import { Registeropplysning } from '../../../../../../typer/registeropplysning';
 import { Datoformat, isoStringTilFormatertString } from '../../../../../../utils/dato';
@@ -23,7 +21,6 @@ interface IRegisteropplysningerProps {
 }
 
 const Registeropplysninger = ({ opplysninger, fødselsdato }: IRegisteropplysningerProps) => {
-    const toggles = useFeatureToggles();
     const manglerRegisteropplysninger = opplysninger.statsborgerskap.length === 0;
 
     const personErDød = opplysninger.dødsboadresse.length > 0;
@@ -89,13 +86,11 @@ const Registeropplysninger = ({ opplysninger, fødselsdato }: IRegisteropplysnin
                         ikon={<HouseIcon fontSize={'1.5rem'} title="Hjem-ikon" focusable="false" />}
                         historikk={opplysninger.bostedsadresse}
                     />
-                    {toggles[FeatureToggle.skalViseOppholdsadresse] && (
-                        <RegisteropplysningerTabell
-                            opplysningstype={Registeropplysning.OPPHOLDSADRESSE}
-                            ikon={<HouseIcon fontSize={'1.5rem'} title="Hjem-ikon" focusable="false" />}
-                            historikk={opplysninger.oppholdsadresse}
-                        />
-                    )}
+                    <RegisteropplysningerTabell
+                        opplysningstype={Registeropplysning.OPPHOLDSADRESSE}
+                        ikon={<HouseIcon fontSize={'1.5rem'} title="Hjem-ikon" focusable="false" />}
+                        historikk={opplysninger.oppholdsadresse}
+                    />
                 </Box>
             )}
         </>

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -3,7 +3,7 @@ import type { IPersonMedAndelerTilkjentYtelse } from './beregning';
 import type { INøkkelPar } from './common';
 import type { IRestFeilutbetaltValuta } from './eøs-feilutbetalt-valuta';
 import type { IRestKompetanse, IRestUtenlandskPeriodeBeløp, IRestValutakurs } from './eøsPerioder';
-import { type FeatureToggles, FeatureToggle } from './featureToggles';
+import { FeatureToggle, type FeatureToggles } from './featureToggles';
 import type { KlageResultat, KlageStatus, KlageÅrsak } from './klage';
 import type { ManglendeSvalbardmerking } from './ManglendeSvalbardmerking';
 import type { IRestOvergangsordningAndel } from './overgangsordningAndel';
@@ -67,9 +67,6 @@ export const behandlingÅrsakerSomIkkeSkalSettesManuelt = (toggles: FeatureToggl
         BehandlingÅrsak.KLAGE,
         BehandlingÅrsak.LOVENDRING_2024,
         BehandlingÅrsak.SATSENDRING,
-        toggles[FeatureToggle.kanOppretteRevurderingMedAarsakIverksetteKaVedtak]
-            ? null
-            : BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
         toggles[FeatureToggle.kanManueltKorrigereMedVedtaksbrev] ? null : BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
     ].filter(behandlingsårsak => behandlingsårsak !== null);
 

--- a/src/frontend/typer/featureToggles.ts
+++ b/src/frontend/typer/featureToggles.ts
@@ -3,9 +3,12 @@ export interface FeatureToggles {
 }
 
 export enum FeatureToggle {
+    // Operasjonelle
     kanBehandleTekniskEndring = 'familie-ks-sak.behandling.teknisk-endring',
     kanManueltKorrigereMedVedtaksbrev = 'familie-ks-sak.behandling.korreksjon-vedtaksbrev',
     tekniskVedlikeholdHenleggelse = 'familie-ks-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring',
     kanOppretteOgEndreSammensatteKontrollsaker = 'familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker',
     skalObfuskereData = 'familie-ks-sak.anonymiser-persondata',
+
+    // Release
 }

--- a/src/frontend/typer/featureToggles.ts
+++ b/src/frontend/typer/featureToggles.ts
@@ -8,7 +8,6 @@ export enum FeatureToggle {
     tekniskVedlikeholdHenleggelse = 'familie-ks-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring',
     kanOppretteOgEndreSammensatteKontrollsaker = 'familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker',
     skalObfuskereData = 'familie-ks-sak.anonymiser-persondata',
-    kanOppretteRevurderingMedAarsakIverksetteKaVedtak = 'familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak',
     skalAlltidViseAlleVedtaksperioder = 'familie-ks-sak-frontend.alltid-vis-alle-vedtaksperioder',
     skalViseOppholdsadresse = 'familie-ks-sak.skal-vise-oppholdsadresse',
 }

--- a/src/frontend/typer/featureToggles.ts
+++ b/src/frontend/typer/featureToggles.ts
@@ -8,5 +8,4 @@ export enum FeatureToggle {
     tekniskVedlikeholdHenleggelse = 'familie-ks-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring',
     kanOppretteOgEndreSammensatteKontrollsaker = 'familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker',
     skalObfuskereData = 'familie-ks-sak.anonymiser-persondata',
-    skalAlltidViseAlleVedtaksperioder = 'familie-ks-sak-frontend.alltid-vis-alle-vedtaksperioder',
 }

--- a/src/frontend/typer/featureToggles.ts
+++ b/src/frontend/typer/featureToggles.ts
@@ -9,5 +9,4 @@ export enum FeatureToggle {
     kanOppretteOgEndreSammensatteKontrollsaker = 'familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker',
     skalObfuskereData = 'familie-ks-sak.anonymiser-persondata',
     skalAlltidViseAlleVedtaksperioder = 'familie-ks-sak-frontend.alltid-vis-alle-vedtaksperioder',
-    skalViseOppholdsadresse = 'familie-ks-sak.skal-vise-oppholdsadresse',
 }

--- a/src/frontend/typer/test/behandling.test.ts
+++ b/src/frontend/typer/test/behandling.test.ts
@@ -22,7 +22,6 @@ describe('behandlingÅrsakerSomIkkeSkalSettesManuelt inneholde alle behandlings�
     test('Alle relevante toggles er skrudd på', () => {
         // Arrange
         const toggles: FeatureToggles = {
-            kanOppretteRevurderingMedAarsakIverksetteKaVedtak: true,
             kanManueltKorrigereMedVedtaksbrev: true,
         };
 
@@ -48,35 +47,6 @@ describe('behandlingÅrsakerSomIkkeSkalSettesManuelt inneholde alle behandlings�
     test('Alle relevante toggles er skrudd av', () => {
         // Arrange
         const toggles: FeatureToggles = {
-            kanOppretteRevurderingMedAarsakIverksetteKaVedtak: false,
-            kanManueltKorrigereMedVedtaksbrev: false,
-        };
-
-        const forventedeBehandlingsårsaker = new Set([
-            BehandlingÅrsak.KLAGE,
-            BehandlingÅrsak.LOVENDRING_2024,
-            BehandlingÅrsak.SATSENDRING,
-            BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
-            BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
-        ]);
-
-        // Act
-        const behandlingsårsaker = behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles);
-
-        // Assert
-        const behandlingsårsakerSet = new Set(behandlingsårsaker);
-        const forventedeBehandlingsårsakerSet = new Set(forventedeBehandlingsårsaker);
-        expect(behandlingsårsakerSet.size == forventedeBehandlingsårsakerSet.size);
-        expect(
-            [...behandlingsårsakerSet].every(behandlingÅrsak =>
-                [...forventedeBehandlingsårsakerSet].includes(behandlingÅrsak)
-            )
-        );
-    });
-    test('Toggelen kanOppretteRevurderingMedAarsakIverksetteKaVedtak er skrudd på', () => {
-        // Arrange
-        const toggles: FeatureToggles = {
-            kanOppretteRevurderingMedAarsakIverksetteKaVedtak: true,
             kanManueltKorrigereMedVedtaksbrev: false,
         };
 
@@ -86,32 +56,7 @@ describe('behandlingÅrsakerSomIkkeSkalSettesManuelt inneholde alle behandlings�
             BehandlingÅrsak.SATSENDRING,
             BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
         ]);
-        // Act
-        const behandlingsårsaker = behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles);
 
-        // Assert
-        const behandlingsårsakerSet = new Set(behandlingsårsaker);
-        const forventedeBehandlingsårsakerSet = new Set(forventedeBehandlingsårsaker);
-        expect(behandlingsårsakerSet.size == forventedeBehandlingsårsakerSet.size);
-        expect(
-            [...behandlingsårsakerSet].every(behandlingÅrsak =>
-                [...forventedeBehandlingsårsakerSet].includes(behandlingÅrsak)
-            )
-        );
-    });
-    test('Toggelen kanManueltKorrigereMedVedtaksbrev er skrudd på', () => {
-        // Arrange
-        const toggles: FeatureToggles = {
-            kanOppretteRevurderingMedAarsakIverksetteKaVedtak: false,
-            kanManueltKorrigereMedVedtaksbrev: true,
-        };
-
-        const forventedeBehandlingsårsaker = new Set([
-            BehandlingÅrsak.KLAGE,
-            BehandlingÅrsak.LOVENDRING_2024,
-            BehandlingÅrsak.SATSENDRING,
-            BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
-        ]);
         // Act
         const behandlingsårsaker = behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles);
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Sletter toggles som har vært på i prod en stund

Slettede toggles:
- `kanOppretteRevurderingMedAarsakIverksetteKaVedtak` har vært på i prod lenge
- `skalViseOppholdsadresse` har vært på i prod lenge
- `skalAlltidViseAlleVedtaksperioder` ble aldri skrudd på, så ble enig med Brage, som jobbet med det, om at den skal slettes