### PR TITLE
NAV-26655 Disable Bekreft-knapp ved lesevisning

### DIFF
--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/BehandlingstemaSelect.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/BehandlingstemaSelect.tsx
@@ -3,13 +3,14 @@ import { useController, useFormContext } from 'react-hook-form';
 import { Select } from '@navikt/ds-react';
 
 import { EndreBehandlingstemaFelt, type EndreBehandlingstemaFormValues } from './useEndreBehandlingstemaSkjema';
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
 import type { IBehandlingstema } from '../../../../typer/behandlingstema';
 import { behandlingstemaer } from '../../../../typer/behandlingstema';
 
-export const BehandlingstemaSelect = () => {
-    const { vurderErLesevisning } = useBehandlingContext();
+interface Props {
+    erLesevisning: boolean;
+}
 
+export const BehandlingstemaSelect = ({ erLesevisning }: Props) => {
     const { control } = useFormContext<EndreBehandlingstemaFormValues>();
     const {
         field: { value, onChange },
@@ -22,8 +23,6 @@ export const BehandlingstemaSelect = () => {
             required: 'Behandlingstema må velges.',
         },
     });
-
-    const erLesevisning = vurderErLesevisning();
 
     const konverterTilBehandlingstema = (behandlingstemaId: string): IBehandlingstema => {
         return behandlingstemaer[behandlingstemaId as keyof typeof behandlingstemaer];

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/EndreBehandlingstemaModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/EndreBehandlingstemaModal.tsx
@@ -4,12 +4,16 @@ import { Button, Fieldset, Modal } from '@navikt/ds-react';
 
 import { BehandlingstemaSelect } from './BehandlingstemaSelect';
 import { useEndreBehandlingstemaSkjema } from './useEndreBehandlingstemaSkjema';
+import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
 
 interface Props {
     lukkModal: () => void;
 }
 
 export const EndreBehandlingstemaModal = ({ lukkModal }: Props) => {
+    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = vurderErLesevisning();
+
     const { form, onSubmit } = useEndreBehandlingstemaSkjema({ lukkModal });
 
     const {
@@ -17,15 +21,11 @@ export const EndreBehandlingstemaModal = ({ lukkModal }: Props) => {
         formState: { isSubmitting, errors },
     } = form;
 
-    const onClose = () => {
-        lukkModal();
-    };
-
     return (
         <Modal
             open
             header={{ heading: 'Endre behandlingstema', size: 'small' }}
-            onClose={onClose}
+            onClose={lukkModal}
             width={'35rem'}
             portal
         >
@@ -33,14 +33,20 @@ export const EndreBehandlingstemaModal = ({ lukkModal }: Props) => {
                 <form onSubmit={handleSubmit(onSubmit)}>
                     <Modal.Body>
                         <Fieldset error={errors.root?.message} legend={'Endre behandlingstema'} hideLegend>
-                            <BehandlingstemaSelect />
+                            <BehandlingstemaSelect erLesevisning={erLesevisning} />
                         </Fieldset>
                     </Modal.Body>
                     <Modal.Footer>
-                        <Button type={'submit'} variant="primary" size="small" loading={isSubmitting}>
+                        <Button
+                            type={'submit'}
+                            variant="primary"
+                            size="small"
+                            loading={isSubmitting}
+                            disabled={erLesevisning}
+                        >
                             Bekreft
                         </Button>
-                        <Button variant="secondary" size="small" onClick={onClose}>
+                        <Button variant="secondary" size="small" onClick={lukkModal}>
                             Avbryt
                         </Button>
                     </Modal.Footer>


### PR DESCRIPTION
### 📮 Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-26655

### 💰 Hva skal gjøres, og hvorfor?
Fiks av etterslep etter refaktorering av EndreBehandlingstema. Disable Bekreft-knapp ved lesevisning og fjern redundant `onClose` til fordel for å bruke `lukkModal` direkte.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_ ingen visuelle eller funksjonelle endringer