### PR TITLE
NAV-28170: Refaktorerer PersonInformasjon

### DIFF
--- a/src/frontend/hooks/useBruker.ts
+++ b/src/frontend/hooks/useBruker.ts
@@ -1,0 +1,6 @@
+import { useBrukerContext } from '../sider/Fagsak/BrukerContext';
+
+export function useBruker() {
+    const { bruker } = useBrukerContext();
+    return bruker;
+}

--- a/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.module.css
+++ b/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.module.css
@@ -1,0 +1,5 @@
+.headingUtenOverflow {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -1,88 +1,50 @@
-import styled from 'styled-components';
-
 import { BodyShort, CopyButton, Heading, HStack } from '@navikt/ds-react';
 
-import { useBrukerContext } from '../../sider/Fagsak/BrukerContext';
+import { useBruker } from '../../hooks/useBruker';
 import { type IGrunnlagPerson, type IPersonInfo, personTypeMap } from '../../typer/person';
 import { formaterIdent, hentAlder } from '../../utils/formatter';
-import { erAdresseBeskyttet } from '../../utils/validators';
 import DødsfallTag from '../DødsfallTag';
 import { PersonIkon } from '../PersonIkon';
+import Styles from './PersonInformasjon.module.css';
+import { erAdresseBeskyttet } from '../../utils/validators';
 
-interface IProps {
-    person: IGrunnlagPerson;
-    somOverskrift?: boolean;
-    width?: string;
-}
-
-const HeadingUtenOverflow = styled(Heading)`
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
-
-const hentAdresseBeskyttelseGradering = (bruker: IPersonInfo, personIdent: string): boolean | undefined => {
-    const forelderBarnRelasjoner = bruker.forelderBarnRelasjon;
-    const forelderBarnRelasjon = forelderBarnRelasjoner.find(rel => rel.personIdent === personIdent);
-
+function hentAdresseBeskyttelseGradering(bruker: IPersonInfo, personIdent: string): boolean | undefined {
     if (bruker.personIdent === personIdent) {
         return erAdresseBeskyttet(bruker.adressebeskyttelseGradering);
-    } else if (forelderBarnRelasjon?.personIdent === personIdent) {
+    }
+    const forelderBarnRelasjon = bruker.forelderBarnRelasjon.find(rel => rel.personIdent === personIdent);
+    if (forelderBarnRelasjon?.personIdent === personIdent) {
         return erAdresseBeskyttet(forelderBarnRelasjon.adressebeskyttelseGradering);
     }
-};
+}
 
-const Skillelinje = ({ erHeading = false }: { erHeading?: boolean }) => {
+function Skillelinje({ erHeading = false }: { erHeading?: boolean }) {
     if (erHeading) {
         return (
-            <Heading level="2" size="medium" as="span">
+            <Heading level={'2'} size={'medium'} as={'span'}>
                 |
             </Heading>
         );
     }
     return <BodyShort>|</BodyShort>;
-};
+}
 
-const PersonInformasjon = ({ person, somOverskrift = false }: IProps) => {
+interface Props {
+    person: IGrunnlagPerson;
+}
+
+export function PersonInformasjon({ person }: Props) {
+    const bruker = useBruker();
+
     const alder = hentAlder(person.fødselsdato);
     const navnOgAlder = `${person.navn} (${alder} år)`;
     const formatertIdent = formaterIdent(person.personIdent);
-    const { bruker } = useBrukerContext();
 
     const erAdresseBeskyttet = hentAdresseBeskyttelseGradering(bruker, person.personIdent);
     const erEgenAnsatt = bruker.erEgenAnsatt;
 
-    if (somOverskrift) {
-        return (
-            <HStack gap="space-24" wrap={false} align="center">
-                <PersonIkon
-                    erBarn={alder < 18}
-                    kjønn={person.kjønn}
-                    størrelse={'m'}
-                    erAdresseBeskyttet={erAdresseBeskyttet}
-                    erEgenAnsatt={erEgenAnsatt}
-                />
-                <HStack gap="space-24" align="center" wrap={false}>
-                    <HeadingUtenOverflow level="2" size="medium" title={navnOgAlder}>
-                        {navnOgAlder}
-                    </HeadingUtenOverflow>
-                    <Skillelinje erHeading />
-                    <HStack gap="space-4" wrap={false} align="center">
-                        <Heading level="2" size="medium" as="span">
-                            {formatertIdent}
-                        </Heading>
-                        <CopyButton size="small" copyText={person.personIdent} />
-                    </HStack>
-                    <Skillelinje erHeading />
-                    <Heading level="2" size="medium" as="span">{`${personTypeMap[person.type]} `}</Heading>
-                    {person.dødsfallDato?.length && <DødsfallTag dødsfallDato={person.dødsfallDato} />}
-                </HStack>
-            </HStack>
-        );
-    }
-
     return (
-        <HStack gap="space-8" align="center" wrap={false}>
+        <HStack gap={'space-24'} wrap={false} align={'center'}>
             <PersonIkon
                 erBarn={alder < 18}
                 kjønn={person.kjønn}
@@ -90,18 +52,21 @@ const PersonInformasjon = ({ person, somOverskrift = false }: IProps) => {
                 erAdresseBeskyttet={erAdresseBeskyttet}
                 erEgenAnsatt={erEgenAnsatt}
             />
-            <BodyShort className={'navn'} title={navnOgAlder}>
-                {navnOgAlder}
-            </BodyShort>
-            <Skillelinje />
-            <HStack gap="space-4" wrap={false} align="center">
-                <BodyShort>{formatertIdent}</BodyShort>
-                <CopyButton size="small" copyText={person.personIdent} />
+            <HStack gap={'space-24'} align={'center'} wrap={false}>
+                <Heading level={'2'} size={'medium'} title={navnOgAlder} className={Styles.headingUtenOverflow}>
+                    {navnOgAlder}
+                </Heading>
+                <Skillelinje erHeading={true} />
+                <HStack gap={'space-4'} align={'center'} wrap={false}>
+                    <Heading level={'2'} size={'medium'} as={'span'}>
+                        {formatertIdent}
+                    </Heading>
+                    <CopyButton size={'small'} copyText={person.personIdent} />
+                </HStack>
+                <Skillelinje erHeading={true} />
+                <Heading level={'2'} size={'medium'} as={'span'}>{`${personTypeMap[person.type]}`}</Heading>
+                {person.dødsfallDato?.length && <DødsfallTag dødsfallDato={person.dødsfallDato} />}
             </HStack>
-            <Skillelinje />
-            <BodyShort>{`${personTypeMap[person.type]} `}</BodyShort>
         </HStack>
     );
-};
-
-export default PersonInformasjon;
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/VilkårsvurderingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/VilkårsvurderingSkjema.tsx
@@ -8,7 +8,7 @@ import GeneriskVilkår from './GeneriskVilkår/GeneriskVilkår';
 import Registeropplysninger from './Registeropplysninger/Registeropplysninger';
 import { useVilkårsvurderingContext } from './VilkårsvurderingContext';
 import styles from './VilkårsvurderingSkjema.module.css';
-import PersonInformasjon from '../../../../../komponenter/PersonInformasjon/PersonInformasjon';
+import { PersonInformasjon } from '../../../../../komponenter/PersonInformasjon/PersonInformasjon';
 import { PersonType } from '../../../../../typer/person';
 import type { IPersonResultat, IVilkårConfig, IVilkårResultat } from '../../../../../typer/vilkår';
 import { annenVurderingConfig, Resultat, vilkårConfig } from '../../../../../typer/vilkår';
@@ -55,7 +55,7 @@ const VilkårsvurderingSkjema = () => {
                             justify={'space-between'}
                             wrap={false}
                         >
-                            <PersonInformasjon person={personResultat.person} somOverskrift />
+                            <PersonInformasjon person={personResultat.person} />
                             <Button
                                 id={`vis-skjul-vilkårsvurdering-${index}_${personResultat.person.fødselsdato}}`}
                                 variant="tertiary"

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonInformasjonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonInformasjonUtbetaling.tsx
@@ -1,0 +1,54 @@
+import { BodyShort, CopyButton, HStack } from '@navikt/ds-react';
+
+import { useBruker } from '../../../hooks/useBruker';
+import { PersonIkon } from '../../../komponenter/PersonIkon';
+import { type IGrunnlagPerson, type IPersonInfo, personTypeMap } from '../../../typer/person';
+import { formaterIdent, hentAlder } from '../../../utils/formatter';
+import { erAdresseBeskyttet } from '../../../utils/validators';
+
+function hentAdresseBeskyttelseGradering(bruker: IPersonInfo, personIdent: string): boolean | undefined {
+    if (bruker.personIdent === personIdent) {
+        return erAdresseBeskyttet(bruker.adressebeskyttelseGradering);
+    }
+    const forelderBarnRelasjon = bruker.forelderBarnRelasjon.find(rel => rel.personIdent === personIdent);
+    if (forelderBarnRelasjon?.personIdent === personIdent) {
+        return erAdresseBeskyttet(forelderBarnRelasjon.adressebeskyttelseGradering);
+    }
+}
+
+interface Props {
+    person: IGrunnlagPerson;
+}
+
+export function PersonInformasjonUtbetaling({ person }: Props) {
+    const bruker = useBruker();
+
+    const alder = hentAlder(person.fødselsdato);
+    const navnOgAlder = `${person.navn} (${alder} år)`;
+    const formatertIdent = formaterIdent(person.personIdent);
+
+    const erAdresseBeskyttet = hentAdresseBeskyttelseGradering(bruker, person.personIdent);
+    const erEgenAnsatt = bruker.erEgenAnsatt;
+
+    return (
+        <HStack gap={'space-8'} align={'center'} wrap={false}>
+            <PersonIkon
+                erBarn={alder < 18}
+                kjønn={person.kjønn}
+                størrelse={'m'}
+                erAdresseBeskyttet={erAdresseBeskyttet}
+                erEgenAnsatt={erEgenAnsatt}
+            />
+            <BodyShort className={'navn'} title={navnOgAlder}>
+                {navnOgAlder}
+            </BodyShort>
+            <BodyShort>|</BodyShort>
+            <HStack gap={'space-4'} wrap={false} align={'center'}>
+                <BodyShort>{formatertIdent}</BodyShort>
+                <CopyButton size={'small'} copyText={person.personIdent} />
+            </HStack>
+            <BodyShort>|</BodyShort>
+            <BodyShort>{`${personTypeMap[person.type]} `}</BodyShort>
+        </HStack>
+    );
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { BodyShort, HStack } from '@navikt/ds-react';
 import { Space16, Space32, Space8 } from '@navikt/ds-tokens/dist/tokens';
 
-import PersonInformasjon from '../../../komponenter/PersonInformasjon/PersonInformasjon';
+import { PersonInformasjonUtbetaling } from './PersonInformasjonUtbetaling';
 import type { IUtbetalingsperiodeDetalj } from '../../../typer/vedtaksperiode';
 import { formaterBeløp } from '../../../utils/formatter';
 
@@ -23,7 +23,7 @@ interface IPersonUtbetalingProps {
 const PersonUtbetaling = ({ utbetalingsperiodeDetaljer }: IPersonUtbetalingProps) => {
     return (
         <section>
-            <PersonInformasjon person={utbetalingsperiodeDetaljer[0].person} />
+            <PersonInformasjonUtbetaling person={utbetalingsperiodeDetaljer[0].person} />
             <Ytelser>
                 {utbetalingsperiodeDetaljer.map(utbetalingsperiodeDetalj => {
                     return (


### PR DESCRIPTION
### 📮 Favro
NAV-28170

### 💰 Hva skal gjøres, og hvorfor?
Refaktorerer PersonInformasjon slik at det blir lettere å skrive om senere. Skiller ut en egen komponent for personinformasjon knyttet til utbetaling.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Endrer ikke logikken stort. 

### 👀 Screen shots
Ingen visuelle endringer.