### PR TITLE
NAV-28126: Tar i bruk ErrorBoundary istendefor /error siden når man i…

### DIFF
--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -29,6 +29,7 @@ export default async (authClient: Client, router: Router) => {
             .end();
     });
 
+    // Brukes av familie-felles-frontend
     router.get('/error', (_: Request, res: Response) => {
         prometheusTellere.errorRoute.inc();
         res.sendFile('error.html', { root: path.join(`assets/`) });

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -11,7 +11,7 @@ import { createContext, useState } from 'react';
 import type { AxiosRequestConfig } from 'axios';
 
 import { Alert, BodyShort, Button } from '@navikt/ds-react';
-import { loggFeil, useHttp } from '@navikt/familie-http';
+import { useHttp } from '@navikt/familie-http';
 import type { ISaksbehandler, Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -23,7 +23,6 @@ import { FeatureToggle } from '../typer/featureToggles';
 import type { IRestTilgang } from '../typer/person';
 import { adressebeskyttelsestyper } from '../typer/person';
 import { gruppeIdTilRolle, gruppeIdTilSuperbrukerRolle } from '../utils/behandling';
-import { tilFeilside } from '../utils/commons';
 
 export type FamilieAxiosRequestConfig<D> = AxiosRequestConfig & {
     data?: D;
@@ -128,12 +127,7 @@ const AppProvider = (props: PropsWithChildren) => {
         }
 
         if (innloggetSaksbehandler && rolle === BehandlerRolle.UKJENT) {
-            loggFeil(
-                undefined,
-                innloggetSaksbehandler,
-                'Saksbehandler tilhører ingen av de definerte tilgangsgruppene.'
-            );
-            tilFeilside();
+            throw new Error('Finner ikke rolle til saksbehandler.');
         }
 
         return rolle;

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/useEndreBehandlendeEnhetForm.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/useEndreBehandlendeEnhetForm.ts
@@ -33,7 +33,7 @@ export function useEndreBehandlendeEnhetForm({ lukkModal }: Props) {
     const { setError } = form;
 
     async function onSubmit(formValues: EndreBehandlendeEnhetFormValues) {
-        mutateAsync({
+        return mutateAsync({
             enhetId: formValues.enhetId,
             begrunnelse: formValues.begrunnelse,
         })

--- a/src/frontend/utils/commons.ts
+++ b/src/frontend/utils/commons.ts
@@ -15,10 +15,6 @@ export function erDefinert<T extends NonNullable<unknown>>(value: T | undefined 
 
 export const fjernWhitespace = (streng: string) => streng.replace(/\s/g, '').replace(/[ \u0085]/g, '');
 
-export const tilFeilside = (): void => {
-    window.location.assign(window.location.protocol + '//' + window.location.host + '/error');
-};
-
 export const sjekkTilgangTilPerson = (personRes: Ressurs<IPersonInfo>): Ressurs<IPersonInfo> => {
     if (personRes.status === RessursStatus.SUKSESS && personRes.data.harTilgang === false) {
         return byggFeiletRessurs('Du har ikke tilgang til denne brukeren.');


### PR DESCRIPTION
### 📮 Favro:
NAV-28126

### 💰 Hva skal gjøres, og hvorfor?
Tar i bruk ErrorBoundary istendefor /error siden når man ikke klarer å hente saksbehandlerrolle. Når man kaster en feil vil man bli tatt til `<ErrorBoundary />` komponenten. 

La også på en `return` som manglet i et av de nye RHF skjemaene. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Fantes ikke eksisterende kode. 

### 👀 Screen shots
Ingen visuelle endringer. 