### PR TITLE
NAV-28792: Legger til vite-tsconfig-paths

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -85,6 +85,7 @@ updates:
         patterns:
           - "vite"
           - "@vitejs/plugin-react"
+          - "vite-tsconfig-paths"
       express:
         patterns:
           - "express"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "react-router": "7.14.1",
     "styled-components": "6.4.0",
     "tslib": "2.8.1",
-    "uuid": "13.0.0"
+    "uuid": "13.0.0",
+    "vite-tsconfig-paths": "6.1.1"
   },
   "devDependencies": {
     "@axe-core/react": "4.11.1",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
     "react-router": "7.14.1",
     "styled-components": "6.4.0",
     "tslib": "2.8.1",
-    "uuid": "13.0.0",
-    "vite-tsconfig-paths": "6.1.1"
+    "uuid": "13.0.0"
   },
   "devDependencies": {
     "@axe-core/react": "4.11.1",
@@ -113,6 +112,7 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.54.0",
     "vite": "7.3.2",
+    "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.4"
   }
 }

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import process from 'process';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import reactPlugin from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig(({ mode }) => {
     try {
@@ -22,6 +23,7 @@ export default defineConfig(({ mode }) => {
             },
             plugins: [
                 reactPlugin(),
+                tsconfigPaths(),
                 mode === 'prod' || mode === 'preprod' ? sentryPlugin() : undefined, // Sentry må være siste plugin
             ],
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2902,7 +2902,7 @@ dayjs@1.11.20:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.20.tgz#88d919fd639dc991415da5f4cb6f1b6650811938"
   integrity sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==
 
-debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.5, debug@^4.3.6, debug@^4.4.0, debug@^4.4.3:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.5, debug@^4.3.6, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -4185,6 +4185,11 @@ globalthis@^1.0.4:
   dependencies:
     define-properties "^1.2.1"
     gopd "^1.0.1"
+
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -6731,6 +6736,11 @@ ts-api-utils@^2.4.0:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.4.0.tgz#2690579f96d2790253bdcf1ca35d569ad78f9ad8"
   integrity sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==
 
+tsconfck@^3.0.3:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.1.6.tgz#da1f0b10d82237ac23422374b3fce1edb23c3ead"
+  integrity sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==
+
 tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
@@ -7020,6 +7030,15 @@ vary@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+
+vite-tsconfig-paths@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz#d5c28cba79c89ebf76489ef1040024b21df6da3a"
+  integrity sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==
+  dependencies:
+    debug "^4.1.1"
+    globrex "^0.1.2"
+    tsconfck "^3.0.3"
 
 vite@7.3.2:
   version "7.3.2"


### PR DESCRIPTION
### 📮 Favro
NAV-28792

### 💰 Hva skal gjøres, og hvorfor?
Legger til vite-tsconfig-paths slik at Vite forstår våre paths imports definert i tsconfig.json.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
Ingen visuelle endringer.