### PR TITLE
NAV-29004: Rydder i BehandlingContext

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -1,5 +1,11 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
 
+import { useNavigerAutomatiskTilSideForBehandlingssteg } from '@hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { BehandlerRolle, BehandlingStatus, BehandlingÅrsak, type IBehandling } from '@typer/behandling';
+import { harTilgangTilEnhet } from '@typer/enhet';
+import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '@utils/behandling';
+import { hentSideHref } from '@utils/miljø';
 import { useLocation } from 'react-router';
 
 import { type Ressurs } from '@navikt/familie-typer';
@@ -7,20 +13,6 @@ import { type Ressurs } from '@navikt/familie-typer';
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
 import useBehandlingssteg from './useBehandlingssteg';
 import { saksbehandlerHarKunLesevisning } from './utils';
-import { useNavigerAutomatiskTilSideForBehandlingssteg } from '../../../../hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
-import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
-import {
-    BehandlerRolle,
-    BehandlingStatus,
-    BehandlingÅrsak,
-    type IBehandling,
-    type IBehandlingPåVent,
-} from '../../../../typer/behandling';
-import { harTilgangTilEnhet } from '../../../../typer/enhet';
-import { PersonType } from '../../../../typer/person';
-import { Målform } from '../../../../typer/søknad';
-import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../../../../utils/behandling';
-import { hentSideHref } from '../../../../utils/miljø';
 import { hentTrinnForBehandling, type ITrinn, KontrollertStatus, type SideId } from '../sider/sider';
 
 interface Props extends PropsWithChildren {
@@ -34,7 +26,6 @@ interface BehandlingContextValue {
     vurderErLesevisning: (sjekkTilgangTilEnhet?: boolean, skalIgnorereOmEnhetErMidlertidig?: boolean) => boolean;
     leggTilBesøktSide: (besøktSide: SideId) => void;
     settIkkeKontrollerteSiderTilManglerKontroll: () => void;
-    søkersMålform: Målform;
     trinnPåBehandling: { [sideId: string]: ITrinn };
     behandling: IBehandling;
     behandlingsstegSubmitressurs: Ressurs<IBehandling>;
@@ -47,7 +38,6 @@ interface BehandlingContextValue {
         erUlagretNyRefusjonEøsPeriode: boolean,
         erSammensattKontrollsak: boolean
     ) => void;
-    behandlingPåVent: IBehandlingPåVent | undefined;
 }
 
 const BehandlingContext = createContext<BehandlingContextValue | undefined>(undefined);
@@ -147,9 +137,6 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
         );
     };
 
-    const søkersMålform: Målform =
-        behandling.personer.find(person => person.type === PersonType.SØKER)?.målform ?? Målform.NB;
-
     const kanBeslutteVedtak =
         behandling.status === BehandlingStatus.FATTER_VEDTAK &&
         BehandlerRolle.BESLUTTER === saksbehandler.rolle &&
@@ -164,14 +151,12 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
                 vurderErLesevisning,
                 leggTilBesøktSide,
                 settIkkeKontrollerteSiderTilManglerKontroll,
-                søkersMålform,
                 trinnPåBehandling,
                 behandling,
                 behandlingsstegSubmitressurs,
                 vilkårsvurderingNesteOnClick,
                 behandlingresultatNesteOnClick,
                 foreslåVedtakNesteOnClick,
-                behandlingPåVent: behandling.behandlingPåVent,
                 settÅpenBehandling: settBehandlingRessurs,
             }}
         >

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/FritekstVedtakbegrunnelser.tsx
@@ -1,5 +1,12 @@
 import type { ChangeEvent } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useOppdaterVedtaksperiodeMedFriteksterMutationState } from '@hooks/useOppdaterVedtaksperiodeMedFriteksterMutationState';
