### PR TITLE
NAV-28792: Legger til "paths" for enklere imports

### DIFF
--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -20,6 +20,18 @@
       "vite/client",
       "vitest/globals",
       "@testing-library/jest-dom"
-    ]
+    ],
+    "paths": {
+      "@api/*": ["./api/*"],
+      "@context/*": ["./context/*"],
+      "@hooks/*": ["./hooks/*"],
+      "@ikoner/*": ["./ikoner/*"],
+      "@komponeter/*": ["./komponeter/*"],
+      "@public/*": ["./public/*"],
+      "@sider/*": ["./sider/*"],
+      "@testutils/*": ["./testutils/*"],
+      "@typer/*": ["./typer/*"],
+      "@utils/*": ["./utils/*"],
+    }
   }
 }


### PR DESCRIPTION
### 📮 Favro
NAV-28792

### 💰 Hva skal gjøres, og hvorfor?
Legger til "paths" for å gjøre imports enklere. Se https://www.typescriptlang.org/tsconfig/#paths.

Kan nå skrive:
import { useSaksbehandler } from '@hooks/useSaksbehandler';

Istendenfor:
import { useSaksbehandler } from '../../hooks/useSaksbehandler';

Vil gjøre det enklere å refaktorere hvis man beveger filer mellom foldere. Legger det inn i PR beskrivelsen også.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
Ingen visuelle endringer.