### PR TITLE
20260212 generertebegrunnelser feilfiks

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
@@ -62,6 +62,8 @@ const Vedtaksperiode = ({ vedtaksperiodeMedBegrunnelser, sisteVedtaksperiodeFom 
                     <Loader size={'small'} />
                     <BodyShort>Laster genererte brevbegrunnelser...</BodyShort>
                 </HStack>
+            ) : genererteBrevbegrunnelserError ? (
+                <ErrorMessage>{genererteBrevbegrunnelserError.message}</ErrorMessage>
             ) : (
                 genererteBrevbegrunnelser &&
                 genererteBrevbegrunnelser.length > 0 && (
@@ -77,7 +79,6 @@ const Vedtaksperiode = ({ vedtaksperiodeMedBegrunnelser, sisteVedtaksperiodeFom 
                     </>
                 )
             )}
-            {genererteBrevbegrunnelserError && <ErrorMessage>{genererteBrevbegrunnelserError.message}</ErrorMessage>}
             {vedtaksperiodeStøtterFritekst && <FritekstVedtakbegrunnelser />}
         </EkspanderbarVedtaksperiode>
     );


### PR DESCRIPTION

### 💰 Hva skal gjøres, og hvorfor?

Oppdaget feil ved visning av brevbegrunnelser. Fikser det her så det blir likt som før.
https://github.com/user-attachments/assets/ca9ccfb4-f066-4c77-a5a4-02e247609d46

Fiksen vil da se slik ut
https://github.com/user-attachments/assets/36f10fa8-9299-4661-9624-9770f5e2d73c