+import { utledSøkersMålform } from '@typer/behandling';
+import { målform } from '@typer/søknad';
+import type { IFritekstFelt } from '@utils/fritekstfelter';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import styled from 'styled-components';
 
 import { ExternalLinkIcon, PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
@@ -7,12 +14,7 @@ import { BodyLong, Button, Fieldset, Heading, HelpText, Label, Link, Tag, Textar
 import type { FeltState } from '@navikt/familie-skjema';
 
 import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
-import { useOppdaterVedtaksperiodeMedFriteksterMutationState } from '../../../../../../hooks/useOppdaterVedtaksperiodeMedFriteksterMutationState';
 import Knapperekke from '../../../../../../komponenter/Knapperekke';
-import { målform } from '../../../../../../typer/søknad';
-import type { IFritekstFelt } from '../../../../../../utils/fritekstfelter';
-import { hentFrontendFeilmelding } from '../../../../../../utils/ressursUtils';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 const FritekstContainer = styled.div`
     padding: 1rem;
@@ -68,8 +70,9 @@ const ItalicText = styled(BodyLong)`
 `;
 
 const FritekstVedtakbegrunnelser = () => {
-    const { vurderErLesevisning, søkersMålform } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+
     const {
         skjema,
         leggTilFritekst,
@@ -133,7 +136,7 @@ const FritekstVedtakbegrunnelser = () => {
                     </ItalicText>
                 </StyledHelpText>
                 <StyledTag variant="neutral" size="small">
-                    Skriv {målform[søkersMålform].toLowerCase()}
+                    Skriv {målform[utledSøkersMålform(behandling)].toLowerCase()}
                 </StyledTag>
             </InfoBoks>
             {erLesevisning ? (

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/useVilkårEkspanderbarRad.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/useVilkårEkspanderbarRad.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 
-import { type IVilkårResultat, Resultat } from '../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { type IVilkårResultat, Resultat } from '@typer/vilkår';
 
 interface IProps {
     vilkårHarEndringerSomIkkeErLagret: () => boolean;
@@ -9,16 +10,15 @@ interface IProps {
 }
 
 export const useVilkårEkspanderbarRad = ({ vilkårHarEndringerSomIkkeErLagret, lagretVilkårResultat }: IProps) => {
-    const { vurderErLesevisning, behandlingPåVent } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     const initiellEkspandering = erLesevisning || lagretVilkårResultat.resultat === Resultat.IKKE_VURDERT;
-
     const [erVilkårEkspandert, settErVilkårEkspandert] = useState(initiellEkspandering);
 
     useEffect(() => {
         settErVilkårEkspandert(initiellEkspandering);
-    }, [behandlingPåVent]);
+    }, [behandling.behandlingPåVent]);
 
     const toggleForm = (visAlert: boolean) => {
         if (erVilkårEkspandert && visAlert && vilkårHarEndringerSomIkkeErLagret()) {

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -1,3 +1,6 @@
+import type { IRestBrevmottaker } from '@komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
+import type { IsoDatoString } from '@utils/dato';
+
 import type { BehandlingKategori } from './behandlingstema';
 import type { IPersonMedAndelerTilkjentYtelse } from './beregning';
 import type { INøkkelPar } from './common';
@@ -7,10 +10,10 @@ import { FeatureToggle, type FeatureToggles } from './featureToggles';
 import type { KlageResultat, KlageStatus, KlageÅrsak } from './klage';
 import type { ManglendeSvalbardmerking } from './ManglendeSvalbardmerking';
 import type { IRestOvergangsordningAndel } from './overgangsordningAndel';
-import type { IGrunnlagPerson } from './person';
+import { type IGrunnlagPerson, PersonType } from './person';
 import type { IRestRefusjonEøs } from './refusjon-eøs';
 import type { ITilbakekreving } from './simulering';
-import type { ISøknadDTO } from './søknad';
+import { type ISøknadDTO, Målform } from './søknad';
 import type {
     Behandlingsstatus,
     TilbakekrevingsbehandlingResultat,
@@ -21,8 +24,6 @@ import type { IRestEndretUtbetalingAndel } from './utbetalingAndel';
 import type { Utbetalingsperiode } from './utbetalingsperiode';
 import type { IRestKorrigertEtterbetaling, IRestKorrigertVedtak, IVedtakForBehandling } from './vedtak';
 import type { IRestPersonResultat, IRestStegTilstand } from './vilkår';
-import type { IRestBrevmottaker } from '../komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
-import type { IsoDatoString } from '../utils/dato';
 
 export const MIDLERTIDIG_BEHANDLENDE_ENHET_ID = '4863';
 
@@ -387,4 +388,9 @@ export const erBehandlingFortsattInnvilget = (behandlingsResultat?: BehandlingRe
 
 export function sjekkErBehandleneEnhetMidlertidig(behandling: IBehandling) {
     return behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId === MIDLERTIDIG_BEHANDLENDE_ENHET_ID;
+}
+
+export function utledSøkersMålform(behandling: IBehandling) {
+    const søker = behandling.personer.find(person => person.type === PersonType.SØKER);
+    return søker?.målform ?? Målform.NB;
 }


### PR DESCRIPTION
### 📮 Favro
NAV-29004

### 💰 Hva skal gjøres, og hvorfor?
Rydder i `BehandlingContext`. Fjerner `søkersMålform` og `behandlingPåVent`. Utleder det heller i komponentene som har behov for verdiene. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 