### PR TITLE
Sett flagg på fagsak som sier om det er strengt fortrolig personer i fagsaken eller ikke

### DIFF
--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/BehandlingstypeFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/BehandlingstypeFelt.tsx
@@ -90,12 +90,14 @@ const BehandlingstypeFelt = ({
                     Tilbakekreving
                 </option>
             )}
-            <option
-                aria-selected={behandlingstype.verdi === Klagebehandlingstype.KLAGE}
-                value={Klagebehandlingstype.KLAGE}
-            >
-                Klage
-            </option>
+            {!minimalFagsak?.finnesStrengtFortroligPersonIFagsak && (
+                <option
+                    aria-selected={behandlingstype.verdi === Klagebehandlingstype.KLAGE}
+                    value={Klagebehandlingstype.KLAGE}
+                >
+                    Klage
+                </option>
+            )}
         </Select>
     );
 };

--- a/src/frontend/testutils/testdata/fagsakTestdata.ts
+++ b/src/frontend/testutils/testdata/fagsakTestdata.ts
@@ -11,6 +11,7 @@ export function lagFagsak(fagsak?: Partial<IMinimalFagsak>): IMinimalFagsak {
         løpendeKategori: undefined,
         behandlinger: [],
         gjeldendeUtbetalingsperioder: [],
+        finnesStrengtFortroligPersonIFagsak: false,
         ...fagsak,
     };
 }

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -24,6 +24,7 @@ interface IBaseFagsak {
 export interface IMinimalFagsak extends IBaseFagsak {
     behandlinger: VisningBehandling[];
     gjeldendeUtbetalingsperioder: Utbetalingsperiode[];
+    finnesStrengtFortroligPersonIFagsak: boolean;
 }
 
 export const fagsakStatus: INøkkelPar = {

--- a/src/frontend/utils/test/minimalFagsak/minimalFagsak.mock.ts
+++ b/src/frontend/utils/test/minimalFagsak/minimalFagsak.mock.ts
@@ -15,6 +15,7 @@ interface IMockMinimalFagsak {
     søkerFødselsnummer?: string;
     underBehandling?: boolean;
     løpendeKategori?: BehandlingKategori;
+    finnesStrengtFortroligPersonIFagsak?: boolean;
 }
 
 export const mockMinimalFagsak = ({
@@ -27,6 +28,7 @@ export const mockMinimalFagsak = ({
     søkerFødselsnummer = '12345678910',
     underBehandling = false,
     løpendeKategori = BehandlingKategori.NASJONAL,
+    finnesStrengtFortroligPersonIFagsak = false,
 }: IMockMinimalFagsak = {}): IMinimalFagsak => ({
     behandlinger,
     id,
@@ -37,4 +39,5 @@ export const mockMinimalFagsak = ({
     underBehandling,
     gjeldendeUtbetalingsperioder,
     løpendeKategori,
+    finnesStrengtFortroligPersonIFagsak,
 });


### PR DESCRIPTION
### 📮 Favro: Nav-28618

### 💰 Hva skal gjøres, og hvorfor?

- Bruk nytt flagg fra backend som sier om personene i fagsaken er strengt fortrolige for å skjule klage som årsak/type hvis det er tilfellet. 