### PR TITLE
fikser nøstet h3/h2 feil

### DIFF
--- a/src/frontend/sider/ManuellJournalføring/AvsenderPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/AvsenderPanel.tsx
@@ -52,14 +52,12 @@ export const AvsenderPanel = () => {
             aria-label={skjema.felter.avsenderNavn.verdi || 'Ukjent avsender'}
         >
             <ExpansionCard.Header>
-                <ExpansionCard.Title>
-                    <DeltagerInfo
-                        ikon={<EmailIkon filled={åpen} width={48} height={48} />}
-                        navn={skjema.felter.avsenderNavn.verdi || 'Ukjent avsender'}
-                        ident={formaterIdent(skjema.felter.avsenderIdent.verdi ?? '')}
-                        undertittel="Avsender"
-                    />
-                </ExpansionCard.Title>
+                <DeltagerInfo
+                    ikon={<EmailIkon filled={åpen} width={48} height={48} />}
+                    navn={skjema.felter.avsenderNavn.verdi || 'Ukjent avsender'}
+                    ident={formaterIdent(skjema.felter.avsenderIdent.verdi ?? '')}
+                    undertittel="Avsender"
+                />
             </ExpansionCard.Header>
             <StyledExpansionContent>
                 {erLesevisning() ? (

--- a/src/frontend/sider/ManuellJournalføring/BrukerPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/BrukerPanel.tsx
@@ -31,6 +31,7 @@ const StyledExpansionContent = styled(ExpansionCard.Content)`
     .navds-expansioncard__content-inner {
         margin: 1rem 4rem;
     }
+
     padding: 0.5rem 1rem 1rem;
 `;
 
@@ -63,14 +64,12 @@ export const BrukerPanel = () => {
             size="small"
         >
             <ExpansionCard.Header>
-                <ExpansionCard.Title>
-                    <DeltagerInfo
-                        ikon={<KontoSirkel filled={åpen} width={48} height={48} />}
-                        navn={skjema.felter.bruker.verdi?.navn || 'Ukjent bruker'}
-                        undertittel={'Søker/Bruker'}
-                        ident={formaterIdent(skjema.felter.bruker.verdi?.personIdent ?? '')}
-                    />
-                </ExpansionCard.Title>
+                <DeltagerInfo
+                    ikon={<KontoSirkel filled={åpen} width={48} height={48} />}
+                    navn={skjema.felter.bruker.verdi?.navn || 'Ukjent bruker'}
+                    undertittel={'Søker/Bruker'}
+                    ident={formaterIdent(skjema.felter.bruker.verdi?.personIdent ?? '')}
+                />
             </ExpansionCard.Header>
             <StyledExpansionContent>
                 {!erLesevisning() && (

--- a/src/frontend/sider/ManuellJournalføring/DeltagerInfo.tsx
+++ b/src/frontend/sider/ManuellJournalføring/DeltagerInfo.tsx
@@ -1,8 +1,6 @@
 import type { ReactNode } from 'react';
 
-import styled from 'styled-components';
-
-import { BodyShort, Heading } from '@navikt/ds-react';
+import { ExpansionCard, HStack, VStack } from '@navikt/ds-react';
 
 interface DeltagerProps {
     ikon: ReactNode;
@@ -12,27 +10,16 @@ interface DeltagerProps {
     children?: ReactNode | ReactNode[];
 }
 
-const HSplit = styled.div`
-    display: flex;
-    flex-direction: row;
-`;
-
-const MarginedDiv = styled.div`
-    margin-right: 1rem;
-`;
-
 export const DeltagerInfo = ({ ikon, navn, undertittel, ident }: DeltagerProps) => {
     return (
-        <div>
-            <HSplit>
-                <MarginedDiv>{ikon}</MarginedDiv>
-                <div>
-                    <Heading size={'small'} level={'2'}>
-                        {ident ? `${navn} | ${ident}` : navn}
-                    </Heading>
-                    <BodyShort>{undertittel}</BodyShort>
-                </div>
-            </HSplit>
-        </div>
+        <HStack gap={'space-16'}>
+            {ikon}
+            <VStack>
+                <ExpansionCard.Title size={'small'} as={'h2'}>
+                    {ident ? `${navn} | ${ident}` : navn}
+                </ExpansionCard.Title>
+                <ExpansionCard.Description>{undertittel}</ExpansionCard.Description>
+            </VStack>
+        </HStack>
     );
 };

--- a/src/frontend/sider/ManuellJournalføring/Journalpost.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Journalpost.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { BodyShort, ExpansionCard, Heading } from '@navikt/ds-react';
+import { BodyShort, ExpansionCard } from '@navikt/ds-react';
 import { FamilieReactSelect } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -62,10 +62,8 @@ const Journalpost = () => {
     return (
         <ExpansionCard id={skjema.felter.journalpostTittel.id} size={'small'} aria-label={'journalpost'}>
             <ExpansionCard.Header>
-                <ExpansionCard.Title>
-                    <Heading size={'small'} level={'2'}>
-                        {skjema.felter.journalpostTittel.verdi || 'Ingen tittel'}
-                    </Heading>
+                <ExpansionCard.Title size={'small'} as={'h2'}>
+                    {skjema.felter.journalpostTittel.verdi || 'Ingen tittel'}
                 </ExpansionCard.Title>
             </ExpansionCard.Header>
             <ExpansionCard.Content>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Oppdaget feil i console med nøstet h2 i h3 feil, dette vil fikse de tre instansene jeg fant på siden.
<img width="1028" height="453" alt="image" src="https://github.com/user-attachments/assets/ab05fcbf-3f93-48e2-a7b5-643ea69cd23f" />

### 👀 Screen shots
FØR
<img width="432" height="617" alt="image" src="https://github.com/user-attachments/assets/9f995177-d1f8-451e-844f-bc2e630d5a6d" />


ETTER
<img width="421" height="593" alt="image" src="https://github.com/user-attachments/assets/d315b2da-47ef-4b4e-a551-68d113461da3" />
