### PR TITLE
NAV-28202 samsvar farger og ikon

### DIFF
--- a/src/frontend/ikoner/StatusIkon.tsx
+++ b/src/frontend/ikoner/StatusIkon.tsx
@@ -20,25 +20,25 @@ export enum Status {
 }
 
 const OkIkon = styled(CheckmarkCircleFillIcon)`
-    color: var(--ax-success-600);
+    color: var(--ax-text-success-subtle);
     font-size: 1.5rem;
     min-width: 1.5rem;
 `;
 
 const FeilIkon = styled(XMarkOctagonFillIcon)`
-    color: var(--ax-danger-700);
+    color: var(--ax-text-danger-subtle);
     font-size: 1.5rem;
     min-width: 1.5rem;
 `;
 
 const AdvarselIkon = styled(ExclamationmarkTriangleFillIcon)`
-    color: var(--ax-warning-500);
+    color: var(--ax-text-warning-subtle);
     font-size: 1.5rem;
     min-width: 1.5rem;
 `;
 
 const InfoIkon = styled(InformationSquareFillIcon)`
-    color: var(--ax-info-700);
+    color: var(--ax-text-info-subtle);
     font-size: 1.5rem;
     min-width: 1.5rem;
 `;

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårEkspanderbarRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårEkspanderbarRad.tsx
@@ -7,8 +7,7 @@ import { BodyShort, Table } from '@navikt/ds-react';
 
 import { vilkårFeilmeldingId } from './VilkårTabell';
 import VilkårResultatIkon from '../../../../../../ikoner/VilkårResultatIkon';
-import type { IVilkårResultat } from '../../../../../../typer/vilkår';
-import { uiResultat } from '../../../../../../typer/vilkår';
+import { type IVilkårResultat, uiResultat } from '../../../../../../typer/vilkår';
 import {
     Datoformat,
     isoDatoPeriodeTilFormatertString,

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Fieldset, Label, Radio, RadioGroup, Select, Textarea } from '@navikt/ds-react';
-import { BorderAccent, BorderNeutral, BorderWarning } from '@navikt/ds-tokens/dist/tokens';
+import { BorderNeutral, TextInfoSubtle, TextWarningSubtle } from '@navikt/ds-tokens/dist/tokens';
 
 import AvslagSkjema from './AvslagSkjema';
 import { UtdypendeVilkårsvurderingMultiselect } from './UtdypendeVilkårsvurderingMultiselect';
@@ -29,9 +29,9 @@ export const FieldsetForVilkårSkjema = styled(Fieldset)<{
             if (props.$lesevisning) {
                 return BorderNeutral;
             } else if (props.$ikkeVurdert) {
-                return BorderWarning;
+                return TextWarningSubtle;
             }
-            return BorderAccent;
+            return TextInfoSubtle;
         }};
     padding-left: 2rem;
 `;


### PR DESCRIPTION
### 📮 Favro: NAV-28202

### 💰 Hva skal gjøres, og hvorfor?
Farger var ulik de som ble brukt i Aksel ettersom de var selvvalgt etter Aksel V.8 oppdatering. Denne fiksen vil bruke samme farge som er brukt i InlineMessage komponenten.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Oppdatering av accent fargen for border-left er veldig mørk for å samsvare med info-ikon. Men da blir den mørk og ser ganske lik ut lesevisning border neutral. Tanker? Behold lysere accent farge?

Bemerk at bildene ikke er reelle eksempler, det er nok ikke mange InlineMessage på disse sidene, men det fins ihvertfall EN warning et sted, men uansett så vil fargene nå samsvare.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 👀 Screen shots
success
før
<img width="472" height="415" alt="Bosatt i riket" src="https://github.com/user-attachments/assets/fcb3cca4-33d1-4a97-99b0-b66b72c406b0" />
etter
<img width="392" height="335" alt="Bosatt i riket" src="https://github.com/user-attachments/assets/43e6923f-6339-4234-a7e3-a5056f7ab885" />

warning
før
<img width="500" height="358" alt="Bosatt i riket" src="https://github.com/user-attachments/assets/3f2fe8b0-145b-4062-a4aa-f250f7ad2f5a" />

etter
<img width="601" height="441" alt="Bosatt i riket" src="https://github.com/user-attachments/assets/d31bb8a4-31b4-4670-b5d3-c648357236bc" />

error
før
<img width="538" height="378" alt="Bosatt i riket" src="https://github.com/user-attachments/assets/a571ffe3-a596-4717-adbf-a0762d6bf424" />

etter
<img width="522" height="407" alt="Bosatt i riket" src="https://github.com/user-attachments/assets/492ca5f6-648a-40ca-a784-b2cf595d408b" />

info
før
<img width="612" height="368" alt="KRITISK HUNDEKJEKS (32 år)  295093 42316 @  Søker" src="https://github.com/user-attachments/assets/e3fe9aaf-6041-411f-a146-4e00a6a5fbd3" />

etter
<img width="596" height="452" alt="Bosatt i riket" src="https://github.com/user-attachments/assets/2ce33c39-e004-4124-ae7c-ce39d4ba066d" />

lesevisning (ikke endret)
<img width="389" height="305" alt="Vurdering" src="https://github.com/user-attachments/assets/f553a73f-1b66-4bd7-a48d-d4f08a34f3ea" />
