### PR TITLE
NAV-28401: Refaktorer logikk rundt saksbehandler

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,21 +1,19 @@
 import '@navikt/ds-css';
 import './index.css';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
-import { hentInnloggetBruker } from './api/saksbehandler';
 import { Container } from './Container';
 import { AppProvider } from './context/AppContext';
 import { AuthContextProvider } from './context/AuthContext';
 import { FeatureTogglesProvider } from './context/FeatureTogglesContext';
 import { HttpContextProvider } from './context/HttpContext';
 import { ModalProvider } from './context/ModalContext';
-import { ErrorBoundary } from './komponenter/ErrorBoundary/ErrorBoundary';
+import { SaksbehandlerProvider } from './context/SaksbehandlerContext';
+import { ErrorBoundary, ErrorBoundaryMedSaksbehandler } from './komponenter/ErrorBoundary/ErrorBoundary';
 import { initGrafanaFaro } from './utils/grafanaFaro';
 import { erProd } from './utils/miljø';
 
@@ -28,31 +26,30 @@ const queryClient = new QueryClient({
 });
 
 const App = () => {
-    const [autentisertSaksbehandler, settInnloggetSaksbehandler] = useState<ISaksbehandler | undefined>(undefined);
-
     useEffect(() => {
         initGrafanaFaro();
-        hentInnloggetBruker().then((innhentetInnloggetSaksbehandler: ISaksbehandler) => {
-            settInnloggetSaksbehandler(innhentetInnloggetSaksbehandler);
-        });
     }, []);
 
     return (
-        <ErrorBoundary autentisertSaksbehandler={autentisertSaksbehandler}>
-            <AuthContextProvider autentisertSaksbehandler={autentisertSaksbehandler}>
-                <HttpContextProvider>
-                    <QueryClientProvider client={queryClient}>
-                        {!erProd() && <ReactQueryDevtools position={'right'} initialIsOpen={false} />}
-                        <FeatureTogglesProvider>
-                            <AppProvider>
-                                <ModalProvider>
-                                    <Container />
-                                </ModalProvider>
-                            </AppProvider>
-                        </FeatureTogglesProvider>
-                    </QueryClientProvider>
-                </HttpContextProvider>
-            </AuthContextProvider>
+        <ErrorBoundary>
+            <QueryClientProvider client={queryClient}>
+                {!erProd() && <ReactQueryDevtools position={'right'} initialIsOpen={false} />}
+                <SaksbehandlerProvider>
+                    <ErrorBoundaryMedSaksbehandler>
+                        <AuthContextProvider>
+                            <HttpContextProvider>
+                                <FeatureTogglesProvider>
+                                    <AppProvider>
+                                        <ModalProvider>
+                                            <Container />
+                                        </ModalProvider>
+                                    </AppProvider>
+                                </FeatureTogglesProvider>
+                            </HttpContextProvider>
+                        </AuthContextProvider>
+                    </ErrorBoundaryMedSaksbehandler>
+                </SaksbehandlerProvider>
+            </QueryClientProvider>
         </ErrorBoundary>
     );
 };

