### PR TITLE
NAV-28506 Refaktorer LeggTilBarnPåBehandling til react-query og react-hook-form

### DIFF
--- a/src/frontend/api/harSaksbehandlerTilgang.ts
+++ b/src/frontend/api/harSaksbehandlerTilgang.ts
@@ -1,0 +1,17 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import type { IRestTilgang } from '../typer/person';
+import { RessursResolver } from '../utils/ressursResolver';
+
+export interface HarSaksbehandlerTilgangPayload {
+    brukerIdent: string;
+}
+
+export async function harSaksbehandlerTilgang(request: FamilieRequest, brukerIdent: string) {
+    const ressurs = await request<HarSaksbehandlerTilgangPayload, IRestTilgang>({
+        data: { brukerIdent: brukerIdent },
+        method: 'POST',
+        url: '/familie-ks-sak/api/tilgang',
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/api/leggTilBarnPåBehandling.ts
+++ b/src/frontend/api/leggTilBarnPåBehandling.ts
@@ -1,0 +1,17 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import type { IBehandling } from '../typer/behandling';
+import { RessursResolver } from '../utils/ressursResolver';
+
+export interface LeggTilBarnPåBehandlingPayload {
+    barnIdent: string;
+}
+
+export async function leggTilBarnPåBehandling(request: FamilieRequest, barnIdent: string, behandlingId: number) {
+    const ressurs = await request<LeggTilBarnPåBehandlingPayload, IBehandling>({
+        data: { barnIdent: barnIdent },
+        method: 'POST',
+        url: `/familie-ks-sak/api/behandlinger/${behandlingId}/legg-til-barn`,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/hooks/useHarSaksbehandlerTilgang.ts
+++ b/src/frontend/hooks/useHarSaksbehandlerTilgang.ts
@@ -1,0 +1,20 @@
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { harSaksbehandlerTilgang, type HarSaksbehandlerTilgangPayload } from '../api/harSaksbehandlerTilgang';
+import type { IRestTilgang } from '../typer/person';
+
+type Options = Omit<UseMutationOptions<IRestTilgang, DefaultError, HarSaksbehandlerTilgangPayload>, 'mutationFn'>;
+
+export function useHarSaksbehandlerTilgang(options?: Options) {
+    const { request } = useHttp();
+
+    return useMutation<IRestTilgang, Error, HarSaksbehandlerTilgangPayload>({
+        mutationFn: (parameters: HarSaksbehandlerTilgangPayload): Promise<IRestTilgang> => {
+            const { brukerIdent } = parameters;
+            return harSaksbehandlerTilgang(request, brukerIdent);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useLeggTilBarnPåBehandling.ts
+++ b/src/frontend/hooks/useLeggTilBarnPåBehandling.ts
@@ -1,9 +1,8 @@
+import { leggTilBarnPåBehandling, type LeggTilBarnPåBehandlingPayload } from '@api/leggTilBarnPåBehandling';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
 
 import { useHttp } from '@navikt/familie-http';
-
-import { leggTilBarnPåBehandling, type LeggTilBarnPåBehandlingPayload } from '../api/leggTilBarnPåBehandling';
-import type { IBehandling } from '../typer/behandling';
 
 interface LeggTilBarnPåBehandlingParameters extends LeggTilBarnPåBehandlingPayload {
     behandlingId: number;

--- a/src/frontend/hooks/useLeggTilBarnPåBehandling.ts
+++ b/src/frontend/hooks/useLeggTilBarnPåBehandling.ts
@@ -1,0 +1,24 @@
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { leggTilBarnPåBehandling, type LeggTilBarnPåBehandlingPayload } from '../api/leggTilBarnPåBehandling';
+import type { IBehandling } from '../typer/behandling';
+
+interface LeggTilBarnPåBehandlingParameters extends LeggTilBarnPåBehandlingPayload {
+    behandlingId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, LeggTilBarnPåBehandlingParameters>, 'mutationFn'>;
+
+export function useLeggTilBarnPåBehandling(options?: Options) {
+    const { request } = useHttp();
+
+    return useMutation<IBehandling, Error, LeggTilBarnPåBehandlingParameters>({
+        mutationFn: (parameters: LeggTilBarnPåBehandlingParameters): Promise<IBehandling> => {
+            const { barnIdent, behandlingId } = parameters;
+            return leggTilBarnPåBehandling(request, barnIdent, behandlingId);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/komponenter/Modal/LeggTilBarn/FødselsnummerField.tsx
+++ b/src/frontend/komponenter/Modal/LeggTilBarn/FødselsnummerField.tsx
@@ -1,10 +1,10 @@
+import { sjekkEr11Tall, sjekkErGyldigIdent } from '@utils/validators';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';
 
 import { useLeggTilBarnModalContext } from './LeggTilBarnModalContext';
 import { Fields, type FormValues } from './useLeggTilBarnForm';
-import { sjekkEr11Tall, sjekkErGyldigIdent } from '../../../utils/validators';
 
 export function FødselsnummerField() {
     const { control } = useFormContext<FormValues>();

--- a/src/frontend/komponenter/Modal/LeggTilBarn/FødselsnummerField.tsx
+++ b/src/frontend/komponenter/Modal/LeggTilBarn/FødselsnummerField.tsx
@@ -1,18 +1,10 @@
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';
-import { idnr } from '@navikt/fnrvalidator';
 
 import { useLeggTilBarnModalContext } from './LeggTilBarnModalContext';
 import { Fields, type FormValues } from './useLeggTilBarnForm';
-
-function sjekkEr11Tall(verdi: string): boolean {
-    return /^\d{11}$/.test(verdi.replace(' ', ''));
-}
-
-function sjekkErGyldigIdent(verdi: string): boolean {
-    return idnr(verdi).status === 'valid';
-}
+import { sjekkEr11Tall, sjekkErGyldigIdent } from '../../../utils/validators';
 
 export function FødselsnummerField() {
     const { control } = useFormContext<FormValues>();

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
@@ -1,3 +1,4 @@
+import { sjekkEr11Tall, sjekkErGyldigIdent } from '@utils/validators';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';
@@ -6,7 +7,6 @@ import {
     LeggTilBarnPåBehandlingFelt,
     type LeggTilBarnPåBehandlingFormValues,
 } from './useLeggTilBarnPåBehandlingSkjema';
-import { sjekkEr11Tall, sjekkErGyldigIdent } from '../../../../utils/validators';
 
 interface Props {
     erLesevisning: boolean;

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
@@ -1,0 +1,49 @@
+import { useController, useFormContext } from 'react-hook-form';
+
+import { TextField } from '@navikt/ds-react';
+
+import {
+    LeggTilBarnPåBehandlingFelt,
+    type LeggTilBarnPåBehandlingFormValues,
+} from './useLeggTilBarnPåBehandlingSkjema';
+import { sjekkEr11Tall, sjekkErGyldigIdent } from '../../../../utils/validators';
+
+interface Props {
+    erLesevisning: boolean;
+}
+
+export function LeggTilBarnFelt({ erLesevisning }: Props) {
+    const { control } = useFormContext<LeggTilBarnPåBehandlingFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: LeggTilBarnPåBehandlingFelt.BARNIDENT,
+        control,
+        rules: {
+            required: 'Fødselsnummer eller D-nummer må oppgis.',
+            validate: value => {
+                if (!sjekkEr11Tall(value)) {
+                    return 'Fødselsnummer eller D-nummer må være 11 siffer.';
+                }
+                if (!sjekkErGyldigIdent(value)) {
+                    return 'Fødselsnummer eller D-nummer er ugyldig.';
+                }
+            },
+        },
+    });
+
+    return (
+        <TextField
+            label={'Fødselsnummer'}
+            placeholder={'11 siffer'}
+            value={value}
+            onChange={onChange}
+            maxLength={11}
+            error={error?.message}
+            readOnly={erLesevisning || isSubmitting}
+        />
+    );
+}

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.tsx
@@ -1,5 +1,5 @@
+import { useBehandling } from '@hooks/useBehandling';
 import { useErLesevisning } from '@hooks/useErLesevisning';
-import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
 import { BehandlingÅrsak } from '@typer/behandling';
 
 import { ActionMenu } from '@navikt/ds-react';
@@ -16,7 +16,7 @@ interface Props {
 }
 
 export function LeggTilBarnPåBehandling({ åpneModal }: Props) {
-    const { behandling } = useBehandlingContext();
+    const behandling = useBehandling();
 
     const erLesevisning = useErLesevisning();
     const harRelevantBehandlingsårsak = relevanteBehandlingsårsaker.includes(behandling.årsak);

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.tsx
@@ -1,7 +1,8 @@
-import { ActionMenu } from '@navikt/ds-react';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
+import { BehandlingÅrsak } from '@typer/behandling';
 
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
-import { BehandlingÅrsak } from '../../../../typer/behandling';
+import { ActionMenu } from '@navikt/ds-react';
 
 const relevanteBehandlingsårsaker = [
     BehandlingÅrsak.NYE_OPPLYSNINGER,
@@ -15,9 +16,9 @@ interface Props {
 }
 
 export function LeggTilBarnPåBehandling({ åpneModal }: Props) {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling } = useBehandlingContext();
 
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
     const harRelevantBehandlingsårsak = relevanteBehandlingsårsaker.includes(behandling.årsak);
 
     if (erLesevisning || !harRelevantBehandlingsårsak) {

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
@@ -16,6 +16,7 @@ interface Props {
     lukkModal: () => void;
 }
 
+// TODO: opprydding her og oppdater til ny kode. Samtidig - se over koden og se at det nye for KS stemmer med det som allerede lå her
 export function LeggTiLBarnPåBehandlingModal({ lukkModal }: Props) {
     const { request } = useHttp();
     const { behandling, settÅpenBehandling } = useBehandlingContext();

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
@@ -1,6 +1,6 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
 import { LeggTilBarnFelt } from '@komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt';
 import { useLeggTilBarnPåBehandlingSkjema } from '@komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema';
-import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
 import { FormProvider } from 'react-hook-form';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
@@ -11,8 +11,7 @@ interface Props {
 }
 
 export function LeggTiLBarnPåBehandlingModal({ lukkModal }: Props) {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const { form, onSubmit } = useLeggTilBarnPåBehandlingSkjema({ lukkModal });
 

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
@@ -1,137 +1,75 @@
-import { Button, Fieldset, Heading, HelpText, HStack, InlineMessage, Modal, TextField } from '@navikt/ds-react';
-import { useHttp } from '@navikt/familie-http';
-import { ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import type { Ressurs } from '@navikt/familie-typer';
-import { byggFeiletRessurs, byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
+import { LeggTilBarnFelt } from '@komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt';
+import { useLeggTilBarnPåBehandlingSkjema } from '@komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema';
+import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
+import { FormProvider } from 'react-hook-form';
 
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
-import type { IBehandling } from '../../../../typer/behandling';
-import type { IPersonInfo, IRestTilgang } from '../../../../typer/person';
-import { adressebeskyttelsestyper } from '../../../../typer/person';
-import { erLokal } from '../../../../utils/miljø';
-import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
-import { identValidator } from '../../../../utils/validators';
+import { InformationSquareIcon } from '@navikt/aksel-icons';
+import { Button, Fieldset, Heading, HelpText, HStack, InfoCard, Modal } from '@navikt/ds-react';
 
 interface Props {
     lukkModal: () => void;
 }
 
-// TODO: opprydding her og oppdater til ny kode. Samtidig - se over koden og se at det nye for KS stemmer med det som allerede lå her
 export function LeggTiLBarnPåBehandlingModal({ lukkModal }: Props) {
-    const { request } = useHttp();
-    const { behandling, settÅpenBehandling } = useBehandlingContext();
+    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = vurderErLesevisning();
 
-    const { skjema, settSubmitRessurs, kanSendeSkjema, nullstillSkjema } = useSkjema<
-        {
-            ident: string;
-        },
-        IPersonInfo
-    >({
-        felter: {
-            ident: useFelt<string>({
-                verdi: '',
-                valideringsfunksjon: erLokal() ? felt => ok(felt) : identValidator,
-            }),
-        },
-        skjemanavn: 'Legg til barn',
-    });
+    const { form, onSubmit } = useLeggTilBarnPåBehandlingSkjema({ lukkModal });
 
-    const onAvbryt = () => {
-        lukkModal();
-        settSubmitRessurs(byggTomRessurs());
-    };
-
-    const leggTilOnClick = () => {
-        const erSkjemaOk = kanSendeSkjema();
-        if (erSkjemaOk) {
-            settSubmitRessurs(byggHenterRessurs());
-            request<{ brukerIdent: string }, IRestTilgang>({
-                method: 'POST',
-                url: '/familie-ks-sak/api/tilgang',
-                data: { brukerIdent: skjema.felter.ident.verdi },
-            }).then((ressurs: Ressurs<IRestTilgang>) => {
-                nullstillSkjema();
-                if (ressurs.status === RessursStatus.SUKSESS) {
-                    if (ressurs.data.saksbehandlerHarTilgang) {
-                        request<{ barnIdent: string }, IBehandling>({
-                            method: 'POST',
-                            data: { barnIdent: skjema.felter.ident.verdi },
-                            url: `/familie-ks-sak/api/behandlinger/${behandling.behandlingId}/legg-til-barn`,
-                        }).then((leggTilRespons: Ressurs<IBehandling>) => {
-                            if (
-                                leggTilRespons.status === RessursStatus.FEILET ||
-                                leggTilRespons.status === RessursStatus.FUNKSJONELL_FEIL ||
-                                leggTilRespons.status === RessursStatus.IKKE_TILGANG
-                            ) {
-                                settSubmitRessurs(byggFeiletRessurs(leggTilRespons.frontendFeilmelding));
-                            } else {
-                                settÅpenBehandling(leggTilRespons);
-                                lukkModal();
-                            }
-                        });
-                    } else {
-                        settSubmitRessurs(
-                            byggFeiletRessurs(
-                                `Barnet kan ikke legges til på grunn av diskresjonskode ${
-                                    adressebeskyttelsestyper[ressurs.data.adressebeskyttelsegradering] ?? 'ukjent'
-                                }`
-                            )
-                        );
-                    }
-                } else if (
-                    [RessursStatus.FEILET, RessursStatus.FUNKSJONELL_FEIL, RessursStatus.IKKE_TILGANG].includes(
-                        ressurs.status
-                    )
-                ) {
-                    settSubmitRessurs(ressurs);
-                }
-            });
-        }
-    };
+    const {
+        handleSubmit,
+        formState: { isSubmitting, errors },
+    } = form;
 
     return (
-        <Modal open onClose={onAvbryt} aria-label={'Legg til barn'} width={'35rem'} portal>
-            <Modal.Header>
-                <HStack gap={'space-8'}>
-                    <Heading level="2" size="small">
-                        Legg til barn
-                    </Heading>
-                    <HelpText strategy={'fixed'} placement={'top'}>
-                        Her kan du, ved klage eller ettersendt dokumentasjon, legge til barn som ikke lenger ligger på
-                        behandlingen fordi vi tidligere har avslått eller opphørt.
-                    </HelpText>
-                </HStack>
-            </Modal.Header>
-            <Modal.Body>
-                <Fieldset
-                    error={hentFrontendFeilmelding(skjema.submitRessurs)}
-                    errorPropagation={false}
-                    legend="Legg til barn på behandling"
-                    hideLegend
-                >
-                    <TextField
-                        {...skjema.felter.ident.hentNavInputProps(skjema.visFeilmeldinger)}
-                        label={'Fødselsnummer'}
-                        placeholder={'11 siffer'}
-                    />
-                    <InlineMessage status={'info'}>
-                        Du er i ferd med å legge til et barn på behandlingen. Handlingen kan ikke reverseres uten å
-                        henlegge.
-                    </InlineMessage>
-                </Fieldset>
-            </Modal.Body>
-            <Modal.Footer>
-                <Button
-                    key={'Legg til'}
-                    variant="primary"
-                    size="small"
-                    onClick={leggTilOnClick}
-                    children={'Legg til'}
-                    loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                    disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
-                />
-                <Button key={'Avbryt'} variant="tertiary" size="small" onClick={onAvbryt} children={'Avbryt'} />
-            </Modal.Footer>
+        <Modal open onClose={lukkModal} aria-label={'Legg til barn'} width={'35rem'} portal>
+            <FormProvider {...form}>
+                <form onSubmit={handleSubmit(onSubmit)}>
+                    <Modal.Header>
+                        <HStack gap={'space-8'}>
+                            <Heading level="2" size="small">
+                                Legg til barn
+                            </Heading>
+                            <HelpText strategy={'fixed'} placement={'top'}>
+                                Her kan du, ved klage eller ettersendt dokumentasjon, legge til barn som ikke lenger
+                                ligger på behandlingen fordi vi tidligere har avslått eller opphørt.
+                            </HelpText>
+                        </HStack>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <Fieldset
+                            error={errors.root?.message}
+                            errorPropagation={false}
+                            legend="Legg til barn på behandling"
+                            hideLegend
+                        >
+                            <InfoCard data-color={'info'}>
+                                <InfoCard.Header icon={<InformationSquareIcon aria-hidden />}>
+                                    <InfoCard.Title>
+                                        Du er i ferd med å legge til et barn på behandlingen. Handlingen kan ikke
+                                        reverseres uten å henlegge.
+                                    </InfoCard.Title>
+                                </InfoCard.Header>
+                            </InfoCard>
+                            <LeggTilBarnFelt erLesevisning={erLesevisning} />
+                        </Fieldset>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button
+                            type={'submit'}
+                            variant="primary"
+                            size="small"
+                            loading={isSubmitting}
+                            disabled={erLesevisning}
+                        >
+                            Legg til
+                        </Button>
+                        <Button variant="tertiary" size="small" onClick={lukkModal}>
+                            Avbryt
+                        </Button>
+                    </Modal.Footer>
+                </form>
+            </FormProvider>
         </Modal>
     );
 }

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
@@ -1,11 +1,10 @@
+import { useHarSaksbehandlerTilgang } from '@hooks/useHarSaksbehandlerTilgang';
+import { useLeggTilBarnPåBehandling } from '@hooks/useLeggTilBarnPåBehandling';
+import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
+import { adressebeskyttelsestyper } from '@typer/person';
 import { useForm } from 'react-hook-form';
 
 import { byggSuksessRessurs } from '@navikt/familie-typer';
-
-import { useHarSaksbehandlerTilgang } from '../../../../hooks/useHarSaksbehandlerTilgang';
-import { useLeggTilBarnPåBehandling } from '../../../../hooks/useLeggTilBarnPåBehandling';
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
-import { adressebeskyttelsestyper } from '../../../../typer/person';
 
 export enum LeggTilBarnPåBehandlingFelt {
     BARNIDENT = 'barnIdent',

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
@@ -1,0 +1,60 @@
+import { useForm } from 'react-hook-form';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+import { useHarSaksbehandlerTilgang } from '../../../../hooks/useHarSaksbehandlerTilgang';
+import { useLeggTilBarnPåBehandling } from '../../../../hooks/useLeggTilBarnPåBehandling';
+import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
+import { adressebeskyttelsestyper } from '../../../../typer/person';
+
+export enum LeggTilBarnPåBehandlingFelt {
+    BARNIDENT = 'barnIdent',
+}
+
+export interface LeggTilBarnPåBehandlingFormValues {
+    [LeggTilBarnPåBehandlingFelt.BARNIDENT]: string;
+}
+
+interface Props {
+    lukkModal: () => void;
+}
+
+export function useLeggTilBarnPåBehandlingSkjema({ lukkModal }: Props) {
+    const { settÅpenBehandling, behandling } = useBehandlingContext();
+    const { mutateAsync: harSaksbehandlerTilgang } = useHarSaksbehandlerTilgang();
+    const { mutateAsync: leggTilBarnPåBehandling } = useLeggTilBarnPåBehandling();
+
+    const form = useForm<LeggTilBarnPåBehandlingFormValues>({
+        defaultValues: {
+            [LeggTilBarnPåBehandlingFelt.BARNIDENT]: '',
+        },
+    });
+
+    const { setError } = form;
+
+    const onSubmit = async (values: LeggTilBarnPåBehandlingFormValues) => {
+        const { barnIdent } = values;
+
+        try {
+            const tilgangRes = await harSaksbehandlerTilgang({ brukerIdent: barnIdent });
+
+            if (!tilgangRes.saksbehandlerHarTilgang) {
+                setError('root', {
+                    message: `Barnet kan ikke legges til på grunn av diskresjonskode ${adressebeskyttelsestyper[tilgangRes.adressebeskyttelsegradering] ?? 'ukjent'}`,
+                });
+                return;
+            }
+            const behandlingResult = await leggTilBarnPåBehandling({
+                barnIdent,
+                behandlingId: behandling.behandlingId,
+            });
+
+            settÅpenBehandling(byggSuksessRessurs(behandlingResult));
+            lukkModal();
+        } catch (e: unknown) {
+            setError('root', {
+                message: e instanceof Error ? e.message : 'Teknisk feil ved forsøk på å legge til barn på behandling.',
+            });
+        }
+    };
+}

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
@@ -57,4 +57,8 @@ export function useLeggTilBarnPåBehandlingSkjema({ lukkModal }: Props) {
             });
         }
     };
+    return {
+        form,
+        onSubmit,
+    };
 }

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
@@ -1,3 +1,4 @@
+import { useBehandling } from '@hooks/useBehandling';
 import { useHarSaksbehandlerTilgang } from '@hooks/useHarSaksbehandlerTilgang';
 import { useLeggTilBarnPåBehandling } from '@hooks/useLeggTilBarnPåBehandling';
 import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
@@ -19,7 +20,8 @@ interface Props {
 }
 
 export function useLeggTilBarnPåBehandlingSkjema({ lukkModal }: Props) {
-    const { settÅpenBehandling, behandling } = useBehandlingContext();
+    const behandling = useBehandling();
+    const { settÅpenBehandling } = useBehandlingContext();
     const { mutateAsync: harSaksbehandlerTilgang } = useHarSaksbehandlerTilgang();
     const { mutateAsync: leggTilBarnPåBehandling } = useLeggTilBarnPåBehandling();
 

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -1,3 +1,10 @@
+import { validerPeriodePåBarnetsAlder } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering';
+import { erBegrunnelsePåkrevd } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema';
+import { Adressebeskyttelsegradering, type IGrunnlagPerson, PersonType } from '@typer/person';
+import { IEndretUtbetalingAndelÅrsak } from '@typer/utbetalingAndel';
+import type { Begrunnelse } from '@typer/vedtak';
+import type { UtdypendeVilkårsvurdering } from '@typer/vilkår';
+import { Resultat, UtdypendeVilkårsvurderingGenerell, VilkårType } from '@typer/vilkår';
 import { addMonths, endOfMonth, isAfter, isBefore, isSameDay, isValid, parseISO } from 'date-fns';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
@@ -5,13 +12,6 @@ import { feil, ok, Valideringsstatus } from '@navikt/familie-skjema';
 import { idnr } from '@navikt/fnrvalidator';
 
 import { hentDagensDato, type IIsoDatoPeriode, isoStringTilDate } from './dato';
-import { validerPeriodePåBarnetsAlder } from '../sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlderValidering';
-import { erBegrunnelsePåkrevd } from '../sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårSkjema';
-import { Adressebeskyttelsegradering, type IGrunnlagPerson, PersonType } from '../typer/person';
-import { IEndretUtbetalingAndelÅrsak } from '../typer/utbetalingAndel';
-import type { Begrunnelse } from '../typer/vedtak';
-import type { UtdypendeVilkårsvurdering } from '../typer/vilkår';
-import { Resultat, UtdypendeVilkårsvurderingGenerell, VilkårType } from '../typer/vilkår';
 
 const harFyltInnIdent = (felt: FeltState<string>): FeltState<string> => {
     return /^\d{11}$/.test(felt.verdi.replace(' ', '')) ? ok(felt) : feil(felt, 'Identen har ikke 11 tall');

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -30,6 +30,14 @@ export const identValidator = (identFelt: FeltState<string>): FeltState<string> 
     return validerIdent(identFelt);
 };
 
+export const sjekkEr11Tall = (verdi: string): boolean => {
+    return /^\d{11}$/.test(verdi.replace(' ', ''));
+};
+
+export const sjekkErGyldigIdent = (verdi: string): boolean => {
+    return idnr(verdi).status === 'valid';
+};
+
 const finnesDatoFørFødselsdato = (person: IGrunnlagPerson, fom: Date, tom?: Date) => {
     const fødselsdato = isoStringTilDate(person.fødselsdato);
 

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -26,6 +26,11 @@ export default defineConfig(({ mode }) => {
                 tsconfigPaths(),
                 mode === 'prod' || mode === 'preprod' ? sentryPlugin() : undefined, // Sentry må være siste plugin
             ],
+            test: {
+                globals: true,
+                environment: 'jsdom',
+                setupFiles: './vitest.setup.ts',
+            },
         };
     } catch (e) {
         console.error('Vite define config feilet', e);

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -26,11 +26,6 @@ export default defineConfig(({ mode }) => {
                 tsconfigPaths(),
                 mode === 'prod' || mode === 'preprod' ? sentryPlugin() : undefined, // Sentry må være siste plugin
             ],
-            test: {
-                globals: true,
-                environment: 'jsdom',
-                setupFiles: './vitest.setup.ts',
-            },
         };
     } catch (e) {
         console.error('Vite define config feilet', e);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    plugins: [tsconfigPaths()],
     test: {
         globals: true,
         environment: 'jsdom',


### PR DESCRIPTION
### 📮 Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-28506
### 💰 Hva skal gjøres, og hvorfor?
Refaktorer LeggTilBarnPåBehandling til å bruke react-query og react-hook-form for å skrive oss over fra egenlagd funksjonalitet til å bruke moderne rammeverk.

Abstraher eksisterende valideringsfunksjoner for å gjenbruke disse - fra LeggTilBarn.

`<Alert />` byttes ut med `<InfoCard />` ifm. oppdatering til Aksel v8. Som en midlertidig løsning brukes derfor `<InfoCard.Header />` og `<InfoCard.Title />`, i påvente av å kunne bytte til `<InfoCard.Message />` når oppdateringen er fullført.

Legg til tsconfigPaths for test også, pga. det brakk noen av testene.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️


_Jeg har ikke skrevet tester fordi:_ ingen funksjonelle endringer


### 👀 Screen shots
_Har det visuelle endret seg?_
Ja, pga. midlertidig Aksel-oppdatering. I tillegg flyttes infoteksten til over feltet, for å samkjøres med uformingen ellers i applikasjonen.