### PR TITLE
NAV-28170: Splitter navn og ident i venstremeny

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.module.css
@@ -5,6 +5,7 @@
 
 .venstreKolonne {
     min-width: 1rem;
+    max-width: 22rem;
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
@@ -1,3 +1,7 @@
+.container {
+    min-width: 18rem;
+}
+
 .knapp {
     position: absolute;
     margin-right: -20px;
@@ -15,6 +19,7 @@
     text-decoration: none;
     padding: var(--ax-space-8) var(--ax-space-20);
     border-left: 5px solid transparent;
+    user-select: text;
 }
 
 .menylenke:focus-visible {
@@ -31,6 +36,7 @@
     text-decoration: none;
     padding: var(--ax-space-8) var(--ax-space-16);
     border-left: 5px solid transparent;
+    user-select: text;
 }
 
 .undersidelenke.active {
@@ -64,4 +70,8 @@
     place-items: center;
     height: var(--ax-space-24);
     width: var(--ax-space-24);
+}
+
+.ident {
+    font-style: italic;
 }

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { NavLink } from 'react-router';
 
 import { ChevronLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons';
-import { BodyShort, Box, Button, HStack, Stack, VStack } from '@navikt/ds-react';
+import { BodyShort, Box, Button, CopyButton, HStack, Stack, VStack } from '@navikt/ds-react';
 
 import { useVenstremeny } from './useVenstremeny';
 import Styles from './Venstremeny.module.css';
@@ -44,7 +44,7 @@ export function Venstremeny() {
                 onClick={() => settErÅpen(prev => !prev)}
             />
             <Activity mode={erÅpen ? 'visible' : 'hidden'}>
-                <Box as={'nav'}>
+                <Box as={'nav'} className={Styles.container}>
                     {Object.entries(trinnPåBehandling).map(([sideId, side], index) => {
                         const tilPath = `/fagsak/${fagsakId}/${behandling.behandlingId}/${side.href}`;
                         const undersider = side.undersider ? side.undersider(behandling) : [];
@@ -61,6 +61,7 @@ export function Venstremeny() {
                                         })
                                     }
                                     onClick={event => stansNavigeringDersomSidenIkkeErAktiv(event, sidenErAktiv)}
+                                    draggable={false}
                                 >
                                     {`${index + 1}. ${side.navn}`}
                                 </NavLink>
@@ -80,6 +81,7 @@ export function Venstremeny() {
                                             onClick={event =>
                                                 stansNavigeringDersomSidenIkkeErAktiv(event, sidenErAktiv)
                                             }
+                                            draggable={false}
                                         >
                                             <HStack align={'center'} gap={'space-8'} wrap={false}>
                                                 {antallAksjonspunkter > 0 ? (
@@ -89,9 +91,15 @@ export function Venstremeny() {
                                                 ) : (
                                                     <Box padding={'space-12'} />
                                                 )}
-                                                <BodyShort size={'small'}>
-                                                    {underside.navn}, {formaterIdent(underside.ident)}
-                                                </BodyShort>
+                                                <VStack>
+                                                    <BodyShort>{underside.navn}</BodyShort>
+                                                    <HStack align={'center'}>
+                                                        <BodyShort size={'small'} className={Styles.ident}>
+                                                            {formaterIdent(underside.ident)}
+                                                        </BodyShort>
+                                                        <CopyButton copyText={underside.ident} size={'xsmall'} />
+                                                    </HStack>
+                                                </VStack>
                                             </HStack>
                                         </NavLink>
                                     );


### PR DESCRIPTION
### 📮 Favro
NAV-28170

### 💰 Hva skal gjøres, og hvorfor?
For å bedre håndtere småe skjermer deler jeg navn og ident opp på hver sin linje. Legger også til en kopieringsknapp på identen da jeg ofte har tenkt at det kunne være nyttig. Setter også `max-width` på venstremenyen slik at den ikke skal vokse i uendeligheten. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
Gammel:
<img width="674" height="629" alt="image" src="https://github.com/user-attachments/assets/baa52178-bc3e-4ca1-baea-1ab04fcbb168" />

Ny med korte navn:
<img width="351" height="558" alt="image" src="https://github.com/user-attachments/assets/adba60e9-8be6-4d64-8844-7d23562f345b" />

Ny med veldig lange navn:
<img width="362" height="499" alt="image" src="https://github.com/user-attachments/assets/fce9c19a-5b73-4c0f-b26d-c33a1b451ca6" />
