### PR TITLE
Lagt til ny oppgaveprioritert kritisk

### DIFF
--- a/src/frontend/typer/oppgave.ts
+++ b/src/frontend/typer/oppgave.ts
@@ -171,6 +171,7 @@ export enum PrioritetFilter {
     NORM = 'Normal',
     HOY = 'Høy',
     LAV = 'Lav',
+    KRITISK = 'Kritisk',
 }
 
 export interface IRestLukkOppgaveOgKnyttJournalpost {


### PR DESCRIPTION
Plukket opp på #team-oppgavehåndtering sin slack [nav-it.slack.com/archives/CB2N21ZME/p1773219930323259](https://nav-it.slack.com/archives/CB2N21ZME/p1773219930323259)

> Vi kommer til å legge til en ny prioritet: KRITISK. For konsumenter som mapper direkte til enums eller har logikk knyttet til prioriteten, kan dette være en brekkende endring.
>
>Vi kommer til å ha dette i dev over en periode, og justere prioriteten til kritisk for en god del oppgaver på tvers av fagområder, for å sikre at ev. problemstillinger fanges opp før det rulles ut i prod.

Så vidt jeg ser så viser vi kun oppgaveprioritet. Så det bør være trygt å merge denne ned før oppgave ruller dette ut i prod. Uten denne så blir prioritert en tom streng

<img width="696" height="146" alt="image" src="https://github.com/user-attachments/assets/155cb222-2735-4c56-bf93-eb747162fbfb" />

