### PR TITLE
Reverter oppdatering til aksel dropdown for begrunnelser

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,8 +112,5 @@
     "typescript-eslint": "8.56.1",
     "vite": "7.3.1",
     "vitest": "4.0.18"
-  },
-  "resolutions": {
-    "csstype": "3.1.2"
   }
 }

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
@@ -1,9 +1,14 @@
-import type { GroupBase } from 'react-select';
 import styled from 'styled-components';
 
 import { BodyShort, Label } from '@navikt/ds-react';
 import { AZIndexPopover } from '@navikt/ds-tokens/dist/tokens';
-import { type ActionMeta, FamilieReactSelect, type FormatOptionLabelMeta } from '@navikt/familie-form-elements';
+import {
+    type ActionMeta,
+    FamilieReactSelect,
+    type FormatOptionLabelMeta,
+    type GroupBase,
+    type StylesConfig,
+} from '@navikt/familie-form-elements';
 
 import { useAlleBegrunnelserContext } from './AlleBegrunnelserContext';
 import { mapBegrunnelserTilSelectOptions } from './utils';
@@ -34,41 +39,42 @@ const BegrunnelserMultiselect = ({ tillatKunLesevisning }: IProps) => {
 
     const begrunnelser = mapBegrunnelserTilSelectOptions(vedtaksperiodeMedBegrunnelser, alleBegrunnelser);
 
+    const propSelectStyles: StylesConfig<OptionType, boolean, GroupBase<OptionType>> = {
+        container: (provided, props) =>
+            Object.assign({}, provided, {
+                maxWidth: '50rem',
+                zIndex: props.isFocused ? Number(AZIndexPopover) : 1,
+            }),
+        groupHeading: provided =>
+            Object.assign({}, provided, {
+                textTransform: 'none',
+            }),
+        multiValue: (provided, props) => {
+            const currentOption = props.data;
+            const vedtakBegrunnelseType: BegrunnelseType | undefined = finnBegrunnelseType(
+                alleBegrunnelser,
+                currentOption.value as Begrunnelse
+            );
+
+            return Object.assign({}, provided, {
+                backgroundColor: hentBakgrunnsfarge(vedtakBegrunnelseType),
+                border: `1px solid ${hentBorderfarge(vedtakBegrunnelseType)}`,
+                borderRadius: '0.5rem',
+            });
+        },
+        multiValueLabel: provided =>
+            Object.assign({}, provided, {
+                whiteSpace: 'pre-wrap',
+                textOverflow: 'hidden',
+                overflow: 'hidden',
+            }),
+    };
+
     return (
         <FamilieReactSelect
             id={`${id}`}
             value={begrunnelser}
-            propSelectStyles={{
-                container: (provided, props) => ({
-                    ...provided,
-                    maxWidth: '50rem',
-                    zIndex: props.isFocused ? AZIndexPopover : 1,
-                }),
-                groupHeading: provided => ({
-                    ...provided,
-                    textTransform: 'none',
-                }),
-                multiValue: (provided, props) => {
-                    const currentOption = props.data as OptionType;
-                    const begrunnelseType: BegrunnelseType | undefined = finnBegrunnelseType(
-                        alleBegrunnelser,
-                        currentOption.value as Begrunnelse
-                    );
-
-                    return {
-                        ...provided,
-                        backgroundColor: hentBakgrunnsfarge(begrunnelseType),
-                        border: `1px solid ${hentBorderfarge(begrunnelseType)}`,
-                        borderRadius: '0.5rem',
-                    };
-                },
-                multiValueLabel: provided => ({
-                    ...provided,
-                    whiteSpace: 'pre-wrap',
-                    textOverflow: 'hidden',
-                    overflow: 'hidden',
-                }),
-            }}
+            propSelectStyles={propSelectStyles}
             placeholder={'Velg begrunnelse(r)'}
             isDisabled={erLesevisning || oppdaterBegrunnelserMutation?.status === 'pending'}
             feil={oppdaterBegrunnelserMutation?.error?.message}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
@@ -1,41 +1,108 @@
-import { Box, UNSAFE_Combobox } from '@navikt/ds-react';
+import type { GroupBase } from 'react-select';
+import styled from 'styled-components';
+
+import { BodyShort, Label } from '@navikt/ds-react';
+import { AZIndexPopover } from '@navikt/ds-tokens/dist/tokens';
+import { type ActionMeta, FamilieReactSelect, type FormatOptionLabelMeta } from '@navikt/familie-form-elements';
 
 import { useAlleBegrunnelserContext } from './AlleBegrunnelserContext';
 import { mapBegrunnelserTilSelectOptions } from './utils';
 import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
 import { useOppdaterBegrunnelserMutationState } from '../../../../../../hooks/useOppdaterStandardbegrunnelserMutationState';
+import type { OptionType } from '../../../../../../typer/common';
+import type { Begrunnelse, BegrunnelseType } from '../../../../../../typer/vedtak';
+import { begrunnelseTyper } from '../../../../../../typer/vedtak';
+import { finnBegrunnelseType, hentBakgrunnsfarge, hentBorderfarge } from '../../../../../../utils/vedtakUtils';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface IProps {
     tillatKunLesevisning: boolean;
 }
 
+const GroupLabel = styled.div`
+    color: black;
+`;
+
 const BegrunnelserMultiselect = ({ tillatKunLesevisning }: IProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = tillatKunLesevisning || vurderErLesevisning();
 
-    const { onChangeBegrunnelse, grupperteBegrunnelser, vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
+    const { id, onChangeBegrunnelse, grupperteBegrunnelser, vedtaksperiodeMedBegrunnelser } =
+        useVedtaksperiodeContext();
     const { alleBegrunnelser } = useAlleBegrunnelserContext();
     const oppdaterBegrunnelserMutation = useOppdaterBegrunnelserMutationState(vedtaksperiodeMedBegrunnelser.id);
 
     const begrunnelser = mapBegrunnelserTilSelectOptions(vedtaksperiodeMedBegrunnelser, alleBegrunnelser);
 
     return (
-        <Box marginBlock={'space-0 space-16'}>
-            <UNSAFE_Combobox
-                selectedOptions={begrunnelser}
-                placeholder={'Velg begrunnelse(r)'}
-                isLoading={erLesevisning || oppdaterBegrunnelserMutation?.status === 'pending'}
-                error={oppdaterBegrunnelserMutation?.error?.message}
-                label="Velg standardtekst i brev"
-                readOnly={erLesevisning}
-                isMultiSelect
-                onToggleSelected={(option, isSelected) => {
-                    onChangeBegrunnelse(option, isSelected);
-                }}
-                options={grupperteBegrunnelser.flatMap(group => group.options)}
-            />
-        </Box>
+        <FamilieReactSelect
+            id={`${id}`}
+            value={begrunnelser}
+            propSelectStyles={{
+                container: (provided, props) => ({
+                    ...provided,
+                    maxWidth: '50rem',
+                    zIndex: props.isFocused ? AZIndexPopover : 1,
+                }),
+                groupHeading: provided => ({
+                    ...provided,
+                    textTransform: 'none',
+                }),
+                multiValue: (provided, props) => {
+                    const currentOption = props.data as OptionType;
+                    const begrunnelseType: BegrunnelseType | undefined = finnBegrunnelseType(
+                        alleBegrunnelser,
+                        currentOption.value as Begrunnelse
+                    );
+
+                    return {
+                        ...provided,
+                        backgroundColor: hentBakgrunnsfarge(begrunnelseType),
+                        border: `1px solid ${hentBorderfarge(begrunnelseType)}`,
+                        borderRadius: '0.5rem',
+                    };
+                },
+                multiValueLabel: provided => ({
+                    ...provided,
+                    whiteSpace: 'pre-wrap',
+                    textOverflow: 'hidden',
+                    overflow: 'hidden',
+                }),
+            }}
+            placeholder={'Velg begrunnelse(r)'}
+            isDisabled={erLesevisning || oppdaterBegrunnelserMutation?.status === 'pending'}
+            feil={oppdaterBegrunnelserMutation?.error?.message}
+            label="Velg standardtekst i brev"
+            creatable={false}
+            erLesevisning={erLesevisning}
+            isMulti={true}
+            onChange={(_, action: ActionMeta<OptionType>) => {
+                onChangeBegrunnelse(action);
+            }}
+            formatOptionLabel={(option: OptionType, formatOptionLabelMeta: FormatOptionLabelMeta<OptionType>) => {
+                const begrunnelseType = finnBegrunnelseType(alleBegrunnelser, option.value as Begrunnelse);
+
+                if (formatOptionLabelMeta.context === 'value') {
+                    const type = begrunnelseTyper[begrunnelseType as BegrunnelseType];
+                    return (
+                        <BodyShort>
+                            <b>{type}</b>: {option.label}
+                        </BodyShort>
+                    );
+                } else {
+                    return <BodyShort>{option.label}</BodyShort>;
+                }
+            }}
+            formatGroupLabel={(group: GroupBase<OptionType>) => {
+                return (
+                    <GroupLabel>
+                        <Label>{group.label}</Label>
+                        <hr />
+                    </GroupLabel>
+                );
+            }}
+            options={grupperteBegrunnelser}
+        />
     );
 };
 

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
@@ -4,7 +4,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import deepEqual from 'deep-equal';
 
-import type { GroupBase, OptionType } from '@navikt/familie-form-elements';
+import type { ActionMeta, GroupBase, OptionType } from '@navikt/familie-form-elements';
 import type { FeiloppsummeringFeil, FeltState, ISkjema } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
 import { byggSuksessRessurs } from '@navikt/familie-typer';
@@ -44,7 +44,7 @@ interface VedtaksperiodeContextValue {
     leggTilFritekst: () => void;
     maksAntallKulepunkter: number;
     makslengdeFritekst: number;
-    onChangeBegrunnelse: (option: string, isSelected: boolean) => void;
+    onChangeBegrunnelse: (action: ActionMeta<OptionType>) => void;
     onPanelClose: (visAlert: boolean) => void;
     putVedtaksperiodeMedFritekster: () => void;
     skjema: ISkjema<BegrunnelserSkjema, IBehandling>;
@@ -146,22 +146,37 @@ export const VedtaksperiodeProvider = ({ åpenBehandling, vedtaksperiodeMedBegru
         populerSkjemaFraBackend();
     }, [vedtaksperiodeMedBegrunnelser]);
 
-    const onChangeBegrunnelse = (option: string, isSelected: boolean) => {
-        if (isSelected) {
-            oppdaterBegrunnelser({
-                begrunnelser: [
-                    ...valgteBegrunnelser.map(vedtaksBegrunnelse => vedtaksBegrunnelse.begrunnelse),
-                    option as Begrunnelse,
-                ],
-            });
-        } else {
-            oppdaterBegrunnelser({
-                begrunnelser: [
-                    ...valgteBegrunnelser.filter(
-                        persistertBegrunnelse => persistertBegrunnelse.begrunnelse !== (option as Begrunnelse)
-                    ),
-                ].map(vedtaksBegrunnelse => vedtaksBegrunnelse.begrunnelse),
-            });
+    const onChangeBegrunnelse = (action: ActionMeta<OptionType>) => {
+        switch (action.action) {
+            case 'select-option':
+                if (action.option) {
+                    oppdaterBegrunnelser({
+                        begrunnelser: [
+                            ...valgteBegrunnelser.map(vedtaksBegrunnelse => vedtaksBegrunnelse.begrunnelse),
+                            action.option?.value as Begrunnelse,
+                        ],
+                    });
+                }
+                break;
+            case 'pop-value':
+            case 'remove-value':
+                if (action.removedValue) {
+                    oppdaterBegrunnelser({
+                        begrunnelser: [
+                            ...valgteBegrunnelser.filter(
+                                persistertBegrunnelse =>
+                                    persistertBegrunnelse.begrunnelse !== (action.removedValue?.value as Begrunnelse)
+                            ),
+                        ].map(vedtaksBegrunnelse => vedtaksBegrunnelse.begrunnelse),
+                    });
+                }
+
+                break;
+            case 'clear':
+                oppdaterBegrunnelser({ begrunnelser: [] });
+                break;
+            default:
+                throw new Error('Ukjent action ved onChange på vedtakbegrunnelser');
         }
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2745,7 +2745,12 @@ cssstyle@^6.0.1:
     css-tree "^3.1.0"
     lru-cache "^11.2.6"
 
-csstype@3.1.2, csstype@3.2.3, csstype@^3.0.2, csstype@^3.2.2:
+csstype@3.2.3, csstype@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
+
+csstype@^3.0.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==


### PR DESCRIPTION
### 📮 Favro: Nav-28027

### 💰 Hva skal gjøres, og hvorfor?
Ruller tilbake aksel oppdateringer gjort for begrunnelse multiselect i denne [PR'n](https://github.com/navikt/familie-ks-sak-frontend/pull/1604) siden man ikke ønsker å miste grupperingsfunksjonaliteten enda.