--- a/src/frontend/Container.tsx
+++ b/src/frontend/Container.tsx
@@ -19,7 +19,7 @@ import ManuellJournalføring from './sider/ManuellJournalføring/ManuellJournalf
 import { Oppgavebenk } from './sider/Oppgavebenk/Oppgavebenk';
 
 export function Container() {
-    const { autentisert, innloggetSaksbehandler, appInfoModal } = useAppContext();
+    const { autentisert, appInfoModal } = useAppContext();
     const { systemetLaster } = useHttp();
 
     return (
@@ -33,10 +33,7 @@ export function Container() {
                         <OpprettFagsakModal />
                         <FeilmeldingModal />
                         <ForhåndsvisOpprettingAvPdfModal />
-                        <HeaderMedSøk
-                            brukerNavn={innloggetSaksbehandler?.displayName}
-                            brukerEnhet={innloggetSaksbehandler?.enhet}
-                        />
+                        <HeaderMedSøk />
                         <Routes>
                             <Route path="/fagsak/:fagsakId/*" element={<FagsakContainer />} />
                             <Route path="/oppgaver/journalfor/:oppgaveId" element={<ManuellJournalføring />} />

--- a/src/frontend/api/hentSaksbehandler.test.ts
+++ b/src/frontend/api/hentSaksbehandler.test.ts
@@ -1,0 +1,56 @@
+import { http, HttpResponse } from 'msw';
+import { describe, it, expect } from 'vitest';
+
+import { hentSaksbehandler } from './hentSaksbehandler';
+import { server } from '../testutils/mocks/node';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+
+describe('hentSaksbehandler', () => {
+    it('skal hente saksbehandler', async () => {
+        // Arrange
+        const saksbehandler = lagSaksbehandler();
+
+        server.use(
+            http.get('/user/profile', () => {
+                return HttpResponse.json(saksbehandler);
+            })
+        );
+
+        // Act
+        const result = await hentSaksbehandler();
+
+        // Assert
+        expect(result).toEqual(saksbehandler);
+    });
+
+    it('skal returnere en tom liste for groups hvis ingen gruppe er definert', async () => {
+        // Arrange
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { groups, ...saksbehandlerUtenGrupper } = lagSaksbehandler();
+
+        server.use(
+            http.get('/user/profile', () => {
+                return HttpResponse.json(saksbehandlerUtenGrupper);
+            })
+        );
+
+        // Act
+        const result = await hentSaksbehandler();
+
+        // Assert
+        expect(result.groups).toEqual([]);
+        expect(result.displayName).toBe('Sak Behandler');
+    });
+
+    it('skal kaste en feil hvis API-kallet feiler', async () => {
+        // Arrange
+        server.use(
+            http.get('/user/profile', () => {
+                return new HttpResponse(null, { status: 401, statusText: 'Unauthorized' });
+            })
+        );
+
+        // Act & assert
+        expect(hentSaksbehandler()).rejects.toThrow();
+    });
+});

--- a/src/frontend/api/hentSaksbehandler.test.ts
+++ b/src/frontend/api/hentSaksbehandler.test.ts
@@ -3,16 +3,16 @@ import { describe, it, expect } from 'vitest';
 
 import { hentSaksbehandler } from './hentSaksbehandler';
 import { server } from '../testutils/mocks/node';
-import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { lagISaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
 
 describe('hentSaksbehandler', () => {
     it('skal hente saksbehandler', async () => {
         // Arrange
-        const saksbehandler = lagSaksbehandler();
+        const iSaksbehandler = lagISaksbehandler();
 
         server.use(
             http.get('/user/profile', () => {
-                return HttpResponse.json(saksbehandler);
+                return HttpResponse.json(iSaksbehandler);
             })
         );
 
@@ -20,26 +20,7 @@ describe('hentSaksbehandler', () => {
         const result = await hentSaksbehandler();
 
         // Assert
-        expect(result).toEqual(saksbehandler);
-    });
-
-    it('skal returnere en tom liste for groups hvis ingen gruppe er definert', async () => {
-        // Arrange
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { groups, ...saksbehandlerUtenGrupper } = lagSaksbehandler();
-
-        server.use(
-            http.get('/user/profile', () => {
-                return HttpResponse.json(saksbehandlerUtenGrupper);
-            })
-        );
-
-        // Act
-        const result = await hentSaksbehandler();
-
-        // Assert
-        expect(result.groups).toEqual([]);
-        expect(result.displayName).toBe('Sak Behandler');
+        expect(result).toEqual(iSaksbehandler);
     });
 
     it('skal kaste en feil hvis API-kallet feiler', async () => {

--- a/src/frontend/api/hentSaksbehandler.ts
+++ b/src/frontend/api/hentSaksbehandler.ts
@@ -1,0 +1,12 @@
+import { preferredAxios } from '@navikt/familie-http';
+import type { ISaksbehandler } from '@navikt/familie-typer';
+
+import type { Saksbehandler } from '../typer/saksbehandler';
+
+export async function hentSaksbehandler(): Promise<Saksbehandler> {
+    const response = await preferredAxios.get<ISaksbehandler>(`/user/profile`);
+    return {
+        ...response.data,
+        groups: response.data.groups ?? [],
+    };
+}

--- a/src/frontend/api/hentSaksbehandler.ts
+++ b/src/frontend/api/hentSaksbehandler.ts
@@ -1,12 +1,7 @@
 import { preferredAxios } from '@navikt/familie-http';
 import type { ISaksbehandler } from '@navikt/familie-typer';
 
-import type { Saksbehandler } from '../typer/saksbehandler';
-
-export async function hentSaksbehandler(): Promise<Saksbehandler> {
+export async function hentSaksbehandler(): Promise<ISaksbehandler> {
     const response = await preferredAxios.get<ISaksbehandler>(`/user/profile`);
-    return {
-        ...response.data,
-        groups: response.data.groups ?? [],
-    };
+    return response.data;
 }

--- a/src/frontend/api/saksbehandler.ts
+++ b/src/frontend/api/saksbehandler.ts
@@ -1,7 +1,0 @@
-import { preferredAxios } from '@navikt/familie-http';
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
-export const hentInnloggetBruker = async (): Promise<ISaksbehandler> => {
-    const svar = await preferredAxios.get<ISaksbehandler>(`/user/profile`);
-    return svar.data;
-};

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -12,17 +12,16 @@ import type { AxiosRequestConfig } from 'axios';
 
 import { Alert, BodyShort, Button } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
-import type { ISaksbehandler, Ressurs } from '@navikt/familie-typer';
+import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useAuthContext } from './AuthContext';
 import { useFeatureToggles } from '../hooks/useFeatureToggles';
+import { useSaksbehandler } from '../hooks/useSaksbehandler';
 import type { IToast, ToastTyper } from '../komponenter/Toast/typer';
-import { BehandlerRolle } from '../typer/behandling';
 import { FeatureToggle } from '../typer/featureToggles';
 import type { IRestTilgang } from '../typer/person';
 import { adressebeskyttelsestyper } from '../typer/person';
-import { gruppeIdTilRolle, gruppeIdTilSuperbrukerRolle } from '../utils/behandling';
 
 export type FamilieAxiosRequestConfig<D> = AxiosRequestConfig & {
     data?: D;
@@ -44,10 +43,6 @@ const initalState: IModal = {
 
 interface AppContextValue {
     autentisert: boolean;
-    hentSaksbehandlerRolle: () => BehandlerRolle;
-    innloggetSaksbehandler: ISaksbehandler | undefined;
-    harInnloggetSaksbehandlerSkrivetilgang: () => boolean;
-    harInnloggetSaksbehandlerSuperbrukerTilgang: () => boolean | undefined;
     lukkModal: () => void;
     appInfoModal: IModal;
     settToast: (toastId: ToastTyper, toast: IToast) => void;
@@ -66,12 +61,14 @@ interface AppContextValue {
 const AppContext = createContext<AppContextValue | undefined>(undefined);
 
 const AppProvider = (props: PropsWithChildren) => {
-    const { autentisert, innloggetSaksbehandler } = useAuthContext();
+    const { autentisert } = useAuthContext();
     const { request } = useHttp();
     const toggles = useFeatureToggles();
 
     const [appInfoModal, settAppInfoModal] = useState<IModal>(initalState);
     const [toasts, settToasts] = useState<{ [toastId: string]: IToast }>({});
+
+    const saksbehandler = useSaksbehandler();
 
     const lukkModal = () => {
         settAppInfoModal(initalState);
@@ -117,40 +114,12 @@ const AppProvider = (props: PropsWithChildren) => {
         });
     };
 
-    const hentSaksbehandlerRolle = (): BehandlerRolle => {
-        let rolle = BehandlerRolle.UKJENT;
-        if (innloggetSaksbehandler && innloggetSaksbehandler.groups) {
-            innloggetSaksbehandler.groups.forEach((id: string) => {
-                rolle = rolle < gruppeIdTilRolle(id) ? gruppeIdTilRolle(id) : rolle;
-            });
-        }
-
-        if (innloggetSaksbehandler && rolle === BehandlerRolle.UKJENT) {
-            throw new Error('Finner ikke rolle til saksbehandler.');
-        }
-
-        return rolle;
-    };
-
-    const harInnloggetSaksbehandlerSuperbrukerTilgang = () =>
-        innloggetSaksbehandler?.groups?.includes(gruppeIdTilSuperbrukerRolle);
-
-    const harInnloggetSaksbehandlerSkrivetilgang = () => {
-        const rolle = hentSaksbehandlerRolle();
-
-        return rolle >= BehandlerRolle.SAKSBEHANDLER;
-    };
-
-    const skalObfuskereData = toggles[FeatureToggle.skalObfuskereData] && !harInnloggetSaksbehandlerSkrivetilgang();
+    const skalObfuskereData = toggles[FeatureToggle.skalObfuskereData] && !saksbehandler.harSkrivetilgang;
 
     return (
         <AppContext.Provider
             value={{
                 autentisert,
-                hentSaksbehandlerRolle,
-                innloggetSaksbehandler,
-                harInnloggetSaksbehandlerSkrivetilgang,
-                harInnloggetSaksbehandlerSuperbrukerTilgang,
                 lukkModal,
                 appInfoModal,
                 settToast: (toastId: ToastTyper, toast: IToast) =>

--- a/src/frontend/context/AuthContext.tsx
+++ b/src/frontend/context/AuthContext.tsx
@@ -1,35 +1,17 @@
 import { type PropsWithChildren, useContext, useState } from 'react';
-import { createContext, useEffect } from 'react';
-
-import type { ISaksbehandler } from '@navikt/familie-typer';
+import { createContext } from 'react';
 
 interface Context {
     autentisert: boolean;
     settAutentisert: (autentisert: boolean) => void;
-    innloggetSaksbehandler: ISaksbehandler | undefined;
 }
 
 const AuthContext = createContext<Context | undefined>(undefined);
 
-interface Props extends PropsWithChildren {
-    autentisertSaksbehandler: ISaksbehandler | undefined;
-}
-
-export function AuthContextProvider({ autentisertSaksbehandler, children }: Props) {
+export function AuthContextProvider({ children }: PropsWithChildren) {
     const [autentisert, settAutentisert] = useState(true);
-    const [innloggetSaksbehandler, settInnloggetSaksbehandler] = useState(autentisertSaksbehandler);
 
-    useEffect(() => {
-        if (autentisertSaksbehandler) {
-            settInnloggetSaksbehandler(autentisertSaksbehandler);
-        }
-    }, [autentisertSaksbehandler]);
-
-    return (
-        <AuthContext.Provider value={{ autentisert, settAutentisert, innloggetSaksbehandler }}>
-            {children}
-        </AuthContext.Provider>
-    );
+    return <AuthContext.Provider value={{ autentisert, settAutentisert }}>{children}</AuthContext.Provider>;
 }
 
 export function useAuthContext() {

--- a/src/frontend/context/HttpContext.tsx
+++ b/src/frontend/context/HttpContext.tsx
@@ -3,17 +3,20 @@ import type { PropsWithChildren } from 'react';
 import { HttpProvider } from '@navikt/familie-http';
 
 import { useAuthContext } from './AuthContext';
+import { useSaksbehandler } from '../hooks/useSaksbehandler';
 
 interface Props extends PropsWithChildren {
     fjernRessursSomLasterTimeout?: number;
 }
 
 export function HttpContextProvider({ fjernRessursSomLasterTimeout = 300, children }: Props) {
-    const { innloggetSaksbehandler, settAutentisert } = useAuthContext();
+    const { settAutentisert } = useAuthContext();
+
+    const saksbehandler = useSaksbehandler();
 
     return (
         <HttpProvider
-            innloggetSaksbehandler={innloggetSaksbehandler}
+            innloggetSaksbehandler={saksbehandler}
             settAutentisert={settAutentisert}
             fjernRessursSomLasterTimeout={fjernRessursSomLasterTimeout}
         >

--- a/src/frontend/context/SaksbehandlerContext.test.tsx
+++ b/src/frontend/context/SaksbehandlerContext.test.tsx
@@ -1,0 +1,102 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { SaksbehandlerProvider, useSaksbehandlerContext } from './SaksbehandlerContext';
+import { useHentSaksbehandler } from '../hooks/useHentSaksbehandler';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import type { Saksbehandler } from '../typer/saksbehandler';
+
+vi.mock('../hooks/useHentSaksbehandler', () => ({
+    useHentSaksbehandler: vi.fn(),
+}));
+
+function TestConsumer() {
+    const { saksbehandler } = useSaksbehandlerContext();
+    return <div>Logget inn som: {saksbehandler.displayName}</div>;
+}
+
+describe('SaksbehandlerContext', () => {
+    beforeEach(() => {
+        vi.mocked(useHentSaksbehandler).mockReset();
+    });
+
+    it('skal vise systemet laster ved innlasting', () => {
+        // Arrange
+        const resultat = {
+            data: undefined,
+            isPending: true,
+            error: null,
+        } as UseQueryResult<Saksbehandler, Error>;
+
+        vi.mocked(useHentSaksbehandler).mockReturnValue(resultat);
+
+        // Act
+        render(
+            <SaksbehandlerProvider>
+                <div>Should not be visible yet</div>
+            </SaksbehandlerProvider>
+        );
+
+        // Assert
+        expect(screen.queryByText('Should not be visible yet')).not.toBeInTheDocument();
+        expect(screen.queryByText('Systemet laster')).toBeInTheDocument();
+    });
+
+    it('skal vise feilmelding hvis feil oppstår ved API-kallet', () => {
+        // Arrange
+        const resultat = {
+            data: undefined,
+            isPending: false,
+            error: new Error('Nettverksfeil'),
+        } as UseQueryResult<Saksbehandler, Error>;
+
+        vi.mocked(useHentSaksbehandler).mockReturnValue(resultat);
+
+        // Act
+        render(
+            <SaksbehandlerProvider>
+                <div>Burde være usynlig</div>
+            </SaksbehandlerProvider>
+        );
+
+        // Assert
+        expect(screen.getByText('Feil oppstod ved innlasting av saksbehandler')).toBeInTheDocument();
+        expect(screen.getByText('Nettverksfeil')).toBeInTheDocument();
+        expect(screen.queryByText('Burde være usynlig')).not.toBeInTheDocument();
+    });
+
+    it('skal eksponere saksbehandler til children', () => {
+        // Arrange
+        const resultat = {
+            data: lagSaksbehandler(),
+            isPending: false,
+            error: null,
+        } as UseQueryResult<Saksbehandler, Error>;
+
+        vi.mocked(useHentSaksbehandler).mockReturnValue(resultat);
+
+        // Act
+        render(
+            <SaksbehandlerProvider>
+                <TestConsumer />
+            </SaksbehandlerProvider>
+        );
+
+        // Assert
+        expect(screen.getByText('Logget inn som: Sak Behandler')).toBeInTheDocument();
+    });
+
+    it('skal kaste feil hvis useSaksbehandlerContext brukes utenfor SaksbehandlerProvider', () => {
+        // Arrange
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        // Act & assert
+        expect(() => render(<TestConsumer />)).toThrow(
+            'useSaksbehandlerContext må brukes innenfor en SaksbehandlerProvider'
+        );
+
+        // Cleanup
+        consoleSpy.mockRestore();
+    });
+});

--- a/src/frontend/context/SaksbehandlerContext.tsx
+++ b/src/frontend/context/SaksbehandlerContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, type PropsWithChildren, useContext } from 'react';
 
-import { Box, LocalAlert } from '@navikt/ds-react';
+import { Box, GlobalAlert } from '@navikt/ds-react';
 
 import { useHentSaksbehandler } from '../hooks/useHentSaksbehandler';
 import SystemetLaster from '../komponenter/SystemetLaster/SystemetLaster';
@@ -26,12 +26,12 @@ export function SaksbehandlerProvider({ saksbehandler, children }: Props) {
     if (error) {
         return (
             <Box padding={'space-8'}>
-                <LocalAlert status={'error'}>
-                    <LocalAlert.Header>
-                        <LocalAlert.Title>Feil oppstod ved innlasting av saksbehandler</LocalAlert.Title>
-                    </LocalAlert.Header>
-                    <LocalAlert.Content>{error.message ?? 'En ukjent feil oppstod.'}</LocalAlert.Content>
-                </LocalAlert>
+                <GlobalAlert status={'error'}>
+                    <GlobalAlert.Header>
+                        <GlobalAlert.Title>Feil oppstod ved innlasting av saksbehandler</GlobalAlert.Title>
+                    </GlobalAlert.Header>
+                    <GlobalAlert.Content>{error.message ?? 'En ukjent feil oppstod.'}</GlobalAlert.Content>
+                </GlobalAlert>
             </Box>
         );
     }

--- a/src/frontend/context/SaksbehandlerContext.tsx
+++ b/src/frontend/context/SaksbehandlerContext.tsx
@@ -1,0 +1,48 @@
+import { createContext, type PropsWithChildren, useContext } from 'react';
+
+import { Box, LocalAlert } from '@navikt/ds-react';
+
+import { useHentSaksbehandler } from '../hooks/useHentSaksbehandler';
+import SystemetLaster from '../komponenter/SystemetLaster/SystemetLaster';
+import type { Saksbehandler } from '../typer/saksbehandler';
+
+interface Context {
+    saksbehandler: Saksbehandler;
+}
+
+const Context = createContext<Context | undefined>(undefined);
+
+interface Props extends PropsWithChildren {
+    saksbehandler?: Saksbehandler;
+}
+
+export function SaksbehandlerProvider({ saksbehandler, children }: Props) {
+    const { data, isPending, error } = useHentSaksbehandler({ initialData: saksbehandler });
+
+    if (isPending) {
+        return <SystemetLaster />;
+    }
+
+    if (error) {
+        return (
+            <Box padding={'space-8'}>
+                <LocalAlert status={'error'}>
+                    <LocalAlert.Header>
+                        <LocalAlert.Title>Feil oppstod ved innlasting av saksbehandler</LocalAlert.Title>
+                    </LocalAlert.Header>
+                    <LocalAlert.Content>{error.message ?? 'En ukjent feil oppstod.'}</LocalAlert.Content>
+                </LocalAlert>
+            </Box>
+        );
+    }
+
+    return <Context.Provider value={{ saksbehandler: data }}>{children}</Context.Provider>;
+}
+
+export function useSaksbehandlerContext() {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useSaksbehandlerContext må brukes innenfor en SaksbehandlerProvider');
+    }
+    return context;
+}

--- a/src/frontend/hooks/useHentSaksbehandler.test.tsx
+++ b/src/frontend/hooks/useHentSaksbehandler.test.tsx
@@ -1,0 +1,91 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useHentSaksbehandler } from './useHentSaksbehandler';
+import { hentSaksbehandler } from '../api/hentSaksbehandler';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+
+vi.mock('../api/hentSaksbehandler', () => ({
+    hentSaksbehandler: vi.fn(),
+}));
+
+const createTestQueryClient = () =>
+    new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+
+describe('useHentSaksbehandler', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('skal hente saksbehandler', async () => {
+        // Arrange
+        const saksbehandler = lagSaksbehandler();
+        vi.mocked(hentSaksbehandler).mockResolvedValueOnce(saksbehandler);
+
+        const queryClient = createTestQueryClient();
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        );
+
+        // Act
+        const { result } = renderHook(() => useHentSaksbehandler(), { wrapper });
+
+        // Assert
+        expect(result.current.isPending).toBe(true);
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(result.current.data).toBe(saksbehandler);
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.error).toBe(null);
+        expect(hentSaksbehandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('skal håndtere feil ved API-kallet', async () => {
+        // Arrange
+        const networkError = new Error('Nettverksfeil');
+        vi.mocked(hentSaksbehandler).mockRejectedValueOnce(networkError);
+
+        const queryClient = createTestQueryClient();
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        );
+
+        // Suppress console.error for clean test output (React Query logs errors to console)
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        // Act
+        const { result } = renderHook(() => useHentSaksbehandler(), { wrapper });
+
+        // Assert
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.data).toBe(undefined);
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.error).toBe(networkError);
+
+        // Cleanup
+        consoleSpy.mockRestore();
+    });
+
+    it('skal kunne sette initialData', () => {
+        // Arrange
+        const saksbehandler = lagSaksbehandler();
+        const queryClient = createTestQueryClient();
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        );
+
+        // Act
+        const { result } = renderHook(() => useHentSaksbehandler({ initialData: saksbehandler }), { wrapper });
+
+        // Assert
+        expect(result.current.data).toBe(saksbehandler);
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.error).toBe(null);
+    });
+});

--- a/src/frontend/hooks/useHentSaksbehandler.test.tsx
+++ b/src/frontend/hooks/useHentSaksbehandler.test.tsx
@@ -4,7 +4,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { useHentSaksbehandler } from './useHentSaksbehandler';
 import { hentSaksbehandler } from '../api/hentSaksbehandler';
-import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { lagISaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { BehandlerRolle } from '../typer/behandling';
 
 vi.mock('../api/hentSaksbehandler', () => ({
     hentSaksbehandler: vi.fn(),
@@ -26,8 +27,8 @@ describe('useHentSaksbehandler', () => {
 
     it('skal hente saksbehandler', async () => {
         // Arrange
-        const saksbehandler = lagSaksbehandler();
-        vi.mocked(hentSaksbehandler).mockResolvedValueOnce(saksbehandler);
+        const iSaksbehandler = lagISaksbehandler();
+        vi.mocked(hentSaksbehandler).mockResolvedValueOnce(iSaksbehandler);
 
         const queryClient = createTestQueryClient();
         const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -40,7 +41,12 @@ describe('useHentSaksbehandler', () => {
         // Assert
         expect(result.current.isPending).toBe(true);
         await waitFor(() => expect(result.current.isSuccess).toBe(true));
-        expect(result.current.data).toBe(saksbehandler);
+        expect(result.current.data).toEqual({
+            ...iSaksbehandler,
+            rolle: BehandlerRolle.SAKSBEHANDLER,
+            harSkrivetilgang: true,
+            harSuperbrukertilgang: false,
+        });
         expect(result.current.isPending).toBe(false);
         expect(result.current.error).toBe(null);
         expect(hentSaksbehandler).toHaveBeenCalledTimes(1);
@@ -74,17 +80,22 @@ describe('useHentSaksbehandler', () => {
 
     it('skal kunne sette initialData', () => {
         // Arrange
-        const saksbehandler = lagSaksbehandler();
+        const iSaksbehandler = lagISaksbehandler();
         const queryClient = createTestQueryClient();
         const wrapper = ({ children }: { children: React.ReactNode }) => (
             <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
         );
 
         // Act
-        const { result } = renderHook(() => useHentSaksbehandler({ initialData: saksbehandler }), { wrapper });
+        const { result } = renderHook(() => useHentSaksbehandler({ initialData: iSaksbehandler }), { wrapper });
 
         // Assert
-        expect(result.current.data).toBe(saksbehandler);
+        expect(result.current.data).toEqual({
+            ...iSaksbehandler,
+            rolle: BehandlerRolle.SAKSBEHANDLER,
+            harSkrivetilgang: true,
+            harSuperbrukertilgang: false,
+        });
         expect(result.current.isPending).toBe(false);
         expect(result.current.error).toBe(null);
     });

--- a/src/frontend/hooks/useHentSaksbehandler.ts
+++ b/src/frontend/hooks/useHentSaksbehandler.ts
@@ -1,17 +1,20 @@
 import { type DefaultError, useQuery, type UseQueryOptions } from '@tanstack/react-query';
 
+import type { ISaksbehandler } from '@navikt/familie-typer';
+
 import { hentSaksbehandler } from '../api/hentSaksbehandler';
-import type { Saksbehandler } from '../typer/saksbehandler';
+import { mapISaksbehandlerTilSaksbehandler, type Saksbehandler } from '../typer/saksbehandler';
 
 type Options = Omit<
-    UseQueryOptions<Saksbehandler, DefaultError, Saksbehandler>,
-    'queryKey' | 'queryFn' | 'gcTime' | 'staleTime'
+    UseQueryOptions<ISaksbehandler, DefaultError, Saksbehandler>,
+    'queryKey' | 'queryFn' | 'gcTime' | 'staleTime' | 'select'
 >;
 
 export function useHentSaksbehandler(options?: Options) {
     return useQuery({
         queryKey: ['saksbehandler'],
-        queryFn: () => hentSaksbehandler(),
+        queryFn: hentSaksbehandler,
+        select: mapISaksbehandlerTilSaksbehandler,
         gcTime: 0,
         staleTime: 0,
         ...options,

--- a/src/frontend/hooks/useHentSaksbehandler.ts
+++ b/src/frontend/hooks/useHentSaksbehandler.ts
@@ -1,0 +1,19 @@
+import { type DefaultError, useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+import { hentSaksbehandler } from '../api/hentSaksbehandler';
+import type { Saksbehandler } from '../typer/saksbehandler';
+
+type Options = Omit<
+    UseQueryOptions<Saksbehandler, DefaultError, Saksbehandler>,
+    'queryKey' | 'queryFn' | 'gcTime' | 'staleTime'
+>;
+
+export function useHentSaksbehandler(options?: Options) {
+    return useQuery({
+        queryKey: ['saksbehandler'],
+        queryFn: () => hentSaksbehandler(),
+        gcTime: 0,
+        staleTime: 0,
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useSaksbehandler.test.ts
+++ b/src/frontend/hooks/useSaksbehandler.test.ts
@@ -15,7 +15,7 @@ describe('useSaksbehandler', () => {
         vi.clearAllMocks();
     });
 
-    it('skal hente saksbehandler med skrivetilgang', () => {
+    it('skal hente saksbehandler', () => {
         // Arrange
         const saksbehandler = lagSaksbehandler();
 
@@ -35,54 +35,6 @@ describe('useSaksbehandler', () => {
         expect(result.current.navIdent).toBe('A1');
         expect(result.current.rolle).toBe(BehandlerRolle.SAKSBEHANDLER);
         expect(result.current.harSkrivetilgang).toBe(true);
-        expect(result.current.harSuperbrukertilgang).toBe(false);
-    });
-
-    it('skal hente saksbehandler med skrivetilgang og superbrukertilgang', () => {
-        // Arrange
-        const grupper = ['c7e0b108-7ae6-432c-9ab4-946174c240c0', '314fa714-f13c-4cdc-ac5c-e13ce08e241c'];
-        const saksbehandler = lagSaksbehandler({ groups: grupper });
-
-        vi.mocked(useSaksbehandlerContext).mockReturnValue({ saksbehandler });
-
-        // Act
-        const { result } = renderHook(() => useSaksbehandler());
-
-        // Assert
-        expect(result.current.displayName).toBe('Sak Behandler');
-        expect(result.current.email).toBe('saksbehandler@nav.no');
-        expect(result.current.firstName).toBe('Sak');
-        expect(result.current.groups).toStrictEqual(grupper);
-        expect(result.current.identifier).toBe('30987654321');
-        expect(result.current.lastName).toBe('Behandler');
-        expect(result.current.enhet).toBe('0001');
-        expect(result.current.navIdent).toBe('A1');
-        expect(result.current.rolle).toBe(BehandlerRolle.SAKSBEHANDLER);
-        expect(result.current.harSkrivetilgang).toBe(true);
-        expect(result.current.harSuperbrukertilgang).toBe(true);
-    });
-
-    it('skal hente saksbehandler uten skrivetilgang eller superbrukertilgang', () => {
-        // Arrange
-        const grupper = ['71f503a2-c28f-4394-a05a-8da263ceca4a'];
-        const saksbehandler = lagSaksbehandler({ groups: grupper });
-
-        vi.mocked(useSaksbehandlerContext).mockReturnValue({ saksbehandler });
-
-        // Act
-        const { result } = renderHook(() => useSaksbehandler());
-
-        // Assert
-        expect(result.current.displayName).toBe('Sak Behandler');
-        expect(result.current.email).toBe('saksbehandler@nav.no');
-        expect(result.current.firstName).toBe('Sak');
-        expect(result.current.groups).toStrictEqual(grupper);
-        expect(result.current.identifier).toBe('30987654321');
-        expect(result.current.lastName).toBe('Behandler');
-        expect(result.current.enhet).toBe('0001');
-        expect(result.current.navIdent).toBe('A1');
-        expect(result.current.rolle).toBe(BehandlerRolle.VEILEDER);
-        expect(result.current.harSkrivetilgang).toBe(false);
         expect(result.current.harSuperbrukertilgang).toBe(false);
     });
 });

--- a/src/frontend/hooks/useSaksbehandler.test.ts
+++ b/src/frontend/hooks/useSaksbehandler.test.ts
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useSaksbehandler } from './useSaksbehandler';
+import { useSaksbehandlerContext } from '../context/SaksbehandlerContext';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { BehandlerRolle } from '../typer/behandling';
+
+vi.mock('../context/SaksbehandlerContext', () => ({
+    useSaksbehandlerContext: vi.fn(),
+}));
+
+describe('useSaksbehandler', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('skal hente saksbehandler med skrivetilgang', () => {
+        // Arrange
+        const saksbehandler = lagSaksbehandler();
+
+        vi.mocked(useSaksbehandlerContext).mockReturnValue({ saksbehandler });
+
+        // Act
+        const { result } = renderHook(() => useSaksbehandler());
+
+        // Assert
+        expect(result.current.displayName).toBe('Sak Behandler');
+        expect(result.current.email).toBe('saksbehandler@nav.no');
+        expect(result.current.firstName).toBe('Sak');
+        expect(result.current.groups).toStrictEqual(['c7e0b108-7ae6-432c-9ab4-946174c240c0']);
+        expect(result.current.identifier).toBe('30987654321');
+        expect(result.current.lastName).toBe('Behandler');
+        expect(result.current.enhet).toBe('0001');
+        expect(result.current.navIdent).toBe('A1');
+        expect(result.current.rolle).toBe(BehandlerRolle.SAKSBEHANDLER);
+        expect(result.current.harSkrivetilgang).toBe(true);
+        expect(result.current.harSuperbrukertilgang).toBe(false);
+    });
+
+    it('skal hente saksbehandler med skrivetilgang og superbrukertilgang', () => {
+        // Arrange
+        const grupper = ['c7e0b108-7ae6-432c-9ab4-946174c240c0', '314fa714-f13c-4cdc-ac5c-e13ce08e241c'];
+        const saksbehandler = lagSaksbehandler({ groups: grupper });
+
+        vi.mocked(useSaksbehandlerContext).mockReturnValue({ saksbehandler });
+
+        // Act
+        const { result } = renderHook(() => useSaksbehandler());
+
+        // Assert
+        expect(result.current.displayName).toBe('Sak Behandler');
+        expect(result.current.email).toBe('saksbehandler@nav.no');
+        expect(result.current.firstName).toBe('Sak');
+        expect(result.current.groups).toStrictEqual(grupper);
+        expect(result.current.identifier).toBe('30987654321');
+        expect(result.current.lastName).toBe('Behandler');
+        expect(result.current.enhet).toBe('0001');
+        expect(result.current.navIdent).toBe('A1');
+        expect(result.current.rolle).toBe(BehandlerRolle.SAKSBEHANDLER);
+        expect(result.current.harSkrivetilgang).toBe(true);
+        expect(result.current.harSuperbrukertilgang).toBe(true);
+    });
+
+    it('skal hente saksbehandler uten skrivetilgang eller superbrukertilgang', () => {
+        // Arrange
+        const grupper = ['71f503a2-c28f-4394-a05a-8da263ceca4a'];
+        const saksbehandler = lagSaksbehandler({ groups: grupper });
+
+        vi.mocked(useSaksbehandlerContext).mockReturnValue({ saksbehandler });
+
+        // Act
+        const { result } = renderHook(() => useSaksbehandler());
+
+        // Assert
+        expect(result.current.displayName).toBe('Sak Behandler');
+        expect(result.current.email).toBe('saksbehandler@nav.no');
+        expect(result.current.firstName).toBe('Sak');
+        expect(result.current.groups).toStrictEqual(grupper);
+        expect(result.current.identifier).toBe('30987654321');
+        expect(result.current.lastName).toBe('Behandler');
+        expect(result.current.enhet).toBe('0001');
+        expect(result.current.navIdent).toBe('A1');
+        expect(result.current.rolle).toBe(BehandlerRolle.VEILEDER);
+        expect(result.current.harSkrivetilgang).toBe(false);
+        expect(result.current.harSuperbrukertilgang).toBe(false);
+    });
+});

--- a/src/frontend/hooks/useSaksbehandler.ts
+++ b/src/frontend/hooks/useSaksbehandler.ts
@@ -1,17 +1,6 @@
-import { useMemo } from 'react';
-
 import { useSaksbehandlerContext } from '../context/SaksbehandlerContext';
-import { harSkrivetilgang, harSuperbrukertilgang, utledBehandlerRolle } from '../typer/saksbehandler';
 
 export function useSaksbehandler() {
     const { saksbehandler } = useSaksbehandlerContext();
-
-    return useMemo(() => {
-        return {
-            ...saksbehandler,
-            rolle: utledBehandlerRolle(saksbehandler),
-            harSuperbrukertilgang: harSuperbrukertilgang(saksbehandler),
-            harSkrivetilgang: harSkrivetilgang(saksbehandler),
-        };
-    }, [saksbehandler]);
+    return saksbehandler;
 }

--- a/src/frontend/hooks/useSaksbehandler.ts
+++ b/src/frontend/hooks/useSaksbehandler.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { useSaksbehandlerContext } from '../context/SaksbehandlerContext';
-import { harSkrivetilgang, harSuperbrukerTilgang, utledBehandlerRolle } from '../typer/saksbehandler';
+import { harSkrivetilgang, harSuperbrukertilgang, utledBehandlerRolle } from '../typer/saksbehandler';
 
 export function useSaksbehandler() {
     const { saksbehandler } = useSaksbehandlerContext();
@@ -10,7 +10,7 @@ export function useSaksbehandler() {
         return {
             ...saksbehandler,
             rolle: utledBehandlerRolle(saksbehandler),
-            harSuperbrukertilgang: harSuperbrukerTilgang(saksbehandler),
+            harSuperbrukertilgang: harSuperbrukertilgang(saksbehandler),
             harSkrivetilgang: harSkrivetilgang(saksbehandler),
         };
     }, [saksbehandler]);

--- a/src/frontend/hooks/useSaksbehandler.ts
+++ b/src/frontend/hooks/useSaksbehandler.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+
+import { useSaksbehandlerContext } from '../context/SaksbehandlerContext';
+import { harSkrivetilgang, harSuperbrukerTilgang, utledBehandlerRolle } from '../typer/saksbehandler';
+
+export function useSaksbehandler() {
+    const { saksbehandler } = useSaksbehandlerContext();
+
+    return useMemo(() => {
+        return {
+            ...saksbehandler,
+            rolle: utledBehandlerRolle(saksbehandler),
+            harSuperbrukertilgang: harSuperbrukerTilgang(saksbehandler),
+            harSkrivetilgang: harSkrivetilgang(saksbehandler),
+        };
+    }, [saksbehandler]);
+}

--- a/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.module.css
+++ b/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.module.css
@@ -1,6 +1,0 @@
-.container {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100vh;
-}

--- a/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.tsx
@@ -1,16 +1,15 @@
-import type { PropsWithChildren, ReactNode } from 'react';
-import { Component } from 'react';
+import { Component, type PropsWithChildren, type ReactNode } from 'react';
 
 import * as Sentry from '@sentry/browser';
 
 import { XMarkOctagonIcon } from '@navikt/aksel-icons';
 import { BodyShort, Button, ErrorMessage, Heading, HStack, VStack } from '@navikt/ds-react';
-import type { ISaksbehandler } from '@navikt/familie-typer';
 
-import Styles from './ErrorBoundary.module.css';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 
 interface Props extends PropsWithChildren {
-    autentisertSaksbehandler?: ISaksbehandler;
+    saksbehandler?: Saksbehandler;
 }
 
 interface State {
@@ -34,10 +33,8 @@ export class ErrorBoundary extends Component<Props, State> {
         console.error(error, info);
         if (Sentry.isEnabled()) {
             Sentry.setUser({
-                username: this.props.autentisertSaksbehandler
-                    ? this.props.autentisertSaksbehandler.displayName
-                    : 'Ukjent bruker',
-                email: this.props.autentisertSaksbehandler ? this.props.autentisertSaksbehandler.email : 'Ukjent email',
+                username: this.props.saksbehandler?.displayName ?? 'Ukjent navn',
+                email: this.props.saksbehandler?.email ?? 'Ukjent e-post',
             });
             Sentry.withScope(scope => {
                 Object.keys(info).forEach(key => {
@@ -45,7 +42,6 @@ export class ErrorBoundary extends Component<Props, State> {
                     Sentry.captureException(error);
                 });
             });
-            this.visSentryDialog();
         }
     }
 
@@ -56,8 +52,8 @@ export class ErrorBoundary extends Component<Props, State> {
                 subtitle: '',
                 subtitle2: 'Teamet har fått beskjed. Dersom du ønsker å hjelpe oss, si litt om hva som skjedde.',
                 user: {
-                    name: this.props.autentisertSaksbehandler?.displayName,
-                    email: this.props.autentisertSaksbehandler?.email,
+                    name: this.props.saksbehandler?.displayName ?? 'Ukjent navn',
+                    email: this.props.saksbehandler?.email ?? 'Ukjent e-post',
                 },
                 labelName: 'NAVN',
                 labelComments: 'HVA SKJEDDE?',
@@ -71,7 +67,7 @@ export class ErrorBoundary extends Component<Props, State> {
     render(): ReactNode {
         if (this.state.hasError) {
             return (
-                <div className={Styles.container}>
+                <VStack height={'100vh'} align={'center'} justify={'center'}>
                     <VStack gap={'space-32'}>
                         <VStack gap={'space-8'}>
                             <Heading size={'medium'} level={'1'}>
@@ -98,9 +94,14 @@ export class ErrorBoundary extends Component<Props, State> {
                             </HStack>
                         )}
                     </VStack>
-                </div>
+                </VStack>
             );
         }
         return this.props.children;
     }
+}
+
+export function ErrorBoundaryMedSaksbehandler({ children }: PropsWithChildren) {
+    const saksbehandler = useSaksbehandler();
+    return <ErrorBoundary saksbehandler={saksbehandler}>{children}</ErrorBoundary>;
 }

--- a/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
@@ -1,43 +1,37 @@
 import { Header } from '@navikt/familie-header';
 
 import FagsakDeltagerSøk from './FagsakDeltagerSøk';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 
-interface IHeaderMedSøkProps {
-    brukerNavn?: string;
-    brukerEnhet?: string;
-}
+export function HeaderMedSøk() {
+    const saksbehandler = useSaksbehandler();
 
-export const HeaderMedSøk = ({ brukerNavn, brukerEnhet }: IHeaderMedSøkProps) => {
-    const genererEksterneLenker = () => {
-        const eksterneLenker = [
-            {
-                name: 'Rekvirer D-nr i DREK',
-                href: `${window.origin}/redirect/drek`,
-                isExternal: true,
-            },
-            {
-                name: 'Barnehagelister',
-                href: `/barnehagelister`,
-                isExternal: false,
-            },
-            {
-                name: 'nEESSI',
-                href: `${window.origin}/redirect/neessi`,
-                isExternal: true,
-            },
-        ];
-
-        return eksterneLenker;
-    };
+    const eksterneLenker = [
+        {
+            name: 'Rekvirer D-nr i DREK',
+            href: `${window.origin}/redirect/drek`,
+            isExternal: true,
+        },
+        {
+            name: 'Barnehagelister',
+            href: `/barnehagelister`,
+            isExternal: false,
+        },
+        {
+            name: 'nEESSI',
+            href: `${window.origin}/redirect/neessi`,
+            isExternal: true,
+        },
+    ];
 
     return (
         <Header
-            tittel="Nav Kontantstøtte"
-            brukerinfo={{ navn: brukerNavn ?? 'Ukjent', enhet: brukerEnhet ?? 'Ukjent' }}
+            tittel={'Nav Kontantstøtte'}
+            brukerinfo={{ navn: saksbehandler.displayName, enhet: saksbehandler.enhet }}
             brukerPopoverItems={[{ name: 'Logg ut', href: `${window.origin}/auth/logout` }]}
-            eksterneLenker={genererEksterneLenker()}
+            eksterneLenker={eksterneLenker}
         >
             <FagsakDeltagerSøk />
         </Header>
     );
-};
+}

--- a/src/frontend/komponenter/Saklinje/Behandlingslinje.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Behandlingslinje.test.tsx
@@ -3,8 +3,6 @@ import type { PropsWithChildren } from 'react';
 import { Route, Routes } from 'react-router';
 import { describe, expect, test } from 'vitest';
 
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
 import { Behandlingslinje } from './Behandlingslinje';
 import { BehandlingProvider } from '../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { HentOgSettBehandlingProvider } from '../../sider/Fagsak/Behandling/context/HentOgSettBehandlingContext';
@@ -16,9 +14,10 @@ import { lagSaksbehandler } from '../../testutils/testdata/saksbehandlerTestdata
 import { render, TestProviders } from '../../testutils/testrender';
 import type { IBehandling } from '../../typer/behandling';
 import type { IMinimalFagsak } from '../../typer/fagsak';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 
 interface WrapperProps extends PropsWithChildren {
-    saksbehandler?: ISaksbehandler;
+    saksbehandler?: Saksbehandler;
     fagsak?: IMinimalFagsak;
     behandling?: IBehandling;
 }

--- a/src/frontend/komponenter/Saklinje/Behandlingslinje.tsx
+++ b/src/frontend/komponenter/Saklinje/Behandlingslinje.tsx
@@ -4,7 +4,7 @@ import { FileTextIcon, HouseIcon } from '@navikt/aksel-icons';
 import { Box, Button, HStack } from '@navikt/ds-react';
 
 import { Behandlingsmeny } from './Meny/Behandlingsmeny';
-import { useAppContext } from '../../context/AppContext';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
 
 function lagAktivFaneStyle(fanenavn: string, pathname: string) {
@@ -14,9 +14,10 @@ function lagAktivFaneStyle(fanenavn: string, pathname: string) {
 }
 
 export function Behandlingslinje() {
-    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
     const { fagsak } = useFagsakContext();
     const { pathname } = useLocation();
+
+    const saksbehandler = useSaksbehandler();
 
     return (
         <Box borderWidth={'0 0 1 0'} borderColor={'neutral-subtle'}>
@@ -43,7 +44,7 @@ export function Behandlingslinje() {
                         Dokumenter
                     </Button>
                 </HStack>
-                {harInnloggetSaksbehandlerSkrivetilgang() && <Behandlingsmeny />}
+                {saksbehandler.harSkrivetilgang && <Behandlingsmeny />}
             </HStack>
         </Box>
     );

--- a/src/frontend/komponenter/Saklinje/Fagsaklinje.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Fagsaklinje.test.tsx
@@ -3,8 +3,6 @@ import type { PropsWithChildren } from 'react';
 import { Route, Routes } from 'react-router';
 import { describe, expect, test } from 'vitest';
 
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
 import { Fagsaklinje } from './Fagsaklinje';
 import { FagsakProvider } from '../../sider/Fagsak/FagsakContext';
 import { ManuelleBrevmottakerePåFagsakProvider } from '../../sider/Fagsak/ManuelleBrevmottakerePåFagsakContext';
@@ -12,9 +10,10 @@ import { lagFagsak } from '../../testutils/testdata/fagsakTestdata';
 import { lagSaksbehandler } from '../../testutils/testdata/saksbehandlerTestdata';
 import { render, TestProviders } from '../../testutils/testrender';
 import type { IMinimalFagsak } from '../../typer/fagsak';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 
 interface WrapperProps extends PropsWithChildren {
-    saksbehandler?: ISaksbehandler;
+    saksbehandler?: Saksbehandler;
     fagsak?: IMinimalFagsak;
 }
 

--- a/src/frontend/komponenter/Saklinje/Fagsaklinje.tsx
+++ b/src/frontend/komponenter/Saklinje/Fagsaklinje.tsx
@@ -4,7 +4,7 @@ import { FileTextIcon, HouseIcon } from '@navikt/aksel-icons';
 import { Box, Button, HStack } from '@navikt/ds-react';
 
 import { Fagsakmeny } from './Meny/Fagsakmeny';
-import { useAppContext } from '../../context/AppContext';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
 
 function lagAktivFaneStyle(fanenavn: string, pathname: string) {
@@ -14,9 +14,10 @@ function lagAktivFaneStyle(fanenavn: string, pathname: string) {
 }
 
 export function Fagsaklinje() {
-    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
     const { fagsak } = useFagsakContext();
     const { pathname } = useLocation();
+
+    const saksbehandler = useSaksbehandler();
 
     return (
         <Box borderWidth={'0 0 1 0'} borderColor={'neutral-subtle'}>
@@ -43,7 +44,7 @@ export function Fagsaklinje() {
                         Dokumenter
                     </Button>
                 </HStack>
-                {harInnloggetSaksbehandlerSkrivetilgang() && <Fagsakmeny />}
+                {saksbehandler.harSkrivetilgang && <Fagsakmeny />}
             </HStack>
         </Box>
     );

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/EndreBehandlendeEnhetModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/EndreBehandlendeEnhetModal.tsx
@@ -5,7 +5,7 @@ import { Button, Fieldset, Modal, VStack } from '@navikt/ds-react';
 import { BegrunnelseField } from './BegrunnelseField';
 import { useEndreBehandlendeEnhetForm } from './useEndreBehandlendeEnhetForm';
 import { VelgNyEnhetField } from './VelgNyEnhetField';
-import { useAppContext } from '../../../../context/AppContext';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { BehandlingSteg, hentStegNummer } from '../../../../typer/behandling';
 
@@ -15,7 +15,7 @@ interface Props {
 
 export function EndreBehandlendeEnhetModal({ lukkModal }: Props) {
     const { behandling, vurderErLesevisning } = useBehandlingContext();
-    const { innloggetSaksbehandler } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
     const { form, onSubmit } = useEndreBehandlendeEnhetForm({ lukkModal });
 
@@ -29,7 +29,7 @@ export function EndreBehandlendeEnhetModal({ lukkModal }: Props) {
         if (
             steg &&
             hentStegNummer(steg) === hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK) &&
-            innloggetSaksbehandler?.navIdent !== behandling.totrinnskontroll?.saksbehandlerId
+            saksbehandler.navIdent !== behandling.totrinnskontroll?.saksbehandlerId
         ) {
             return false;
         } else {

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandling.ts
@@ -7,12 +7,12 @@ import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
-import { useAppContext } from '../../../../context/AppContext';
 import { useFagsak } from '../../../../hooks/useFagsak';
 import { HentFagsakQueryKeyFactory } from '../../../../hooks/useHentFagsak';
 import { HentKlagebehandlingerQueryKeyFactory } from '../../../../hooks/useHentKlagebehandlinger';
 import { HentKontantstøttebehandlingerQueryKeyFactory } from '../../../../hooks/useHentKontantstøttebehandlinger';
 import { HentTilbakekrevingsbehandlingerQueryKeyFactory } from '../../../../hooks/useHentTilbakekrevingsbehandlinger';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { useBrukerContext } from '../../../../sider/Fagsak/BrukerContext';
 import type { IBehandling, IRestNyBehandling } from '../../../../typer/behandling';
 import { Behandlingstype, BehandlingÅrsak } from '../../../../typer/behandling';
@@ -38,9 +38,9 @@ const useOpprettBehandling = ({
     onOpprettTilbakekrevingSuccess: () => void;
 }) => {
     const { bruker } = useBrukerContext();
-    const { innloggetSaksbehandler } = useAppContext();
 
     const fagsak = useFagsak();
+    const saksbehandler = useSaksbehandler();
     const queryClient = useQueryClient();
     const navigate = useNavigate();
 
@@ -170,7 +170,7 @@ const useOpprettBehandling = ({
                     søkersIdent: søkersIdent,
                     behandlingType: behandlingstype.verdi as Behandlingstype,
                     behandlingÅrsak: behandlingsårsak.verdi as BehandlingÅrsak,
-                    saksbehandlerIdent: innloggetSaksbehandler?.navIdent,
+                    saksbehandlerIdent: saksbehandler.navIdent,
                     søknadMottattDato: dateTilIsoDatoStringEllerUndefined(skjema.felter.søknadMottattDato.verdi),
                 },
                 method: 'POST',

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -6,7 +6,7 @@ import { BodyShort, Button, Detail, Fieldset, Heading, HStack, Radio, RadioGroup
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useAppContext } from '../../../../../context/AppContext';
+import { useSaksbehandler } from '../../../../../hooks/useSaksbehandler';
 import ØyeGrå from '../../../../../ikoner/ØyeGrå';
 import ØyeGrønn from '../../../../../ikoner/ØyeGrønn';
 import ØyeRød from '../../../../../ikoner/ØyeRød';
@@ -28,7 +28,7 @@ const StyledButton = styled(Button)`
 
 export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props) {
     const { behandling, trinnPåBehandling } = useBehandlingContext();
-    const { innloggetSaksbehandler } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
     const [beslutning, settBeslutning] = useState<TotrinnskontrollBeslutning>(TotrinnskontrollBeslutning.IKKE_VURDERT);
     const [begrunnelse, settBegrunnelse] = useState<string>('');
@@ -37,10 +37,10 @@ export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props)
 
     const totrinnskontroll = behandling.totrinnskontroll;
 
-    const saksbehandler = totrinnskontroll?.saksbehandler ?? 'UKJENT SAKSBEHANDLER';
+    const totrinnskontrollSaksbehandler = totrinnskontroll?.saksbehandler ?? 'UKJENT SAKSBEHANDLER';
     const opprettetTidspunkt = totrinnskontroll?.opprettetTidspunkt ?? undefined;
 
-    const egetVedtak = totrinnskontroll?.saksbehandlerId === innloggetSaksbehandler?.navIdent;
+    const egetVedtak = totrinnskontroll?.saksbehandlerId === saksbehandler.navIdent;
 
     return (
         <Fieldset
@@ -63,7 +63,7 @@ export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props)
                             defaultString: 'UKJENT OPPRETTELSESTIDSPUNKT',
                         })}
                     </BodyShort>
-                    <BodyShort>{saksbehandler}</BodyShort>
+                    <BodyShort>{totrinnskontrollSaksbehandler}</BodyShort>
                     <br />
                     <Detail>Vedtaket er sendt til godkjenning</Detail>
                 </div>

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/useSkalViseTotrinnskontroll.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/useSkalViseTotrinnskontroll.ts
@@ -1,12 +1,14 @@
-import { useAppContext } from '../../../../context/AppContext';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { BehandlerRolle, BehandlingStatus } from '../../../../typer/behandling';
 import { useBehandlingContext } from '../context/BehandlingContext';
 
 export function useSkalViseTotrinnskontroll() {
     const { behandling } = useBehandlingContext();
-    const { hentSaksbehandlerRolle } = useAppContext();
 
-    const saksbehandlerrolle = hentSaksbehandlerRolle();
+    const saksbehandler = useSaksbehandler();
 
-    return BehandlerRolle.BESLUTTER === saksbehandlerrolle && behandling.status === BehandlingStatus.FATTER_VEDTAK;
+    const erBeslutter = saksbehandler.rolle === BehandlerRolle.BESLUTTER;
+    const erPåFatterVedtak = behandling.status === BehandlingStatus.FATTER_VEDTAK;
+
+    return erBeslutter && erPåFatterVedtak;
 }

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -7,8 +7,8 @@ import { type Ressurs } from '@navikt/familie-typer';
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
 import useBehandlingssteg from './useBehandlingssteg';
 import { saksbehandlerHarKunLesevisning } from './utils';
-import { useAppContext } from '../../../../context/AppContext';
 import { useNavigerAutomatiskTilSideForBehandlingssteg } from '../../../../hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import {
     BehandlerRolle,
     BehandlingStatus,
@@ -52,6 +52,8 @@ const BehandlingContext = createContext<BehandlingContextValue | undefined>(unde
 export const BehandlingProvider = ({ behandling, children }: Props) => {
     const { settBehandlingRessurs } = useHentOgSettBehandlingContext();
 
+    const saksbehandler = useSaksbehandler();
+
     useNavigerAutomatiskTilSideForBehandlingssteg({ behandling });
 
     const {
@@ -60,13 +62,6 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
         behandlingresultatNesteOnClick,
         foreslåVedtakNesteOnClick,
     } = useBehandlingssteg(settBehandlingRessurs, behandling);
-
-    const {
-        harInnloggetSaksbehandlerSkrivetilgang,
-        harInnloggetSaksbehandlerSuperbrukerTilgang,
-        innloggetSaksbehandler,
-        hentSaksbehandlerRolle,
-    } = useAppContext();
 
     const location = useLocation();
     const [trinnPåBehandling, settTrinnPåBehandling] = useState<{ [sideId: string]: ITrinn }>({});
@@ -125,26 +120,20 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
             return true;
         }
 
-        const innloggetSaksbehandlerSkrivetilgang = harInnloggetSaksbehandlerSkrivetilgang();
-        const innloggetSaksbehandlerHarSuperbrukerTilgang = harInnloggetSaksbehandlerSuperbrukerTilgang();
-
         const behandlingsårsak = behandling.årsak;
         const behandlingsårsakErÅpenForAlleMedTilgangTilÅOppretteÅrsak =
             behandlingsårsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV;
 
         const saksbehandlerHarTilgangTilEnhet =
-            innloggetSaksbehandlerHarSuperbrukerTilgang ||
+            saksbehandler.harSuperbrukertilgang ||
             behandlingsårsakErÅpenForAlleMedTilgangTilÅOppretteÅrsak ||
-            harTilgangTilEnhet(
-                behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId ?? '',
-                innloggetSaksbehandler?.groups ?? []
-            );
+            harTilgangTilEnhet(behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId ?? '', saksbehandler.groups);
 
         const steg = behandling.steg;
         const status = behandling.status;
 
         return saksbehandlerHarKunLesevisning(
-            innloggetSaksbehandlerSkrivetilgang,
+            saksbehandler.harSkrivetilgang,
             saksbehandlerHarTilgangTilEnhet,
             steg,
             status,
@@ -157,8 +146,8 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
 
     const kanBeslutteVedtak =
         behandling.status === BehandlingStatus.FATTER_VEDTAK &&
-        BehandlerRolle.BESLUTTER === hentSaksbehandlerRolle() &&
-        innloggetSaksbehandler?.email !== behandling.endretAv;
+        BehandlerRolle.BESLUTTER === saksbehandler.rolle &&
+        saksbehandler.email !== behandling.endretAv;
 
     const erBehandleneEnhetMidlertidig =
         behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId === MIDLERTIDIG_BEHANDLENDE_ENHET_ID;

--- a/src/frontend/sider/Fagsak/Behandling/context/useBehandlingssteg.ts
+++ b/src/frontend/sider/Fagsak/Behandling/context/useBehandlingssteg.ts
@@ -6,8 +6,8 @@ import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggFeiletRessurs, byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
-import { useAppContext } from '../../../../context/AppContext';
 import { useFagsakId } from '../../../../hooks/useFagsakId';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { BehandlingResultat, BehandlingÅrsak, type IBehandling } from '../../../../typer/behandling';
 import { defaultFunksjonellFeil } from '../../../../typer/feilmeldinger';
 
@@ -16,10 +16,10 @@ const useBehandlingssteg = (
     behandling: IBehandling
 ) => {
     const { request } = useHttp();
-    const { innloggetSaksbehandler } = useAppContext();
 
     const fagsakId = useFagsakId();
     const navigate = useNavigate();
+    const saksbehandler = useSaksbehandler();
 
     const [submitRessurs, settSubmitRessurs] = useState<Ressurs<IBehandling>>(byggTomRessurs());
 
@@ -116,7 +116,7 @@ const useBehandlingssteg = (
         request<void, IBehandling>({
             method: 'POST',
             url: `/familie-ks-sak/api/behandlinger/${behandling?.behandlingId}/steg/foreslå-vedtak?behandlendeEnhet=${
-                innloggetSaksbehandler?.enhet ?? '9999'
+                saksbehandler.enhet ?? '9999'
             }`,
             påvirkerSystemLaster: true,
         }).then((response: Ressurs<IBehandling>) => {

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -14,9 +14,9 @@ import { useSammensattKontrollsakContext } from './SammensattKontrollsak/Sammens
 import { Vedtaksmeny } from './Vedtaksmeny/Vedtaksmeny';
 import { AlleBegrunnelserProvider } from './Vedtaksperioder/AlleBegrunnelserContext';
 import Vedtaksperioder from './Vedtaksperioder/Vedtaksperioder';
-import { useAppContext } from '../../../../../context/AppContext';
 import useDokument from '../../../../../hooks/useDokument';
 import { useFagsakId } from '../../../../../hooks/useFagsakId';
+import { useSaksbehandler } from '../../../../../hooks/useSaksbehandler';
 import { BrevmottakereAlert } from '../../../../../komponenter/BrevmottakereAlert';
 import PdfVisningModal from '../../../../../komponenter/PdfVisningModal/PdfVisningModal';
 import {
@@ -53,11 +53,11 @@ const OppsummeringVedtakInnhold = ({
     settVisModal,
     bruker,
 }: IOppsummeringVedtakInnholdProps) => {
-    const { hentSaksbehandlerRolle } = useAppContext();
     const { vurderErLesevisning } = useBehandlingContext();
 
     const fagsakId = useFagsakId();
     const navigate = useNavigate();
+    const saksbehandler = useSaksbehandler();
 
     const erLesevisning = vurderErLesevisning();
 
@@ -69,10 +69,8 @@ const OppsummeringVedtakInnhold = ({
     const { erRefusjonEøsTabellSynlig } = useRefusjonEøsTabellContext();
 
     const hentVedtaksbrev = () => {
-        const rolle = hentSaksbehandlerRolle();
         const skalOgsåLagreBrevPåVedtak =
-            rolle &&
-            rolle > BehandlerRolle.VEILEDER &&
+            saksbehandler.rolle > BehandlerRolle.VEILEDER &&
             hentStegNummer(åpenBehandling.steg) <= hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
 
         if (skalOgsåLagreBrevPåVedtak) {

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -9,7 +9,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 import BarnIBrevSkjema from './BarnIBrev/BarnIBrevSkjema';
 import { dokumentÅrsak, DokumentÅrsak, useDokumentutsendingContext } from './DokumentutsendingContext';
 import { LeggTilBarnKnapp } from './LeggTilBarnKnapp';
-import { useAppContext } from '../../../context/AppContext';
+import { useSaksbehandler } from '../../../hooks/useSaksbehandler';
 import { BrevmottakereAlert } from '../../../komponenter/BrevmottakereAlert';
 import FritekstAvsnitt from '../../../komponenter/FritekstAvsnitt';
 import { LeggTilBarnModal } from '../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
@@ -58,7 +58,8 @@ enum BarnIBrevÅrsak {
 
 export function DokumentutsendingSkjema() {
     const { bruker } = useBrukerContext();
-    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
+
+    const saksbehandler = useSaksbehandler();
 
     const {
         hentForhåndsvisningPåFagsak,
@@ -100,7 +101,7 @@ export function DokumentutsendingSkjema() {
 
     const skalViseFritekstAvsnitt = årsakVerdi === DokumentÅrsak.INNHENTE_OPPLYSNINGER_KLAGE;
 
-    const erLesevisning = !harInnloggetSaksbehandlerSkrivetilgang();
+    const erLesevisning = !saksbehandler.harSkrivetilgang;
 
     function onLeggTilBarn(barn: IBarnMedOpplysninger) {
         skjema.felter.barnIBrev.validerOgSettFelt([...skjema.felter.barnIBrev.verdi, barn]);

--- a/src/frontend/sider/Fagsak/Dokumentutsending/LeggTilBarnKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/LeggTilBarnKnapp.tsx
@@ -1,14 +1,15 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 
-import { useAppContext } from '../../../context/AppContext';
+import { useSaksbehandler } from '../../../hooks/useSaksbehandler';
 import { useLeggTilBarnModalContext } from '../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
 
 export function LeggTilBarnKnapp() {
     const { åpneModal } = useLeggTilBarnModalContext();
-    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
 
-    if (!harInnloggetSaksbehandlerSkrivetilgang()) {
+    const saksbehandler = useSaksbehandler();
+
+    if (!saksbehandler.harSkrivetilgang) {
         return null;
     }
 

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
@@ -19,8 +19,8 @@ import {
 } from '@navikt/familie-typer';
 
 import useFagsakApi from '../../api/useFagsakApi';
-import { useAppContext } from '../../context/AppContext';
 import useDokument from '../../hooks/useDokument';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { Behandlingstype, BehandlingÅrsak } from '../../typer/behandling';
 import type { IBehandlingstema } from '../../typer/behandlingstema';
 import type { IMinimalFagsak } from '../../typer/fagsak';
@@ -88,11 +88,12 @@ interface ManuellJournalføringContextValue {
 const ManuellJournalføringContext = createContext<ManuellJournalføringContextValue | undefined>(undefined);
 
 export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
-    const { innloggetSaksbehandler } = useAppContext();
     const { hentFagsakForPerson } = useFagsakApi();
     const navigate = useNavigate();
     const { request } = useHttp();
     const { oppgaveId } = useParams<{ oppgaveId: string }>();
+
+    const saksbehandler = useSaksbehandler();
 
     const { hentForhåndsvisning, nullstillDokument, hentetDokument } = useDokument();
 
@@ -421,8 +422,8 @@ export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
                                   ? BehandlingÅrsak.SØKNAD
                                   : nyBehandlingsårsak,
 
-                        navIdent: innloggetSaksbehandler?.navIdent ?? '',
-                        journalførendeEnhet: innloggetSaksbehandler?.enhet ?? '9999',
+                        navIdent: saksbehandler.navIdent,
+                        journalførendeEnhet: saksbehandler.navIdent,
                     },
                 },
                 (fagsakId: Ressurs<string>) => {
@@ -480,7 +481,7 @@ export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
                                     : nyBehandlingsårsak === ''
                                       ? BehandlingÅrsak.SØKNAD
                                       : nyBehandlingsårsak,
-                            navIdent: innloggetSaksbehandler?.navIdent ?? '',
+                            navIdent: saksbehandler.navIdent,
                         },
                     },
                     (fagsakId: Ressurs<string>) => {
@@ -497,8 +498,7 @@ export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
 
     const tilordnetInnloggetSaksbehandler = () =>
         dataForManuellJournalføring.status === RessursStatus.SUKSESS &&
-        innloggetSaksbehandler !== undefined &&
-        dataForManuellJournalføring.data.oppgave.tilordnetRessurs === innloggetSaksbehandler.navIdent;
+        dataForManuellJournalføring.data.oppgave.tilordnetRessurs === saksbehandler.navIdent;
 
     const erLesevisning = () => {
         return (

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
@@ -423,7 +423,7 @@ export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
                                   : nyBehandlingsårsak,
 
                         navIdent: saksbehandler.navIdent,
-                        journalførendeEnhet: saksbehandler.navIdent,
+                        journalførendeEnhet: saksbehandler.enhet,
                     },
                 },
                 (fagsakId: Ressurs<string>) => {

--- a/src/frontend/sider/Oppgavebenk/FilterSkjema.tsx
+++ b/src/frontend/sider/Oppgavebenk/FilterSkjema.tsx
@@ -8,7 +8,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { useOppgavebenkContext } from './OppgavebenkContext';
 import type { IOppgaveFelt } from './oppgavefelter';
-import { useAppContext } from '../../context/AppContext';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import DatovelgerForGammelSkjemaløsning from '../../komponenter/Datovelger/DatovelgerForGammelSkjemaløsning';
 import type { IPar } from '../../typer/common';
 import type { IsoDatoString } from '../../utils/dato';
@@ -18,9 +18,10 @@ const DatoVelgerContainer = styled.div`
 `;
 
 const FilterSkjema = () => {
-    const { innloggetSaksbehandler } = useAppContext();
     const { hentOppgaver, oppgaver, oppgaveFelter, settVerdiPåOppgaveFelt, tilbakestillOppgaveFelter, validerSkjema } =
         useOppgavebenkContext();
+
+    const saksbehandler = useSaksbehandler();
 
     function tilOppgaveFeltKomponent(oppgaveFelt: IOppgaveFelt): JSX.Element | null {
         switch (oppgaveFelt.filter?.type) {
@@ -56,7 +57,7 @@ const FilterSkjema = () => {
                             {oppgaveFelt.filter.nøkkelPar &&
                                 Object.values(oppgaveFelt.filter.nøkkelPar)
                                     .filter((par: IPar) =>
-                                        oppgaveFelt.erSynlig ? oppgaveFelt.erSynlig(par, innloggetSaksbehandler) : true
+                                        oppgaveFelt.erSynlig ? oppgaveFelt.erSynlig(par, saksbehandler) : true
                                     )
                                     .map((par: IPar) => {
                                         return (

--- a/src/frontend/sider/Oppgavebenk/OppgaveList.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveList.tsx
@@ -126,7 +126,7 @@ const OppgaveList = () => {
                             <Table.DataCell>
                                 <OppgavelisteSaksbehandler
                                     oppgave={rad.tilordnetRessurs.oppg}
-                                    innloggetSaksbehandler={rad.tilordnetRessurs.innloggetSaksbehandler}
+                                    saksbehandler={rad.tilordnetRessurs.innloggetSaksbehandler}
                                 />
                             </Table.DataCell>
                             <Table.DataCell>

--- a/src/frontend/sider/Oppgavebenk/OppgaveList.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveList.tsx
@@ -126,7 +126,7 @@ const OppgaveList = () => {
                             <Table.DataCell>
                                 <OppgavelisteSaksbehandler
                                     oppgave={rad.tilordnetRessurs.oppg}
-                                    saksbehandler={rad.tilordnetRessurs.innloggetSaksbehandler}
+                                    saksbehandler={rad.tilordnetRessurs.saksbehandler}
                                 />
                             </Table.DataCell>
                             <Table.DataCell>

--- a/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
@@ -13,6 +13,7 @@ import { byggFeiletRessurs, byggHenterRessurs, byggTomRessurs, RessursStatus } f
 import { initialOppgaveFelter, type IOppgaveFelt, type IOppgaveFelter } from './oppgavefelter';
 import { type IOppgaveRad, mapIOppgaverTilOppgaveRad, sorterEtterNøkkel, Sorteringsnøkkel } from './utils';
 import { useAppContext } from '../../context/AppContext';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { AlertType, ToastTyper } from '../../komponenter/Toast/typer';
 import type { IMinimalFagsak } from '../../typer/fagsak';
 import {
@@ -55,20 +56,21 @@ const OppgavebenkContext = createContext<OppgavebenkContextValue | undefined>(un
 
 export const OppgavebenkProvider = (props: PropsWithChildren) => {
     const navigate = useNavigate();
-    const { innloggetSaksbehandler, settToast } = useAppContext();
+    const { settToast } = useAppContext();
     const { request } = useHttp();
     const { opprettEllerHentFagsak } = useOpprettEllerHentFagsak();
+    const saksbehandler = useSaksbehandler();
 
     const [hentOppgaverVedSidelast, settHentOppgaverVedSidelast] = useState(true);
     const [side, settSide] = useState<number>(1);
 
     const [oppgaver, settOppgaver] = useState<Ressurs<IHentOppgaveDto>>(byggTomRessurs<IHentOppgaveDto>());
 
-    const [oppgaveFelter, settOppgaveFelter] = useState<IOppgaveFelter>(initialOppgaveFelter(innloggetSaksbehandler));
+    const [oppgaveFelter, settOppgaveFelter] = useState<IOppgaveFelter>(initialOppgaveFelter(saksbehandler));
 
     const oppgaverader: IOppgaveRad[] = useMemo(() => {
         return oppgaver.status === RessursStatus.SUKSESS && oppgaver.data.oppgaver.length > 0
-            ? mapIOppgaverTilOppgaveRad(oppgaver.data.oppgaver, innloggetSaksbehandler)
+            ? mapIOppgaverTilOppgaveRad(oppgaver.data.oppgaver, saksbehandler)
             : [];
     }, [oppgaver]);
 
@@ -105,11 +107,11 @@ export const OppgavebenkProvider = (props: PropsWithChildren) => {
     };
 
     useEffect(() => {
-        settOppgaveFelter(initialOppgaveFelter(innloggetSaksbehandler));
-    }, [innloggetSaksbehandler]);
+        settOppgaveFelter(initialOppgaveFelter(saksbehandler));
+    }, [saksbehandler]);
 
     useEffect(() => {
-        if (hentOppgaverVedSidelast && innloggetSaksbehandler) {
+        if (hentOppgaverVedSidelast) {
             if (
                 Object.values(oppgaveFelter).filter(
                     (oppgaveFelt: IOppgaveFelt) =>
@@ -187,7 +189,7 @@ export const OppgavebenkProvider = (props: PropsWithChildren) => {
 
     const tilbakestillOppgaveFelter = () => {
         tilbakestillOppgaveFeltILocalStorage();
-        settOppgaveFelter(initialOppgaveFelter(innloggetSaksbehandler));
+        settOppgaveFelter(initialOppgaveFelter(saksbehandler));
     };
 
     const fordelOppgave = (oppgave: IOppgave, saksbehandler: string) => {
@@ -316,7 +318,7 @@ export const OppgavebenkProvider = (props: PropsWithChildren) => {
             hentOppgaveFelt('tildeltEnhetsnr').filter?.selectedValue,
             hentOppgaveFelt('fristFerdigstillelse').filter?.selectedValue,
             hentOppgaveFelt('opprettetTidspunkt').filter?.selectedValue,
-            saksbehandlerFilter === SaksbehandlerFilter.INNLOGGET ? innloggetSaksbehandler?.navIdent : undefined,
+            saksbehandlerFilter === SaksbehandlerFilter.INNLOGGET ? saksbehandler.navIdent : undefined,
             tildeltRessurs
         ).then((oppgaverRessurs: Ressurs<IHentOppgaveDto>) => {
             settOppgaver(oppgaverRessurs);

--- a/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
@@ -1,20 +1,20 @@
 import { useEffect, useRef } from 'react';
 
-import { Alert, BodyShort, Button, HGrid } from '@navikt/ds-react';
-import type { ISaksbehandler } from '@navikt/familie-typer';
+import { BodyShort, Button, HGrid } from '@navikt/ds-react';
 
 import { useOppgavebenkContext } from './OppgavebenkContext';
 import { useAppContext } from '../../context/AppContext';
 import type { IOppgave } from '../../typer/oppgave';
 import { OppgavetypeFilter } from '../../typer/oppgave';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 import { hentFnrFraOppgaveIdenter } from '../../utils/oppgave';
 
 interface IOppgavelisteSaksbehandler {
     oppgave: IOppgave;
-    innloggetSaksbehandler?: ISaksbehandler;
+    saksbehandler: Saksbehandler;
 }
 
-const OppgavelisteSaksbehandler = ({ oppgave, innloggetSaksbehandler }: IOppgavelisteSaksbehandler) => {
+const OppgavelisteSaksbehandler = ({ oppgave, saksbehandler }: IOppgavelisteSaksbehandler) => {
     const { fordelOppgave, tilbakestillFordelingPåOppgave } = useOppgavebenkContext();
     const { sjekkTilgang } = useAppContext();
     const oppgaveRef = useRef<IOppgave | null>(null);
@@ -25,10 +25,6 @@ const OppgavelisteSaksbehandler = ({ oppgave, innloggetSaksbehandler }: IOppgave
         }
         oppgaveRef.current = oppgave;
     }, [oppgave]);
-
-    if (innloggetSaksbehandler == null) {
-        return <Alert variant="error">Klarte ikke hente innlogget saksbehandler</Alert>;
-    }
 
     const oppgaveTypeErStøttet =
         [
@@ -70,7 +66,7 @@ const OppgavelisteSaksbehandler = ({ oppgave, innloggetSaksbehandler }: IOppgave
                         const brukerident = hentFnrFraOppgaveIdenter(oppgave.identer);
 
                         if (!brukerident || (brukerident && (await sjekkTilgang(brukerident)))) {
-                            fordelOppgave(oppgave, innloggetSaksbehandler?.navIdent);
+                            fordelOppgave(oppgave, saksbehandler.navIdent);
                         }
                     }}
                     children={'Tildel meg'}

--- a/src/frontend/sider/Oppgavebenk/oppgavefelter.ts
+++ b/src/frontend/sider/Oppgavebenk/oppgavefelter.ts
@@ -1,5 +1,4 @@
 import { Valideringsstatus } from '@navikt/familie-skjema';
-import type { ISaksbehandler } from '@navikt/familie-typer';
 
 import type { INøkkelPar, IPar } from '../../typer/common';
 import { hentPar } from '../../typer/common';
@@ -14,6 +13,7 @@ import {
     SaksbehandlerFilter,
     saksbehandlerFilter,
 } from '../../typer/oppgave';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 
 enum FeltSortOrder {
     NONE = 'NONE',
@@ -36,7 +36,7 @@ export interface IOppgaveFelt {
     // TODO: midlertidig - ønsker å bruke FeltState og Skjema-hook
     valideringsstatus?: Valideringsstatus;
     feilmelding?: string;
-    erSynlig?: (par: IPar, innloggetSaksbehandler?: ISaksbehandler) => boolean;
+    erSynlig?: (par: IPar, saksbehandler: Saksbehandler) => boolean;
 }
 
 export interface IOppgaveFelter {
@@ -53,7 +53,7 @@ export interface IOppgaveFelter {
     tilordnetRessurs: IOppgaveFelt;
 }
 
-export const initialOppgaveFelter = (innloggetSaksbehandler?: ISaksbehandler): IOppgaveFelter => {
+export const initialOppgaveFelter = (saksbehandler: Saksbehandler): IOppgaveFelter => {
     const searchParams = JSON.parse(localStorage.getItem('oppgaveFeltVerdier') || '{}');
 
     return {
@@ -132,8 +132,8 @@ export const initialOppgaveFelter = (innloggetSaksbehandler?: ISaksbehandler): I
                 nøkkelPar: enhetFilter,
             },
             order: FeltSortOrder.NONE,
-            erSynlig: (par: IPar, innloggetSaksbehandler?: ISaksbehandler) => {
-                return harTilgangTilEnhet(par.id.replace('E', ''), innloggetSaksbehandler?.groups ?? []);
+            erSynlig: (par: IPar, saksbehandler: Saksbehandler) => {
+                return harTilgangTilEnhet(par.id.replace('E', ''), saksbehandler.groups);
             },
         },
         tilordnetRessurs: {
@@ -143,11 +143,11 @@ export const initialOppgaveFelter = (innloggetSaksbehandler?: ISaksbehandler): I
                 type: 'select',
                 selectedValue: hentPar(
                     searchParams['tilordnetRessurs']?.toString(),
-                    saksbehandlerFilter(innloggetSaksbehandler),
+                    saksbehandlerFilter(saksbehandler),
                     SaksbehandlerFilter.ALLE
                 ),
                 initialValue: SaksbehandlerFilter.ALLE,
-                nøkkelPar: saksbehandlerFilter(innloggetSaksbehandler),
+                nøkkelPar: saksbehandlerFilter(saksbehandler),
             },
             order: FeltSortOrder.NONE,
         },

--- a/src/frontend/sider/Oppgavebenk/utils.ts
+++ b/src/frontend/sider/Oppgavebenk/utils.ts
@@ -42,7 +42,7 @@ export const sorterEtterNøkkel = (a: IOppgaveRad, b: IOppgaveRad, sorteringsnø
 
 export interface IOppgaveRad extends Omit<IOppgave, 'tilordnetRessurs' | 'identer'> {
     ident: IOppgaveIdent[] | undefined;
-    tilordnetRessurs: { oppg: IOppgave; innloggetSaksbehandler: Saksbehandler };
+    tilordnetRessurs: { oppg: IOppgave; saksbehandler: Saksbehandler };
     handlinger: IOppgave;
 }
 
@@ -60,7 +60,7 @@ export const mapIOppgaverTilOppgaveRad = (oppgaver: IOppgave[], saksbehandler: S
             beskrivelse: oppg.beskrivelse,
             opprettetTidspunkt: oppg.opprettetTidspunkt,
             prioritet: oppg.prioritet,
-            tilordnetRessurs: { oppg, innloggetSaksbehandler: saksbehandler },
+            tilordnetRessurs: { oppg, saksbehandler },
             tildeltEnhetsnr: enhet ? enhet.navn : oppg.tildeltEnhetsnr,
             handlinger: oppg,
         };

--- a/src/frontend/sider/Oppgavebenk/utils.ts
+++ b/src/frontend/sider/Oppgavebenk/utils.ts
@@ -1,8 +1,7 @@
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
 import type { IPar } from '../../typer/common';
 import type { BehandlingstypeFilter, EnhetFilter, IOppgave, IOppgaveIdent } from '../../typer/oppgave';
 import { behandlingstypeFilter, enhetFilter } from '../../typer/oppgave';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 import { hentFnrFraOppgaveIdenter } from '../../utils/oppgave';
 
 export enum Sorteringsnøkkel {
@@ -43,14 +42,11 @@ export const sorterEtterNøkkel = (a: IOppgaveRad, b: IOppgaveRad, sorteringsnø
 
 export interface IOppgaveRad extends Omit<IOppgave, 'tilordnetRessurs' | 'identer'> {
     ident: IOppgaveIdent[] | undefined;
-    tilordnetRessurs: { oppg: IOppgave; innloggetSaksbehandler?: ISaksbehandler };
+    tilordnetRessurs: { oppg: IOppgave; innloggetSaksbehandler: Saksbehandler };
     handlinger: IOppgave;
 }
 
-export const mapIOppgaverTilOppgaveRad = (
-    oppgaver: IOppgave[],
-    innloggetSaksbehandler?: ISaksbehandler
-): IOppgaveRad[] =>
+export const mapIOppgaverTilOppgaveRad = (oppgaver: IOppgave[], saksbehandler: Saksbehandler): IOppgaveRad[] =>
     oppgaver.map((oppg: IOppgave) => {
         const enhet: IPar | undefined = enhetFilter[`E${oppg.tildeltEnhetsnr}` as EnhetFilter];
         return {
@@ -64,7 +60,7 @@ export const mapIOppgaverTilOppgaveRad = (
             beskrivelse: oppg.beskrivelse,
             opprettetTidspunkt: oppg.opprettetTidspunkt,
             prioritet: oppg.prioritet,
-            tilordnetRessurs: { oppg, innloggetSaksbehandler },
+            tilordnetRessurs: { oppg, innloggetSaksbehandler: saksbehandler },
             tildeltEnhetsnr: enhet ? enhet.navn : oppg.tildeltEnhetsnr,
             handlinger: oppg,
         };

--- a/src/frontend/testutils/mocks/handlers/handlers.ts
+++ b/src/frontend/testutils/mocks/handlers/handlers.ts
@@ -4,6 +4,7 @@ import { fagsakHandlers } from './fagsakHandlers';
 import { featureToggleHandlers } from './featureToggleHandlers';
 import { klageHandlers } from './klageHandlers';
 import { personHandlers } from './personHandlers';
+import { saksbehandlerHandlers } from './saksbehandlerHandlers';
 import { tilbakekrevingHandlers } from './tilbakekrevingHandlers';
 import { versionHandlers } from './versionHandlers';
 
@@ -16,4 +17,5 @@ export const handlers = [
     ...personHandlers,
     ...fagsakHandlers,
     ...ainntektHandlers,
+    ...saksbehandlerHandlers,
 ];

--- a/src/frontend/testutils/mocks/handlers/saksbehandlerHandlers.ts
+++ b/src/frontend/testutils/mocks/handlers/saksbehandlerHandlers.ts
@@ -1,0 +1,9 @@
+import { http, HttpResponse } from 'msw';
+
+import { lagSaksbehandler } from '../../testdata/saksbehandlerTestdata';
+
+export const saksbehandlerHandlers = [
+    http.get('/user/profile', () => {
+        return HttpResponse.json(lagSaksbehandler());
+    }),
+];

--- a/src/frontend/testutils/testdata/saksbehandlerTestdata.ts
+++ b/src/frontend/testutils/testdata/saksbehandlerTestdata.ts
@@ -1,3 +1,6 @@
+import type { ISaksbehandler } from '@navikt/familie-typer';
+
+import { BehandlerRolle } from '../../typer/behandling';
 import type { Saksbehandler } from '../../typer/saksbehandler';
 
 export function lagSaksbehandler(saksbehandler: Partial<Saksbehandler> = {}): Saksbehandler {
@@ -10,7 +13,24 @@ export function lagSaksbehandler(saksbehandler: Partial<Saksbehandler> = {}): Sa
         lastName: 'Behandler',
         enhet: '0001',
         navIdent: 'A1',
+        rolle: BehandlerRolle.SAKSBEHANDLER,
+        harSkrivetilgang: true,
+        harSuperbrukertilgang: false,
         ...saksbehandler,
+    };
+}
+
+export function lagISaksbehandler(iSaksbehandler: Partial<ISaksbehandler> = {}): ISaksbehandler {
+    return {
+        displayName: 'Sak Behandler',
+        email: 'saksbehandler@nav.no',
+        firstName: 'Sak',
+        groups: ['c7e0b108-7ae6-432c-9ab4-946174c240c0'],
+        identifier: '30987654321',
+        lastName: 'Behandler',
+        enhet: '0001',
+        navIdent: 'A1',
+        ...iSaksbehandler,
     };
 }
 

--- a/src/frontend/testutils/testdata/saksbehandlerTestdata.ts
+++ b/src/frontend/testutils/testdata/saksbehandlerTestdata.ts
@@ -1,8 +1,8 @@
-import { type ISaksbehandler } from '@navikt/familie-typer';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 
-export function lagSaksbehandler(saksbehandler: Partial<ISaksbehandler> = {}): ISaksbehandler {
+export function lagSaksbehandler(saksbehandler: Partial<Saksbehandler> = {}): Saksbehandler {
     return {
-        displayName: 'Saksbehandler',
+        displayName: 'Sak Behandler',
         email: 'saksbehandler@nav.no',
         firstName: 'Sak',
         groups: ['c7e0b108-7ae6-432c-9ab4-946174c240c0'],

--- a/src/frontend/testutils/testrender.tsx
+++ b/src/frontend/testutils/testrender.tsx
@@ -5,15 +5,15 @@ import { render as rtlRender, type RenderOptions, screen as rtlScreen } from '@t
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
 import { AppProvider } from '../context/AppContext';
 import { AuthContextProvider } from '../context/AuthContext';
 import { ModalProvider } from '../context/ModalContext';
 import { lagSaksbehandler } from './testdata/saksbehandlerTestdata';
 import { FeatureTogglesProvider } from '../context/FeatureTogglesContext';
 import { HttpContextProvider } from '../context/HttpContext';
+import { SaksbehandlerProvider } from '../context/SaksbehandlerContext';
 import type { FeatureToggles } from '../typer/featureToggles';
+import type { Saksbehandler } from '../typer/saksbehandler';
 import { skruPåAlleToggles } from './mocks/handlers/featureToggleHandlers';
 
 function lagQueryClient() {
@@ -29,7 +29,7 @@ function lagQueryClient() {
 interface Props extends PropsWithChildren {
     queryClient?: QueryClient;
     initialEntries?: [{ pathname: string }];
-    saksbehandler?: ISaksbehandler;
+    saksbehandler?: Saksbehandler;
     fjernRessursSomLasterTimeout?: number;
     featureToggles?: FeatureToggles;
 }
@@ -43,19 +43,21 @@ export function TestProviders({
     children,
 }: Props) {
     return (
-        <AuthContextProvider autentisertSaksbehandler={saksbehandler}>
-            <HttpContextProvider fjernRessursSomLasterTimeout={fjernRessursSomLasterTimeout}>
-                <QueryClientProvider client={queryClient}>
-                    <FeatureTogglesProvider featureToggles={featureToggles}>
-                        <AppProvider>
-                            <ModalProvider>
-                                <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
-                            </ModalProvider>
-                        </AppProvider>
-                    </FeatureTogglesProvider>
-                </QueryClientProvider>
-            </HttpContextProvider>
-        </AuthContextProvider>
+        <QueryClientProvider client={queryClient}>
+            <SaksbehandlerProvider saksbehandler={saksbehandler}>
+                <AuthContextProvider>
+                    <HttpContextProvider fjernRessursSomLasterTimeout={fjernRessursSomLasterTimeout}>
+                        <FeatureTogglesProvider featureToggles={featureToggles}>
+                            <AppProvider>
+                                <ModalProvider>
+                                    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+                                </ModalProvider>
+                            </AppProvider>
+                        </FeatureTogglesProvider>
+                    </HttpContextProvider>
+                </AuthContextProvider>
+            </SaksbehandlerProvider>
+        </QueryClientProvider>
     );
 }
 

--- a/src/frontend/typer/oppgave.ts
+++ b/src/frontend/typer/oppgave.ts
@@ -1,5 +1,3 @@
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
 import {
     type BehandlingKategori,
     type IBehandlingstema,
@@ -8,6 +6,7 @@ import {
 } from './behandlingstema';
 import type { IPar } from './common';
 import type { INavnOgIdent, TilknyttetBehandling } from './manuell-journalføring';
+import type { Saksbehandler } from './saksbehandler';
 
 export interface IFinnOppgaveRequest {
     behandlingstype?: string;
@@ -91,10 +90,8 @@ export enum SaksbehandlerFilter {
     UFORDELTE = 'UFORDELTE',
 }
 
-export const saksbehandlerFilter = (
-    innloggetSaksbehandler: ISaksbehandler | undefined
-): Record<SaksbehandlerFilter, IPar> => ({
-    INNLOGGET: { id: 'INNLOGGET', navn: innloggetSaksbehandler?.displayName ?? 'INNLOGGET' },
+export const saksbehandlerFilter = (saksbehandler: Saksbehandler): Record<SaksbehandlerFilter, IPar> => ({
+    INNLOGGET: { id: 'INNLOGGET', navn: saksbehandler.displayName },
     ALLE: { id: 'ALLE', navn: 'Alle' },
     FORDELTE: { id: 'FORDELTE', navn: 'Fordelte' },
     UFORDELTE: { id: 'UFORDELTE', navn: 'Ufordelte' },

--- a/src/frontend/typer/saksbehandler.test.ts
+++ b/src/frontend/typer/saksbehandler.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { BehandlerRolle } from './behandling';
-import { utledBehandlerRolle, harSuperbrukerTilgang, harSkrivetilgang } from './saksbehandler';
+import { utledBehandlerRolle, harSuperbrukertilgang, harSkrivetilgang } from './saksbehandler';
 import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
 import { erProd } from '../utils/miljø';
 
@@ -39,10 +39,10 @@ describe('Saksbehandler', () => {
             });
         });
 
-        describe('harSuperbrukerTilgang', () => {
+        describe('harSuperbrukertilgang', () => {
             it('skal returnere true hvis bruker har superbruker-gruppe', () => {
                 const saksbehandler = lagSaksbehandler({ groups: [devGrupper.superbruker] });
-                expect(harSuperbrukerTilgang(saksbehandler)).toBe(true);
+                expect(harSuperbrukertilgang(saksbehandler)).toBe(true);
             });
         });
 
@@ -84,10 +84,10 @@ describe('Saksbehandler', () => {
             });
         });
 
-        describe('harSuperbrukerTilgang', () => {
+        describe('harSuperbrukertilgang', () => {
             it('skal returnere true for prod-superbruker', () => {
                 const saksbehandler = lagSaksbehandler({ groups: [prodGrupper.superbruker] });
-                expect(harSuperbrukerTilgang(saksbehandler)).toBe(true);
+                expect(harSuperbrukertilgang(saksbehandler)).toBe(true);
             });
         });
     });

--- a/src/frontend/typer/saksbehandler.test.ts
+++ b/src/frontend/typer/saksbehandler.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { BehandlerRolle } from './behandling';
+import { utledBehandlerRolle, harSuperbrukerTilgang, harSkrivetilgang } from './saksbehandler';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { erProd } from '../utils/miljø';
+
+vi.mock('../utils/miljø', () => ({
+    erProd: vi.fn(),
+}));
+
+describe('Saksbehandler', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    describe('Når miljø ikke er prod (Dev/Preprod)', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(false);
+        });
+
+        const devGrupper = {
+            veileder: '71f503a2-c28f-4394-a05a-8da263ceca4a',
+            saksbehandler: 'c7e0b108-7ae6-432c-9ab4-946174c240c0',
+            beslutter: '52fe1bef-224f-49df-a40a-29f92d4520f8',
+            superbruker: '314fa714-f13c-4cdc-ac5c-e13ce08e241c',
+            ukjent: 'en-tilfeldig-gruppe-id',
+        };
+
+        describe('utledBehandlerRolle', () => {
+            it('skal returnere høyeste rolle (BESLUTTER) ved flere grupper', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.veileder, devGrupper.beslutter] });
+                expect(utledBehandlerRolle(saksbehandler)).toBe(BehandlerRolle.BESLUTTER);
+            });
+
+            it('skal kaste feil hvis ingen gyldige grupper finnes', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.ukjent] });
+                expect(() => utledBehandlerRolle(saksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
+            });
+        });
+
+        describe('harSuperbrukerTilgang', () => {
+            it('skal returnere true hvis bruker har superbruker-gruppe', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.superbruker] });
+                expect(harSuperbrukerTilgang(saksbehandler)).toBe(true);
+            });
+        });
+
+        describe('harSkrivetilgang', () => {
+            it('skal returnere true for SAKSBEHANDLER', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.saksbehandler] });
+                expect(harSkrivetilgang(saksbehandler)).toBe(true);
+            });
+
+            it('skal returnere false for kun VEILEDER', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.veileder] });
+                expect(harSkrivetilgang(saksbehandler)).toBe(false);
+            });
+        });
+    });
+
+    describe('Når miljø ER prod', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(true);
+        });
+
+        const prodGrupper = {
+            veileder: '54cd86b8-2e23-48b2-8852-b05b5827bb0f',
+            saksbehandler: 'e40090eb-c2fb-400e-b412-e9084019a73b',
+            beslutter: '4e7f23d9-5db1-45c0-acec-89c86a9ec678',
+            superbruker: 'b8158d87-a284-4620-9bf9-f0aa3f62c8aa',
+        };
+
+        describe('utledBehandlerRolle', () => {
+            it('skal returnere riktig rolle basert på prod-grupper', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [prodGrupper.saksbehandler] });
+                expect(utledBehandlerRolle(saksbehandler)).toBe(BehandlerRolle.SAKSBEHANDLER);
+            });
+
+            it('skal kaste feil hvis en bruker i prod kun har dev-grupper', () => {
+                const devVeilederGruppe = '93a26831-9866-4410-927b-74ff51a9107c';
+                const saksbehandler = lagSaksbehandler({ groups: [devVeilederGruppe] });
+                expect(() => utledBehandlerRolle(saksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
+            });
+        });
+
+        describe('harSuperbrukerTilgang', () => {
+            it('skal returnere true for prod-superbruker', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [prodGrupper.superbruker] });
+                expect(harSuperbrukerTilgang(saksbehandler)).toBe(true);
+            });
+        });
+    });
+});

--- a/src/frontend/typer/saksbehandler.test.ts
+++ b/src/frontend/typer/saksbehandler.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { BehandlerRolle } from './behandling';
-import { utledBehandlerRolle, harSuperbrukertilgang, harSkrivetilgang } from './saksbehandler';
-import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import {
+    utledBehandlerRolle,
+    harSuperbrukertilgang,
+    harSkrivetilgang,
+    mapISaksbehandlerTilSaksbehandler,
+} from './saksbehandler';
+import { lagISaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
 import { erProd } from '../utils/miljø';
 
 vi.mock('../utils/miljø', () => ({
@@ -14,80 +19,132 @@ describe('Saksbehandler', () => {
         vi.resetAllMocks();
     });
 
-    describe('Når miljø ikke er prod (Dev/Preprod)', () => {
+    const devGrupper = {
+        veileder: '71f503a2-c28f-4394-a05a-8da263ceca4a',
+        saksbehandler: 'c7e0b108-7ae6-432c-9ab4-946174c240c0',
+        beslutter: '52fe1bef-224f-49df-a40a-29f92d4520f8',
+        superbruker: '314fa714-f13c-4cdc-ac5c-e13ce08e241c',
+        ukjent: 'en-tilfeldig-gruppe-id',
+    };
+
+    const prodGrupper = {
+        veileder: '54cd86b8-2e23-48b2-8852-b05b5827bb0f',
+        saksbehandler: 'e40090eb-c2fb-400e-b412-e9084019a73b',
+        beslutter: '4e7f23d9-5db1-45c0-acec-89c86a9ec678',
+        superbruker: 'b8158d87-a284-4620-9bf9-f0aa3f62c8aa',
+    };
+
+    describe('utledBehandlerRolle - ikke prod', () => {
         beforeEach(() => {
             vi.mocked(erProd).mockReturnValue(false);
         });
 
-        const devGrupper = {
-            veileder: '71f503a2-c28f-4394-a05a-8da263ceca4a',
-            saksbehandler: 'c7e0b108-7ae6-432c-9ab4-946174c240c0',
-            beslutter: '52fe1bef-224f-49df-a40a-29f92d4520f8',
-            superbruker: '314fa714-f13c-4cdc-ac5c-e13ce08e241c',
-            ukjent: 'en-tilfeldig-gruppe-id',
-        };
-
-        describe('utledBehandlerRolle', () => {
-            it('skal returnere høyeste rolle (BESLUTTER) ved flere grupper', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.veileder, devGrupper.beslutter] });
-                expect(utledBehandlerRolle(saksbehandler)).toBe(BehandlerRolle.BESLUTTER);
-            });
-
-            it('skal kaste feil hvis ingen gyldige grupper finnes', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.ukjent] });
-                expect(() => utledBehandlerRolle(saksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
-            });
+        it('skal returnere høyeste rolle (BESLUTTER) ved flere grupper', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [devGrupper.veileder, devGrupper.beslutter] });
+            expect(utledBehandlerRolle(iSaksbehandler)).toBe(BehandlerRolle.BESLUTTER);
         });
 
-        describe('harSuperbrukertilgang', () => {
-            it('skal returnere true hvis bruker har superbruker-gruppe', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.superbruker] });
-                expect(harSuperbrukertilgang(saksbehandler)).toBe(true);
-            });
-        });
-
-        describe('harSkrivetilgang', () => {
-            it('skal returnere true for SAKSBEHANDLER', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.saksbehandler] });
-                expect(harSkrivetilgang(saksbehandler)).toBe(true);
-            });
-
-            it('skal returnere false for kun VEILEDER', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.veileder] });
-                expect(harSkrivetilgang(saksbehandler)).toBe(false);
-            });
+        it('skal kaste feil hvis ingen gyldige grupper finnes', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [devGrupper.ukjent] });
+            expect(() => utledBehandlerRolle(iSaksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
         });
     });
 
-    describe('Når miljø ER prod', () => {
+    describe('utledBehandlerRolle - prod', () => {
         beforeEach(() => {
             vi.mocked(erProd).mockReturnValue(true);
         });
 
-        const prodGrupper = {
-            veileder: '54cd86b8-2e23-48b2-8852-b05b5827bb0f',
-            saksbehandler: 'e40090eb-c2fb-400e-b412-e9084019a73b',
-            beslutter: '4e7f23d9-5db1-45c0-acec-89c86a9ec678',
-            superbruker: 'b8158d87-a284-4620-9bf9-f0aa3f62c8aa',
-        };
-
-        describe('utledBehandlerRolle', () => {
-            it('skal returnere riktig rolle basert på prod-grupper', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [prodGrupper.saksbehandler] });
-                expect(utledBehandlerRolle(saksbehandler)).toBe(BehandlerRolle.SAKSBEHANDLER);
-            });
-
-            it('skal kaste feil hvis en bruker i prod kun har dev-grupper', () => {
-                const devVeilederGruppe = '93a26831-9866-4410-927b-74ff51a9107c';
-                const saksbehandler = lagSaksbehandler({ groups: [devVeilederGruppe] });
-                expect(() => utledBehandlerRolle(saksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
-            });
+        it('skal returnere riktig rolle basert på prod-grupper', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [prodGrupper.saksbehandler] });
+            expect(utledBehandlerRolle(iSaksbehandler)).toBe(BehandlerRolle.SAKSBEHANDLER);
         });
 
-        describe('harSuperbrukertilgang', () => {
-            it('skal returnere true for prod-superbruker', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [prodGrupper.superbruker] });
-                expect(harSuperbrukertilgang(saksbehandler)).toBe(true);
+        it('skal kaste feil hvis en bruker i prod kun har dev-grupper', () => {
+            const devVeilederGruppe = '93a26831-9866-4410-927b-74ff51a9107c';
+            const iSaksbehandler = lagISaksbehandler({ groups: [devVeilederGruppe] });
+            expect(() => utledBehandlerRolle(iSaksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
+        });
+    });
+
+    describe('harSuperbrukertilgang - ikke prod', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(false);
+        });
+
+        it('skal returnere true hvis bruker har superbruker-gruppe', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [devGrupper.superbruker] });
+            expect(harSuperbrukertilgang(iSaksbehandler)).toBe(true);
+        });
+    });
+
+    describe('harSuperbrukertilgang - prod', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(true);
+        });
+
+        it('skal returnere true for prod-superbruker', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [prodGrupper.superbruker] });
+            expect(harSuperbrukertilgang(iSaksbehandler)).toBe(true);
+        });
+    });
+
+    describe('harSkrivetilgang - ikke prod', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(false);
+        });
+
+        it('skal returnere true for SAKSBEHANDLER', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [devGrupper.saksbehandler] });
+            expect(harSkrivetilgang(iSaksbehandler)).toBe(true);
+        });
+
+        it('skal returnere false for kun VEILEDER', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [devGrupper.veileder] });
+            expect(harSkrivetilgang(iSaksbehandler)).toBe(false);
+        });
+    });
+
+    describe('harSkrivetilgang - prod', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(true);
+        });
+
+        it('skal returnere true for SAKSBEHANDLER', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [prodGrupper.saksbehandler] });
+            expect(harSkrivetilgang(iSaksbehandler)).toBe(true);
+        });
+
+        it('skal returnere false for kun VEILEDER', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [prodGrupper.veileder] });
+            expect(harSkrivetilgang(iSaksbehandler)).toBe(false);
+        });
+    });
+
+    describe('mapISaksbehandlerTilSaksbehandler', () => {
+        it('skal kaste feil hvis groups er undefined for ISaksbehandler', () => {
+            // Arrange
+            const iSaksbehandler = lagISaksbehandler({ groups: undefined });
+
+            // Act & assert
+            expect(() => mapISaksbehandlerTilSaksbehandler(iSaksbehandler)).toThrow(
+                'Finner ikke rolle til saksbehandler.'
+            );
+        });
+
+        it('skal bevare gruppene fra ISaksbehandler', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: ['71f503a2-c28f-4394-a05a-8da263ceca4a'] });
+
+            // Act
+            const result = mapISaksbehandlerTilSaksbehandler(iSaksbehandler);
+
+            // Assert
+            expect(result).toEqual({
+                ...iSaksbehandler,
+                groups: ['71f503a2-c28f-4394-a05a-8da263ceca4a'],
+                rolle: BehandlerRolle.VEILEDER,
+                harSkrivetilgang: false,
+                harSuperbrukertilgang: false,
             });
         });
     });

--- a/src/frontend/typer/saksbehandler.ts
+++ b/src/frontend/typer/saksbehandler.ts
@@ -24,11 +24,15 @@ function hentGruppeIdTilSuperbrukerRolle() {
 
 export interface Saksbehandler extends ISaksbehandler {
     groups: string[];
+    rolle: BehandlerRolle;
+    harSkrivetilgang: boolean;
+    harSuperbrukertilgang: boolean;
 }
 
-export function utledBehandlerRolle(saksbehandler: Saksbehandler): BehandlerRolle {
+export function utledBehandlerRolle(iSaksbehandler: ISaksbehandler): BehandlerRolle {
     let rolle = BehandlerRolle.UKJENT;
-    saksbehandler.groups.forEach(id => {
+    const groups = iSaksbehandler.groups ?? [];
+    groups.forEach(id => {
         rolle = rolle < gruppeIdTilRolle(id) ? gruppeIdTilRolle(id) : rolle;
     });
     if (rolle === BehandlerRolle.UKJENT) {
@@ -37,11 +41,22 @@ export function utledBehandlerRolle(saksbehandler: Saksbehandler): BehandlerRoll
     return rolle;
 }
 
-export function harSuperbrukertilgang(saksbehandler: Saksbehandler) {
-    return saksbehandler.groups.includes(hentGruppeIdTilSuperbrukerRolle());
+export function harSuperbrukertilgang(iSaksbehandler: ISaksbehandler) {
+    const groups = iSaksbehandler.groups ?? [];
+    return groups.includes(hentGruppeIdTilSuperbrukerRolle());
 }
 
-export function harSkrivetilgang(saksbehandler: Saksbehandler) {
-    const rolle = utledBehandlerRolle(saksbehandler);
+export function harSkrivetilgang(iSaksbehandler: ISaksbehandler) {
+    const rolle = utledBehandlerRolle(iSaksbehandler);
     return rolle >= BehandlerRolle.SAKSBEHANDLER;
+}
+
+export function mapISaksbehandlerTilSaksbehandler(iSaksbehandler: ISaksbehandler): Saksbehandler {
+    return {
+        ...iSaksbehandler,
+        groups: iSaksbehandler.groups ?? [],
+        rolle: utledBehandlerRolle(iSaksbehandler),
+        harSkrivetilgang: harSkrivetilgang(iSaksbehandler),
+        harSuperbrukertilgang: harSuperbrukertilgang(iSaksbehandler),
+    };
 }

--- a/src/frontend/typer/saksbehandler.ts
+++ b/src/frontend/typer/saksbehandler.ts
@@ -37,7 +37,7 @@ export function utledBehandlerRolle(saksbehandler: Saksbehandler): BehandlerRoll
     return rolle;
 }
 
-export function harSuperbrukerTilgang(saksbehandler: Saksbehandler) {
+export function harSuperbrukertilgang(saksbehandler: Saksbehandler) {
     return saksbehandler.groups.includes(hentGruppeIdTilSuperbrukerRolle());
 }
 

--- a/src/frontend/typer/saksbehandler.ts
+++ b/src/frontend/typer/saksbehandler.ts
@@ -1,0 +1,47 @@
+import type { ISaksbehandler } from '@navikt/familie-typer';
+
+import { BehandlerRolle } from './behandling';
+import { erProd } from '../utils/miljø';
+
+function gruppeIdTilRolle(gruppeId: string) {
+    const rolleConfig = erProd()
+        ? new Map([
+              ['54cd86b8-2e23-48b2-8852-b05b5827bb0f', BehandlerRolle.VEILEDER],
+              ['e40090eb-c2fb-400e-b412-e9084019a73b', BehandlerRolle.SAKSBEHANDLER],
+              ['4e7f23d9-5db1-45c0-acec-89c86a9ec678', BehandlerRolle.BESLUTTER],
+          ])
+        : new Map([
+              ['71f503a2-c28f-4394-a05a-8da263ceca4a', BehandlerRolle.VEILEDER],
+              ['c7e0b108-7ae6-432c-9ab4-946174c240c0', BehandlerRolle.SAKSBEHANDLER],
+              ['52fe1bef-224f-49df-a40a-29f92d4520f8', BehandlerRolle.BESLUTTER],
+          ]);
+    return rolleConfig.get(gruppeId) ?? BehandlerRolle.UKJENT;
+}
+
+function hentGruppeIdTilSuperbrukerRolle() {
+    return erProd() ? 'b8158d87-a284-4620-9bf9-f0aa3f62c8aa' : '314fa714-f13c-4cdc-ac5c-e13ce08e241c';
+}
+
+export interface Saksbehandler extends ISaksbehandler {
+    groups: string[];
+}
+
+export function utledBehandlerRolle(saksbehandler: Saksbehandler): BehandlerRolle {
+    let rolle = BehandlerRolle.UKJENT;
+    saksbehandler.groups.forEach(id => {
+        rolle = rolle < gruppeIdTilRolle(id) ? gruppeIdTilRolle(id) : rolle;
+    });
+    if (rolle === BehandlerRolle.UKJENT) {
+        throw new Error('Finner ikke rolle til saksbehandler.');
+    }
+    return rolle;
+}
+
+export function harSuperbrukerTilgang(saksbehandler: Saksbehandler) {
+    return saksbehandler.groups.includes(hentGruppeIdTilSuperbrukerRolle());
+}
+
+export function harSkrivetilgang(saksbehandler: Saksbehandler) {
+    const rolle = utledBehandlerRolle(saksbehandler);
+    return rolle >= BehandlerRolle.SAKSBEHANDLER;
+}

--- a/src/frontend/utils/behandling.ts
+++ b/src/frontend/utils/behandling.ts
@@ -1,28 +1,7 @@
-import { erProd } from './miljø';
 import type { IBehandling } from '../typer/behandling';
-import { BehandlerRolle } from '../typer/behandling';
 import type { IGrunnlagPerson } from '../typer/person';
 import { PersonType } from '../typer/person';
 import { Målform } from '../typer/søknad';
-
-export const gruppeIdTilRolle = (gruppeId: string) => {
-    const rolleConfig = erProd()
-        ? new Map([
-              ['54cd86b8-2e23-48b2-8852-b05b5827bb0f', BehandlerRolle.VEILEDER],
-              ['e40090eb-c2fb-400e-b412-e9084019a73b', BehandlerRolle.SAKSBEHANDLER],
-              ['4e7f23d9-5db1-45c0-acec-89c86a9ec678', BehandlerRolle.BESLUTTER],
-          ])
-        : new Map([
-              ['71f503a2-c28f-4394-a05a-8da263ceca4a', BehandlerRolle.VEILEDER],
-              ['c7e0b108-7ae6-432c-9ab4-946174c240c0', BehandlerRolle.SAKSBEHANDLER],
-              ['52fe1bef-224f-49df-a40a-29f92d4520f8', BehandlerRolle.BESLUTTER],
-          ]);
-    return rolleConfig.get(gruppeId) ?? BehandlerRolle.UKJENT;
-};
-
-export const gruppeIdTilSuperbrukerRolle = erProd()
-    ? 'b8158d87-a284-4620-9bf9-f0aa3f62c8aa'
-    : '314fa714-f13c-4cdc-ac5c-e13ce08e241c';
 
 export const hentSøkersMålform = (behandling: IBehandling) =>
     behandling.personer.find((person: IGrunnlagPerson) => {


### PR DESCRIPTION
### 📮 Favro
NAV-28401

### 💰 Hva skal gjøres, og hvorfor?
Flytter saksbehandler tilstanden til react-query. Introdusere en "composite" `useSaksbehandler` hook for å hente ut saksbehandler, samt legger til ekstra informasjon som som `rolle`, `harSkrivetilgang`, og `harSuperbrukertilgang`. Dette vil også gjøre slik at vi ikke trenger å sjekke saksbehandler for `undefined` da man alltid vil ha en `saksbehandler` i minne hvis man har lastet inn applikasjonen. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
Feil ved innlasting av saksbehandler:
<img width="3099" height="113" alt="image" src="https://github.com/user-attachments/assets/60b89a2a-47f2-4f6d-9439-145d5924732c" />