### PR TITLE
Nav-28039: Ny landvelger

### DIFF
--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -9,9 +9,12 @@ import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import type { ILeggTilFjernBrevmottakerSkjemaFelter } from './useBrevmottakerSkjema';
 import { Mottaker, mottakerVisningsnavn } from './useBrevmottakerSkjema';
+import { useFeatureToggles } from '../../../../hooks/useFeatureToggles';
 import { FamilieLandvelger } from '../../../../sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/EøsKomponenter/FamilieLandvelger';
 import type { IBehandling } from '../../../../typer/behandling';
+import { FeatureToggle } from '../../../../typer/featureToggles';
 import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
+import { ALLE_LAND_REGIONKODER, RegionCombobox, type Regionkode } from '../../../FlaggCombobox';
 
 const StyledTextField = styled(TextField)<{ $width: string }>`
     width: ${props => props.$width};
@@ -25,6 +28,7 @@ interface Props {
 }
 
 const BrevmottakerSkjema = ({ erLesevisning, skjema, navnErPreutfylt }: Props) => {
+    const toggles = useFeatureToggles();
     const erPåDokumentutsendingPåFagsak = useLocation().pathname.includes('dokumentutsending');
 
     const gyldigeMottakerTyper = erPåDokumentutsendingPåFagsak
@@ -62,27 +66,58 @@ const BrevmottakerSkjema = ({ erLesevisning, skjema, navnErPreutfylt }: Props) =
                             skjema.felter.navn.validerOgSettFelt(event.target.value);
                         }}
                     />
-                    <FamilieLandvelger
-                        id={'land'}
-                        value={skjema.felter.land.verdi !== '' ? skjema.felter.land.verdi : undefined}
-                        label={'Land'}
-                        medFlag
-                        utenMargin
-                        eksluderLand={
-                            skjema.felter.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
-                                ? ['NO', 'XU']
-                                : ['XU']
-                        }
-                        feil={
-                            skjema.visFeilmeldinger && skjema.felter.land.valideringsstatus === Valideringsstatus.FEIL
-                                ? skjema.felter.land.feilmelding?.toString()
-                                : ''
-                        }
-                        erLesevisning={erLesevisning}
-                        onChange={land => {
-                            skjema.felter.land.validerOgSettFelt(land.value);
-                        }}
-                    />
+                    {toggles[FeatureToggle.brukNyFlagCombobox] ? (
+                        <RegionCombobox
+                            label={'Land'}
+                            value={
+                                (skjema.felter.land.verdi !== '' ? skjema.felter.land.verdi : undefined) as Regionkode
+                            }
+                            options={ALLE_LAND_REGIONKODER.filter(regionkode => {
+                                if (skjema.felter.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE) {
+                                    return regionkode !== 'NO' && regionkode !== 'XU';
+                                }
+                                return regionkode !== 'XU';
+                            })}
+                            onChange={value => {
+                                if (value) {
+                                    skjema.felter.land.validerOgSettFelt(value);
+                                } else {
+                                    skjema.felter.land.nullstill();
+                                }
+                            }}
+                            readOnly={erLesevisning}
+                            error={
+                                skjema.visFeilmeldinger &&
+                                skjema.felter.land.valideringsstatus === Valideringsstatus.FEIL
+                                    ? skjema.felter.land.feilmelding?.toString()
+                                    : ''
+                            }
+                            dropdownPlacement={skjema.felter.land.verdi ? 'bottom' : 'top'}
+                        />
+                    ) : (
+                        <FamilieLandvelger
+                            id={'land'}
+                            value={skjema.felter.land.verdi !== '' ? skjema.felter.land.verdi : undefined}
+                            label={'Land'}
+                            medFlag
+                            utenMargin
+                            eksluderLand={
+                                skjema.felter.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
+                                    ? ['NO', 'XU']
+                                    : ['XU']
+                            }
+                            feil={
+                                skjema.visFeilmeldinger &&
+                                skjema.felter.land.valideringsstatus === Valideringsstatus.FEIL
+                                    ? skjema.felter.land.feilmelding?.toString()
+                                    : ''
+                            }
+                            erLesevisning={erLesevisning}
+                            onChange={land => {
+                                skjema.felter.land.validerOgSettFelt(land.value);
+                            }}
+                        />
+                    )}
                     {skjema.felter.land.verdi && (
                         <>
                             <TextField

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
@@ -3,10 +3,12 @@ import styled from 'styled-components';
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Alert, Button, Heading, HStack, Spacer } from '@navikt/ds-react';
 import { FontWeightBold } from '@navikt/ds-tokens/dist/tokens';
-import CountryData from '@navikt/land-verktoy';
+import _CountryData from '@navikt/land-verktoy';
 
 import type { IRestBrevmottaker, SkjemaBrevmottaker } from './useBrevmottakerSkjema';
 import { mottakerVisningsnavn } from './useBrevmottakerSkjema';
+
+const CountryData = (_CountryData as unknown as { default?: typeof _CountryData }).default ?? _CountryData;
 
 const MarginTop = styled.div`
     margin-top: 2.5rem;

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -5,6 +5,8 @@ import { Valideringsstatus } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 import type { Country } from '@navikt/land-verktoy';
 
