### PR TITLE
Slett overflow hidden for å vise hele dropdown

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
@@ -65,7 +65,6 @@ const BegrunnelserMultiselect = ({ tillatKunLesevisning }: IProps) => {
             Object.assign({}, provided, {
                 whiteSpace: 'pre-wrap',
                 textOverflow: 'hidden',
-                overflow: 'hidden',
             }),
     };
 
@@ -81,6 +80,8 @@ const BegrunnelserMultiselect = ({ tillatKunLesevisning }: IProps) => {
             creatable={false}
             erLesevisning={erLesevisning}
             isMulti={true}
+            menuPosition="fixed"
+            menuPortalTarget={typeof document !== 'undefined' ? document.body : null}
             onChange={(_, action: ActionMeta<OptionType>) => {
                 onChangeBegrunnelse(action);
             }}


### PR DESCRIPTION
### 📮 Favro: NAV-28386

### 💰 Hva skal gjøres, og hvorfor?
Tror dette oppstår etter oppgradering til aksel v8, men man får ikke valgt begrunnelse lenger, og da stopper jo hele behandlingen opp.

FØR
<img width="897" height="286" alt="Screenshot 2026-03-27 at 16 58 53" src="https://github.com/user-attachments/assets/ce3d0667-ad5c-4591-8b31-9ab17694df54" />

ETTER
<img width="982" height="734" alt="Screenshot 2026-03-27 at 17 08 20" src="https://github.com/user-attachments/assets/86de0328-06e4-407b-b9c6-3600ae6671a7" />
