### PR TITLE
NAV-27173: Refaktorerer oppdater registeropplysninger til react-query

### DIFF
--- a/src/frontend/api/oppdaterRegisteropplysninger.ts
+++ b/src/frontend/api/oppdaterRegisteropplysninger.ts
@@ -1,0 +1,17 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import type { IBehandling } from '../typer/behandling';
+import { RessursResolver } from '../utils/ressursResolver';
+
+export async function oppdaterRegisteropplysninger(
+    request: FamilieRequest,
+    behandlingId: number,
+    påvirkerSystemLaster: boolean = false
+): Promise<IBehandling> {
+    const ressurs = await request<void, IBehandling>({
+        method: 'GET', // Dette burde kanskje ikke være GET?
+        url: `/familie-ks-sak/api/person/oppdater-registeropplysninger/${behandlingId}`,
+        påvirkerSystemLaster: påvirkerSystemLaster,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/hooks/useOppdaterRegisteropplysninger.ts
+++ b/src/frontend/hooks/useOppdaterRegisteropplysninger.ts
@@ -1,0 +1,24 @@
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { oppdaterRegisteropplysninger } from '../api/oppdaterRegisteropplysninger';
+import type { IBehandling } from '../typer/behandling';
+
+interface Parameters {
+    behandlingId: number;
+    påvirkerSystemLaster?: boolean;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, Parameters>, 'mutationFn'>;
+
+export function useOppdaterRegisteropplysninger(options: Options = {}) {
+    const { request } = useHttp();
+    return useMutation({
+        mutationFn: (parameters: Parameters) => {
+            const { behandlingId, påvirkerSystemLaster = false } = parameters;
+            return oppdaterRegisteropplysninger(request, behandlingId, påvirkerSystemLaster);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/sider/Fagsak/Behandling/BehandlingRouter.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingRouter.tsx
@@ -13,7 +13,7 @@ import { SimuleringProvider } from './sider/Simulering/SimuleringContext';
 import { FeilutbetaltValutaTabellProvider } from './sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabellContext';
 import { SammensattKontrollsakProvider } from './sider/Vedtak/SammensattKontrollsak/SammensattKontrollsakContext';
 import Vedtak from './sider/Vedtak/Vedtak';
-import Vilkårsvurdering from './sider/Vilkårsvurdering/Vilkårsvurdering';
+import { Vilkårsvurdering } from './sider/Vilkårsvurdering/Vilkårsvurdering';
 import { VilkårsvurderingProvider } from './sider/Vilkårsvurdering/VilkårsvurderingContext';
 import { TidslinjeProvider } from '../../../komponenter/Tidslinje/TidslinjeContext';
 import { hentSideHref } from '../../../utils/miljø';
@@ -47,7 +47,7 @@ export function BehandlingRouter() {
                 path="/vilkaarsvurdering"
                 element={
                     <VilkårsvurderingProvider åpenBehandling={behandling}>
-                        <Vilkårsvurdering åpenBehandling={behandling} />
+                        <Vilkårsvurdering />
                     </VilkårsvurderingProvider>
                 }
             />

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -51,7 +51,6 @@ interface BehandlingContextValue {
     vilkårsvurderingNesteOnClick: () => void;
     behandlingresultatNesteOnClick: () => void;
     settÅpenBehandling: (behandling: Ressurs<IBehandling>, oppdaterMinimalFagsak?: boolean) => void;
-    oppdaterRegisteropplysninger: () => Promise<Ressurs<IBehandling>>;
     foreslåVedtakNesteOnClick: (
         settVisModal: (visModal: boolean) => void,
         erUlagretNyFeilutbetaltValuta: boolean,
@@ -74,7 +73,7 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
         foreslåVedtakNesteOnClick,
     } = useBehandlingssteg(settBehandlingRessurs, behandling);
 
-    const { logg, hentLogg, oppdaterRegisteropplysninger } = useBehandlingApi(settBehandlingRessurs);
+    const { logg, hentLogg } = useBehandlingApi();
 
     const {
         harInnloggetSaksbehandlerSkrivetilgang,
@@ -206,7 +205,6 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
                 behandlingsstegSubmitressurs,
                 vilkårsvurderingNesteOnClick,
                 behandlingresultatNesteOnClick,
-                oppdaterRegisteropplysninger,
                 foreslåVedtakNesteOnClick,
                 behandlingPåVent: behandling.behandlingPåVent,
                 settÅpenBehandling: settBehandlingRessurs,

--- a/src/frontend/sider/Fagsak/Behandling/context/useBehandlingApi.ts
+++ b/src/frontend/sider/Fagsak/Behandling/context/useBehandlingApi.ts
@@ -1,20 +1,15 @@
 import { useState } from 'react';
 
-import type { AxiosError } from 'axios';
-
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
-import { byggFeiletRessurs, byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
+import { byggFeiletRessurs, byggHenterRessurs, byggTomRessurs } from '@navikt/familie-typer';
 
 import { useAppContext } from '../../../../context/AppContext';
 import useSakOgBehandlingParams from '../../../../hooks/useSakOgBehandlingParams';
-import { type IBehandling } from '../../../../typer/behandling';
 import type { ILogg } from '../../../../typer/logg';
 import { obfuskerLogg } from '../../../../utils/obfuskerData';
 
-const useBehandlingApi = (
-    oppdaterBehandling: (behandling: Ressurs<IBehandling>, oppdaterMinimalFagsak?: boolean) => void
-) => {
+const useBehandlingApi = () => {
     const { request } = useHttp();
     const { behandlingId } = useSakOgBehandlingParams();
 
@@ -42,35 +37,9 @@ const useBehandlingApi = (
         }
     };
 
-    const oppdaterRegisteropplysninger = (): Promise<Ressurs<IBehandling>> => {
-        return request<void, IBehandling>({
-            method: 'GET',
-            url: `/familie-ks-sak/api/person/oppdater-registeropplysninger/${behandlingId}`,
-            påvirkerSystemLaster: false,
-        })
-            .then((response: Ressurs<IBehandling>) => {
-                if (
-                    response.status === RessursStatus.FEILET ||
-                    response.status === RessursStatus.FUNKSJONELL_FEIL ||
-                    response.status === RessursStatus.IKKE_TILGANG
-                ) {
-                    return byggFeiletRessurs(
-                        'Kunne ikke oppdatere registeropplysninger. Prøv igjen eller kontakt brukerstøtte hvis problemet vedvarer.'
-                    ) as Ressurs<IBehandling>;
-                } else {
-                    oppdaterBehandling(response);
-                    return response;
-                }
-            })
-            .catch((_error: AxiosError) => {
-                return byggFeiletRessurs('Ukjent feil ved oppdatering av registeropplysninger') as Ressurs<IBehandling>;
-            });
-    };
-
     return {
         logg,
         hentLogg,
-        oppdaterRegisteropplysninger,
     };
 };
 

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/OppdaterRegisteropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/OppdaterRegisteropplysninger.tsx
@@ -1,0 +1,54 @@
+import { ArrowsSquarepathIcon } from '@navikt/aksel-icons';
+import { Button, Detail, ErrorMessage, HStack, VStack } from '@navikt/ds-react';
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+import { useVilkårsvurderingContext } from './VilkårsvurderingContext';
+import { useOppdaterRegisteropplysninger } from '../../../../../hooks/useOppdaterRegisteropplysninger';
+import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
+import { useBehandlingContext } from '../../context/BehandlingContext';
+
+const FALLBACK_MESSAGE =
+    'Kunne ikke oppdatere registeropplysninger. Prøv igjen eller kontakt brukerstøtte hvis problemet vedvarer.';
+
+function formaterTidspunkt(registeropplysningerHentetTidpsunkt: string | undefined) {
+    if (!registeropplysningerHentetTidpsunkt) {
+        return 'Kunne ikke hente innhentingstidspunkt for registeropplysninger.';
+    }
+    const formatertTidspunkt = isoStringTilFormatertString({
+        isoString: registeropplysningerHentetTidpsunkt,
+        tilFormat: Datoformat.DATO_TID_SEKUNDER,
+    });
+    return `Registeropplysninger hentet ${formatertTidspunkt} fra Folkeregisteret.`;
+}
+
+export function OppdaterRegisteropplysninger() {
+    const { behandling, settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { vilkårsvurdering } = useVilkårsvurderingContext();
+
+    const { mutate, isPending, error } = useOppdaterRegisteropplysninger({
+        onSuccess: behandling => settÅpenBehandling(byggSuksessRessurs(behandling)),
+    });
+
+    const registeropplysningerHentetTidpsunkt = vilkårsvurdering[0]?.person?.registerhistorikk?.hentetTidspunkt;
+
+    const erLesevisning = vurderErLesevisning();
+
+    return (
+        <VStack gap={'space-8'}>
+            <HStack align={'center'} gap={'space-8'}>
+                <Detail textColor={'subtle'}>{formaterTidspunkt(registeropplysningerHentetTidpsunkt)}</Detail>
+                {!erLesevisning && (
+                    <Button
+                        aria-label={'Oppdater registeropplysninger'}
+                        onClick={() => mutate({ behandlingId: behandling.behandlingId })}
+                        loading={isPending}
+                        variant={'tertiary'}
+                        size={'small'}
+                        icon={<ArrowsSquarepathIcon fontSize={'1.5rem'} focusable={'false'} />}
+                    />
+                )}
+            </HStack>
+            {error && <ErrorMessage>{error.message ?? FALLBACK_MESSAGE}</ErrorMessage>}
+        </VStack>
+    );
+}


### PR DESCRIPTION
### 📮 Favro
NAV-27173

### 💰 Hva skal gjøres, og hvorfor?
Refaktorerer oppdatering av registeropplysninger til react-query. Fjerner det fra `BehandlingContext`.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ønsker ikke å skrive tester før man har ryddet opp i `BehandlingContext` og kanskje `VilkårvurderingContext`. 

### 👀 Screen shots
Normal:
<img width="528" height="157" alt="image" src="https://github.com/user-attachments/assets/b6f14e30-95b7-408f-8a26-cdea234e6a03" />

Feilmelding:
<img width="528" height="177" alt="image" src="https://github.com/user-attachments/assets/f7b15c4b-d572-4c93-957b-7bff607ff227" />

Laster:
<img width="528" height="177" alt="image" src="https://github.com/user-attachments/assets/cbf4888c-9a42-44f8-9880-930391d3dec8" />