+import { useFeatureToggles } from '../../../../../../../hooks/useFeatureToggles';
+import { EØS_LAND_REGIONKODER, RegionCombobox, type Regionkode } from '../../../../../../../komponenter/FlaggCombobox';
 import { type IBehandling } from '../../../../../../../typer/behandling';
 import type { OptionType } from '../../../../../../../typer/common';
 import {
@@ -17,6 +19,7 @@ import {
     kompetanseResultater,
     SøkersAktivitet,
 } from '../../../../../../../typer/eøsPerioder';
+import { FeatureToggle } from '../../../../../../../typer/featureToggles';
 import { useBehandlingContext } from '../../../../context/BehandlingContext';
 import EøsPeriodeSkjema from '../EøsKomponenter/EøsPeriodeSkjema';
 import { FamilieLandvelger } from '../EøsKomponenter/FamilieLandvelger';
@@ -47,6 +50,7 @@ export function KompetanseTabellRadEndre({
     erAnnenForelderOmfattetAvNorskLovgivning,
 }: Props) {
     const { vurderErLesevisning } = useBehandlingContext();
+    const toggles = useFeatureToggles();
     const lesevisning = vurderErLesevisning(true);
 
     const visSubmitFeilmelding = () => {
@@ -158,69 +162,135 @@ export function KompetanseTabellRadEndre({
                         Søker har enten aleneomsorg for egne barn eller forsørger andre barn
                     </Alert>
                 )}
-                <FamilieLandvelger
-                    erLesevisning={lesevisning}
-                    id={'søkersAktivitetsland'}
-                    label={'Søkers aktivitetsland'}
-                    kunEøs
-                    medFlag
-                    size="medium"
-                    kanNullstilles
-                    value={skjema.felter.søkersAktivitetsland.verdi}
-                    onChange={(value: Country) => {
-                        const nyVerdi = value ? value.value : undefined;
-                        skjema.felter.søkersAktivitetsland.validerOgSettFelt(nyVerdi);
-                    }}
-                    feil={
-                        skjema.visFeilmeldinger &&
-                        skjema.felter.søkersAktivitetsland.valideringsstatus === Valideringsstatus.FEIL
-                            ? skjema.felter.søkersAktivitetsland.feilmelding?.toString()
-                            : ''
-                    }
-                    utenMargin
-                />
-                <FamilieLandvelger
-                    erLesevisning={lesevisning}
-                    id={'annenForeldersAktivitetsland'}
-                    label={'Annen forelders aktivitetsland'}
-                    kunEøs
-                    medFlag
-                    size="medium"
-                    kanNullstilles
-                    value={skjema.felter.annenForeldersAktivitetsland.verdi}
-                    onChange={(value: Country) => {
-                        const nyVerdi = value ? value.value : undefined;
-                        skjema.felter.annenForeldersAktivitetsland.validerOgSettFelt(nyVerdi);
-                    }}
-                    feil={
-                        skjema.visFeilmeldinger &&
-                        skjema.felter.annenForeldersAktivitetsland.valideringsstatus === Valideringsstatus.FEIL
-                            ? skjema.felter.annenForeldersAktivitetsland.feilmelding?.toString()
-                            : ''
-                    }
-                    utenMargin
-                />
-                <FamilieLandvelger
-                    erLesevisning={lesevisning}
-                    id={'bostedadresse'}
-                    label={'Barnets bostedsland'}
-                    kunEøs
-                    medFlag
-                    size="medium"
-                    kanNullstilles
-                    value={skjema.felter.barnetsBostedsland?.verdi}
-                    onChange={(value: Country) => {
-                        const nyVerdi = value ? value.value : undefined;
-                        skjema.felter.barnetsBostedsland.validerOgSettFelt(nyVerdi);
-                    }}
-                    feil={
-                        skjema.visFeilmeldinger &&
-                        skjema.felter.barnetsBostedsland.valideringsstatus === Valideringsstatus.FEIL
-                            ? skjema.felter.barnetsBostedsland?.feilmelding?.toString()
-                            : ''
-                    }
-                    utenMargin
-                />
+                {toggles[FeatureToggle.brukNyFlagCombobox] ? (
+                    <RegionCombobox
+                        label={'Søkers aktivitetsland'}
+                        value={skjema.felter.søkersAktivitetsland.verdi as Regionkode}
+                        options={EØS_LAND_REGIONKODER}
+                        onChange={value => {
+                            if (value) {
+                                skjema.felter.søkersAktivitetsland.validerOgSettFelt(value);
+                            } else {
+                                skjema.felter.søkersAktivitetsland.nullstill();
+                            }
+                        }}
+                        readOnly={lesevisning}
+                        error={
+                            skjema.visFeilmeldinger &&
+                            skjema.felter.søkersAktivitetsland.valideringsstatus === Valideringsstatus.FEIL
+                                ? skjema.felter.søkersAktivitetsland.feilmelding?.toString()
+                                : ''
+                        }
+                    />
+                ) : (
+                    <FamilieLandvelger
+                        erLesevisning={lesevisning}
+                        id={'søkersAktivitetsland'}
+                        label={'Søkers aktivitetsland'}
+                        kunEøs
+                        medFlag
+                        size="medium"
+                        kanNullstilles
+                        value={skjema.felter.søkersAktivitetsland.verdi}
+                        onChange={(value: Country) => {
+                            const nyVerdi = value ? value.value : undefined;
+                            skjema.felter.søkersAktivitetsland.validerOgSettFelt(nyVerdi);
+                        }}
+                        feil={
+                            skjema.visFeilmeldinger &&
+                            skjema.felter.søkersAktivitetsland.valideringsstatus === Valideringsstatus.FEIL
+                                ? skjema.felter.søkersAktivitetsland.feilmelding?.toString()
+                                : ''
+                        }
+                        utenMargin
+                    />
+                )}
+                {toggles[FeatureToggle.brukNyFlagCombobox] ? (
+                    <RegionCombobox
+                        label={'Annen forelders aktivitetsland'}
+                        value={skjema.felter.annenForeldersAktivitetsland.verdi as Regionkode}
+                        options={EØS_LAND_REGIONKODER}
+                        onChange={value => {
+                            if (value) {
+                                skjema.felter.annenForeldersAktivitetsland.validerOgSettFelt(value);
+                            } else {
+                                skjema.felter.annenForeldersAktivitetsland.nullstill();
+                            }
+                        }}
+                        readOnly={lesevisning}
+                        error={
+                            skjema.visFeilmeldinger &&
+                            skjema.felter.annenForeldersAktivitetsland.valideringsstatus === Valideringsstatus.FEIL
+                                ? skjema.felter.annenForeldersAktivitetsland.feilmelding?.toString()
+                                : ''
+                        }
+                    />
+                ) : (
+                    <FamilieLandvelger
+                        erLesevisning={lesevisning}
+                        id={'annenForeldersAktivitetsland'}
+                        label={'Annen forelders aktivitetsland'}
+                        kunEøs
+                        medFlag
+                        size="medium"
+                        kanNullstilles
+                        value={skjema.felter.annenForeldersAktivitetsland.verdi}
+                        onChange={(value: Country) => {
+                            const nyVerdi = value ? value.value : undefined;
+                            skjema.felter.annenForeldersAktivitetsland.validerOgSettFelt(nyVerdi);
+                        }}
+                        feil={
+                            skjema.visFeilmeldinger &&
+                            skjema.felter.annenForeldersAktivitetsland.valideringsstatus === Valideringsstatus.FEIL
+                                ? skjema.felter.annenForeldersAktivitetsland.feilmelding?.toString()
+                                : ''
+                        }
+                        utenMargin
+                    />
+                )}
+                {toggles[FeatureToggle.brukNyFlagCombobox] ? (
+                    <RegionCombobox
+                        label={'Barnets bostedsland'}
+                        value={skjema.felter.barnetsBostedsland.verdi as Regionkode}
+                        options={EØS_LAND_REGIONKODER}
+                        onChange={value => {
+                            if (value) {
+                                skjema.felter.barnetsBostedsland.validerOgSettFelt(value);
+                            } else {
+                                skjema.felter.barnetsBostedsland.nullstill();
+                            }
+                        }}
+                        readOnly={lesevisning}
+                        error={
+                            skjema.visFeilmeldinger &&
+                            skjema.felter.barnetsBostedsland.valideringsstatus === Valideringsstatus.FEIL
+                                ? skjema.felter.barnetsBostedsland.feilmelding?.toString()
+                                : ''
+                        }
+                    />
+                ) : (
+                    <FamilieLandvelger
+                        erLesevisning={lesevisning}
+                        id={'bostedadresse'}
+                        label={'Barnets bostedsland'}
+                        kunEøs
+                        medFlag
+                        size="medium"
+                        kanNullstilles
+                        value={skjema.felter.barnetsBostedsland?.verdi}
+                        onChange={(value: Country) => {
+                            const nyVerdi = value ? value.value : undefined;
+                            skjema.felter.barnetsBostedsland.validerOgSettFelt(nyVerdi);
+                        }}
+                        feil={
+                            skjema.visFeilmeldinger &&
+                            skjema.felter.barnetsBostedsland.valideringsstatus === Valideringsstatus.FEIL
+                                ? skjema.felter.barnetsBostedsland?.feilmelding?.toString()
+                                : ''
+                        }
+                        utenMargin
+                    />
+                )}
                 <Select
                     {...skjema.felter.resultat.hentNavInputProps(skjema.visFeilmeldinger)}
                     readOnly={lesevisning}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/form/LandkodeField.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/form/LandkodeField.module.css
@@ -1,3 +1,3 @@
 .landvelger {
-    max-width: 18rem;
+    max-width: 25rem;
 }

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/form/LandkodeField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/form/LandkodeField.tsx
@@ -4,6 +4,9 @@ import { useController, useFormContext } from 'react-hook-form';
 
 import Styles from './LandkodeField.module.css';
 import { Fields, type FormValues } from './useRefusjonEøsForm';
+import { useFeatureToggles } from '../../../../../../../hooks/useFeatureToggles';
+import { EØS_LAND_REGIONKODER, RegionCombobox, type Regionkode } from '../../../../../../../komponenter/FlaggCombobox';
+import { FeatureToggle } from '../../../../../../../typer/featureToggles';
 import { FamilieLandvelger } from '../../../Behandlingsresultat/Eøs/EøsKomponenter/FamilieLandvelger';
 
 interface Props {
@@ -11,6 +14,7 @@ interface Props {
 }
 
 export function LandkodeField({ readOnly = false }: Props) {
+    const toggles = useFeatureToggles();
     const id = useId();
 
     const { control } = useFormContext<FormValues>();
@@ -26,16 +30,30 @@ export function LandkodeField({ readOnly = false }: Props) {
     });
 
     return (
-        <FamilieLandvelger
-            id={`refusjon-eøs-form${id}`}
-            label={'EØS-land'}
-            kunEøs={true}
-            eksluderLand={['NO']}
-            value={value}
-            onChange={value => onChange(value.value)}
-            erLesevisning={readOnly || isSubmitting}
-            feil={error?.message}
-            className={Styles.landvelger}
-        />
+        <>
+            {toggles[FeatureToggle.brukNyFlagCombobox] ? (
+                <RegionCombobox
+                    label={'EØS-land'}
+                    value={value as Regionkode}
+                    options={EØS_LAND_REGIONKODER.filter(regionkode => regionkode !== 'NO')}
+                    onChange={value => onChange(value)}
+                    readOnly={readOnly || isSubmitting}
+                    error={error?.message}
+                    className={Styles.landvelger}
+                />
+            ) : (
+                <FamilieLandvelger
+                    id={`refusjon-eøs-form${id}`}
+                    label={'EØS-land'}
+                    kunEøs={true}
+                    eksluderLand={['NO']}
+                    value={value}
+                    onChange={value => onChange(value.value)}
+                    erLesevisning={readOnly || isSubmitting}
+                    feil={error?.message}
+                    className={Styles.landvelger}
+                />
+            )}
+        </>
     );
 }


### PR DESCRIPTION
### 📮 Favro
NAV-28039

### 💰 Hva skal gjøres, og hvorfor?
Tar i bruk ny komponent for å velge land slik at vi kan kvitte oss med tredjepartsavhengigheten til landvelger på sikt.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Fantes ingen eksisterende tester.

### 👀 Screen shots
Brevmottaker:

Ny:
<img width="457" height="796" alt="image" src="https://github.com/user-attachments/assets/5c36990a-4ab7-43ac-a58c-be2e3271a62e" />

Gammel:
<img width="457" height="792" alt="image" src="https://github.com/user-attachments/assets/5a7220c5-b117-4dcf-ae84-658b7b100de6" />

--- 

Kompetanse

Ny:
<img width="658" height="540" alt="image" src="https://github.com/user-attachments/assets/036a986c-71a9-40af-b840-a3a10ff58df0" />

Gammel:
<img width="658" height="536" alt="image" src="https://github.com/user-attachments/assets/d05ff473-355c-4125-8c67-3ff4434e6e07" />

---

Refusjon EØS:

Ny:
<img width="448" height="365" alt="image" src="https://github.com/user-attachments/assets/32777861-3856-49a9-ac94-1796479df7f4" />

Gammel:
<img width="448" height="365" alt="image" src="https://github.com/user-attachments/assets/0711f2c2-52b8-4e82-abb3-fcb1718ba4b7" />
