### PR TITLE
NAV-28170: Tilpasser venstre- og høyremeny

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.module.css
@@ -5,7 +5,6 @@
 
 .venstreKolonne {
     min-width: 1rem;
-    max-width: 22rem;
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
@@ -20,7 +19,6 @@
 
 .høyreKolonne {
     min-width: 1rem;
-    max-width: 25rem;
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Behandlingskort.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Behandlingskort.tsx
@@ -1,19 +1,9 @@
-import styled from 'styled-components';
+import { BodyShort, Box, Heading, HStack, VStack } from '@navikt/ds-react';
+import { TextDangerSubtle, TextInfoSubtle, TextNeutral, TextSuccessSubtle } from '@navikt/ds-tokens/dist/tokens';
 
-import { BodyShort, Heading } from '@navikt/ds-react';
-import {
-    BorderAccent,
-    BorderDanger,
-    BorderNeutral,
-    BorderNeutralSubtle,
-    BorderSuccess,
-    TextDangerSubtle,
-    TextInfoSubtle,
-    TextNeutral,
-    TextSuccessSubtle,
-} from '@navikt/ds-tokens/dist/tokens';
-
-import Informasjonsbolk from './Informasjonsbolk';
+import { Informasjonsbolk } from './Informasjonsbolk';
+import { useBehandling } from '../../../../../hooks/useBehandling';
+import { useFagsak } from '../../../../../hooks/useFagsak';
 import {
     BehandlingResultat,
     behandlingsresultater,
@@ -22,128 +12,119 @@ import {
     behandlingÅrsak,
     erBehandlingHenlagt,
 } from '../../../../../typer/behandling';
+import { behandlingKategori } from '../../../../../typer/behandlingstema';
 import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
-import { useFagsakContext } from '../../../FagsakContext';
-import { sakstype } from '../../../Saksoversikt/Saksoversikt';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 
-const hentResultatfarge = (behandlingResultat: BehandlingResultat) => {
+function hentResultatfarge(behandlingResultat: BehandlingResultat) {
     if (erBehandlingHenlagt(behandlingResultat)) {
-        return BorderNeutralSubtle;
+        return 'neutral-subtle';
     }
-
     switch (behandlingResultat) {
         case BehandlingResultat.INNVILGET:
         case BehandlingResultat.DELVIS_INNVILGET:
         case BehandlingResultat.FORTSATT_INNVILGET:
-            return BorderSuccess;
-        case (BehandlingResultat.ENDRET_UTBETALING, BehandlingResultat.ENDRET_UTEN_UTBETALING):
-            return BorderAccent;
+            return 'success';
+        case BehandlingResultat.ENDRET_UTBETALING:
+        case BehandlingResultat.ENDRET_UTEN_UTBETALING:
+            return 'accent';
         case BehandlingResultat.AVSLÅTT:
-        case (BehandlingResultat.OPPHØRT, BehandlingResultat.FORTSATT_OPPHØRT):
-            return BorderDanger;
+        case BehandlingResultat.OPPHØRT:
+        case BehandlingResultat.FORTSATT_OPPHØRT:
+            return 'danger';
         case BehandlingResultat.IKKE_VURDERT:
-            return BorderNeutralSubtle;
+            return 'neutral-subtle';
         default:
-            return BorderNeutral;
+            return 'neutral';
     }
-};
+}
 
-const hentResultatfargeTekst = (behandlingResultat: BehandlingResultat) => {
+function hentResultatfargeTekst(behandlingResultat: BehandlingResultat) {
     if (erBehandlingHenlagt(behandlingResultat)) {
         return TextNeutral;
     }
-
     switch (behandlingResultat) {
         case BehandlingResultat.INNVILGET:
         case BehandlingResultat.DELVIS_INNVILGET:
         case BehandlingResultat.FORTSATT_INNVILGET:
             return TextSuccessSubtle;
-        case (BehandlingResultat.ENDRET_UTBETALING, BehandlingResultat.ENDRET_UTEN_UTBETALING):
+        case BehandlingResultat.ENDRET_UTBETALING:
+        case BehandlingResultat.ENDRET_UTEN_UTBETALING:
             return TextInfoSubtle;
         case BehandlingResultat.AVSLÅTT:
-        case (BehandlingResultat.OPPHØRT, BehandlingResultat.FORTSATT_OPPHØRT):
+        case BehandlingResultat.OPPHØRT:
+        case BehandlingResultat.FORTSATT_OPPHØRT:
             return TextDangerSubtle;
         default:
             return TextNeutral;
     }
-};
-
-const Container = styled.div<{ $behandlingResultat: BehandlingResultat }>`
-    border: 1px solid ${BorderNeutralSubtle};
-    border-left: 0.5rem solid ${BorderNeutralSubtle};
-    border-radius: 0.25rem;
-    padding: 0.5rem;
-    margin: 0.5rem;
-    border-color: ${({ $behandlingResultat }) => hentResultatfarge($behandlingResultat)};
-`;
-
-const StyledHeading = styled(Heading)`
-    font-size: 1rem;
-    margin-bottom: 0.2rem;
-`;
-
-const StyledHr = styled.hr`
-    border: none;
-    border-bottom: 1px solid ${BorderNeutralSubtle};
-`;
+}
 
 export function Behandlingskort() {
-    const { fagsak } = useFagsakContext();
-    const { behandling } = useBehandlingContext();
+    const fagsak = useFagsak();
+    const behandling = useBehandling();
 
-    const behandlinger = fagsak.behandlinger ?? [];
-
+    const behandlinger = fagsak.behandlinger;
     const antallBehandlinger = behandlinger.length;
     const behandlingIndex = behandlinger.findIndex(b => b.behandlingId === behandling.behandlingId) + 1;
 
-    const tittel = `${behandlingstyper[behandling.type].navn} (${behandlingIndex}/${antallBehandlinger}) - ${sakstype(behandling).toLowerCase()}`;
-
     return (
-        <Container $behandlingResultat={behandling.resultat}>
-            <StyledHeading size={'small'} level={'2'}>
-                {tittel}
-            </StyledHeading>
-            <BodyShort>{behandlingÅrsak[behandling.årsak]}</BodyShort>
-            <StyledHr />
-            <Informasjonsbolk label="Behandlingsstatus" tekst={behandlingsstatuser[behandling.status]} />
-            <Informasjonsbolk
-                label="Resultat"
-                tekst={behandlingsresultater[behandling.resultat]}
-                tekstFarge={hentResultatfargeTekst(behandling.resultat)}
-            />
-            <div>
-                {behandling.søknadMottattDato && (
+        <Box
+            padding="space-8"
+            borderColor={hentResultatfarge(behandling.resultat)}
+            borderWidth="1 1 1 5"
+            borderRadius="4"
+            margin="space-8"
+        >
+            <Box borderWidth="0 0 1 0" borderColor="neutral-subtle">
+                <VStack gap="space-4" marginBlock="space-0 space-8">
+                    <HStack gap={'space-4'}>
+                        <Heading size={'xsmall'} level={'2'}>
+                            {`${behandlingstyper[behandling.type].navn} (${behandlingIndex}/${antallBehandlinger})`}
+                        </Heading>
+                        <BodyShort>{behandlingKategori[behandling.kategori]}</BodyShort>
+                    </HStack>
+                    <BodyShort>{behandlingÅrsak[behandling.årsak]}</BodyShort>
+                </VStack>
+            </Box>
+            <VStack gap="space-16" marginBlock="space-12 space-0">
+                <Informasjonsbolk label="Behandlingsstatus" tekst={behandlingsstatuser[behandling.status]} />
+                <Informasjonsbolk
+                    label="Resultat"
+                    tekst={behandlingsresultater[behandling.resultat]}
+                    tekstFarge={hentResultatfargeTekst(behandling.resultat)}
+                />
+                <Box>
+                    {behandling.søknadMottattDato && (
+                        <Informasjonsbolk
+                            label="Søknad mottatt"
+                            tekst={isoStringTilFormatertString({
+                                isoString: behandling.søknadMottattDato,
+                                tilFormat: Datoformat.DATO,
+                            })}
+                        />
+                    )}
                     <Informasjonsbolk
-                        label="Søknad mottatt"
+                        label="Opprettet"
                         tekst={isoStringTilFormatertString({
-                            isoString: behandling.søknadMottattDato,
+                            isoString: behandling.opprettetTidspunkt,
                             tilFormat: Datoformat.DATO,
                         })}
                     />
-                )}
+                    <Informasjonsbolk
+                        label="Vedtaksdato"
+                        tekst={isoStringTilFormatertString({
+                            isoString: behandling.vedtak?.vedtaksdato,
+                            tilFormat: Datoformat.DATO,
+                            defaultString: 'Ikke satt',
+                        })}
+                    />
+                </Box>
                 <Informasjonsbolk
-                    label="Opprettet"
-                    tekst={isoStringTilFormatertString({
-                        isoString: behandling.opprettetTidspunkt,
-                        tilFormat: Datoformat.DATO,
-                    })}
+                    label="Enhet"
+                    tekst={behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId}
+                    tekstHover={behandling.arbeidsfordelingPåBehandling.behandlendeEnhetNavn}
                 />
-                <Informasjonsbolk
-                    label="Vedtaksdato"
-                    tekst={isoStringTilFormatertString({
-                        isoString: behandling.vedtak?.vedtaksdato,
-                        tilFormat: Datoformat.DATO,
-                        defaultString: 'Ikke satt',
-                    })}
-                />
-            </div>
-
-            <Informasjonsbolk
-                label="Enhet"
-                tekst={behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId}
-                tekstHover={behandling.arbeidsfordelingPåBehandling.behandlendeEnhetNavn}
-            />
-        </Container>
+            </VStack>
+        </Box>
     );
 }

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Informasjonsbolk.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Informasjonsbolk.tsx
@@ -1,22 +1,20 @@
 import { BodyShort, HGrid } from '@navikt/ds-react';
 import { TextNeutral } from '@navikt/ds-tokens/dist/tokens';
 
-interface IProps {
+interface Props {
     label: string;
     tekst: string;
     tekstHover?: string;
     tekstFarge?: string;
 }
 
-const Informasjonsbolk = ({ label, tekst, tekstHover, tekstFarge }: IProps) => {
+export function Informasjonsbolk({ label, tekst, tekstHover, tekstFarge }: Props) {
     return (
-        <HGrid columns={2}>
+        <HGrid columns={'1.25fr 1fr'} gap={'space-8'} align={'center'}>
             <BodyShort>{label}</BodyShort>
-            <BodyShort weight="semibold" style={{ color: tekstFarge ?? TextNeutral }} title={tekstHover}>
+            <BodyShort weight={'semibold'} style={{ color: tekstFarge ?? TextNeutral }} title={tekstHover}>
                 {tekst}
             </BodyShort>
         </HGrid>
     );
-};
-
-export default Informasjonsbolk;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
@@ -332,7 +332,7 @@ export const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                 <Button
                     id={'forhandsvis-vedtaksbrev'}
                     variant={'secondary'}
-                    size={'medium'}
+                    size={'small'}
                     disabled={skjemaErLåst}
                     onClick={() => {
                         if (behandling.behandlingId === undefined) {
@@ -351,7 +351,7 @@ export const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                 </Button>
                 <Button
                     variant={'primary'}
-                    size={'medium'}
+                    size={'small'}
                     loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                     disabled={skjemaErLåst}
                     onClick={() => {

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
@@ -48,7 +48,7 @@ export function Høyremeny() {
                     onClick={() => settErÅpen(prev => !prev)}
                 />
                 <Activity mode={erÅpen ? 'visible' : 'hidden'}>
-                    <VStack width={'25rem'}>
+                    <VStack width={'clamp(20rem, 20vw, 25rem)'}>
                         <Behandlingskort />
                         <Tabs value={tab} onChange={tab => settTab(tab as Tab)} iconPosition={'top'}>
                             <Tabvelger />

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Tabvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Tabvelger.tsx
@@ -1,6 +1,5 @@
 import { Tabs } from '@navikt/ds-react';
 
-import IkonDokumenter from './Ikoner/IkonDokumenter';
 import IkonHistorikk from './Ikoner/IkonHistorikk';
 import IkonMeldinger from './Ikoner/IkonMeldinger';
 import IkonTotrinnskontroll from './Ikoner/IkonTotrinnskontroll';
@@ -21,7 +20,6 @@ export function Tabvelger() {
                 <Tabs.Tab value={Tab.Totrinnskontroll} label={Tab.Totrinnskontroll} icon={<IkonTotrinnskontroll />} />
             )}
             <Tabs.Tab value={Tab.Historikk} label={Tab.Historikk} icon={<IkonHistorikk />} />
-            <Tabs.Tab value={Tab.Dokumenter} label={Tab.Dokumenter} icon={<IkonDokumenter />} />
             {!erLesevisning && <Tabs.Tab value={Tab.Meldinger} label={'Send brev'} icon={<IkonMeldinger />} />}
         </Tabs.List>
     );

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
@@ -1,7 +1,3 @@
-.container {
-    min-width: 18rem;
-}
-
 .knapp {
     position: absolute;
     margin-right: -20px;
@@ -17,7 +13,7 @@
 
 .menylenke {
     text-decoration: none;
-    padding: var(--ax-space-8) var(--ax-space-20);
+    padding: var(--ax-space-6) var(--ax-space-8);
     border-left: 5px solid transparent;
     user-select: text;
 }
@@ -34,7 +30,7 @@
 
 .undersidelenke {
     text-decoration: none;
-    padding: var(--ax-space-8) var(--ax-space-16);
+    padding: var(--ax-space-6) var(--ax-space-12);
     border-left: 5px solid transparent;
     user-select: text;
 }
@@ -66,10 +62,12 @@
     border: 1px solid var(--ax-border-warning);
     border-radius: 50%;
     background-color: var(--ax-bg-warning-moderate);
-    display: inline-grid;
-    place-items: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--ax-space-24);
     height: var(--ax-space-24);
-    width: var(--ax-space-24);
+    padding: 0 0.4em;
 }
 
 .ident {

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
@@ -44,7 +44,7 @@ export function Venstremeny() {
                 onClick={() => settErÅpen(prev => !prev)}
             />
             <Activity mode={erÅpen ? 'visible' : 'hidden'}>
-                <Box as={'nav'} className={Styles.container}>
+                <Box as={'nav'} width={'clamp(14rem, 15vw, 25rem)'}>
                     {Object.entries(trinnPåBehandling).map(([sideId, side], index) => {
                         const tilPath = `/fagsak/${fagsakId}/${behandling.behandlingId}/${side.href}`;
                         const undersider = side.undersider ? side.undersider(behandling) : [];

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -7,9 +7,8 @@ import { Behandlinger } from './Behandlinger';
 import { FagsakLenkepanel, SaksoversiktPanelBredde } from './FagsakLenkepanel';
 import Utbetalinger from './Utbetalinger';
 import type { VisningBehandling } from './visningBehandling';
-import type { IBehandling } from '../../../typer/behandling';
 import { BehandlingStatus, erBehandlingHenlagt } from '../../../typer/behandling';
-import { behandlingKategori, BehandlingKategori } from '../../../typer/behandlingstema';
+import { BehandlingKategori } from '../../../typer/behandlingstema';
 import { FagsakStatus } from '../../../typer/fagsak';
 import { Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
 import {
@@ -141,11 +140,3 @@ export function Saksoversikt() {
         </Box>
     );
 }
-
-export const sakstype = (behandling?: IBehandling) => {
-    if (!behandling) {
-        return 'Ikke satt';
-    }
-
-    return `${behandling?.kategori ? behandlingKategori[behandling?.kategori] : behandling?.kategori}`;
-};


### PR DESCRIPTION
### 📮 Favro
NAV-28170

### 💰 Hva skal gjøres, og hvorfor?
Tilpasser venstre- og høyremeny for forskjellige skjermstørrelser. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
1280x720 ny:
<img width="1044" height="587" alt="image" src="https://github.com/user-attachments/assets/7fd5c2b9-b945-4988-8376-37e0d48f1b14" />

1280x720 gammel:
<img width="1044" height="587" alt="image" src="https://github.com/user-attachments/assets/22943202-6954-4fd7-b2a7-a9d6059276da" />

--- 

1920x1080 ny:
<img width="969" height="554" alt="image" src="https://github.com/user-attachments/assets/39cd0319-f6f8-4db3-9a70-677345520f0b" />

1920x1080 gammel:
<img width="966" height="550" alt="image" src="https://github.com/user-attachments/assets/0dbf100b-7e42-4cf6-83aa-d55c482327e7" />

---

2560x1080 ny:
<img width="1291" height="554" alt="image" src="https://github.com/user-attachments/assets/1c064c1b-f98d-424e-a544-c05e58bd1dbb" />

2560x1080 gammel:
<img width="1291" height="550" alt="image" src="https://github.com/user-attachments/assets/aebb2215-bb1e-4bd3-b946-a1496f2ec964" />
