### PR TITLE
Fiks fremtidig opphør validering

### DIFF
--- a/src/frontend/context/Vilkårsvurdering/hentFeilIVilkårsvurdering.ts
+++ b/src/frontend/context/Vilkårsvurdering/hentFeilIVilkårsvurdering.ts
@@ -123,9 +123,9 @@ const barnetsAlderPeriodeManglerBarnehagePeriode = (
         return true;
     }
 
-    const periodeMedFramtidigOpphørPgaBarnehageplass = barnehageplassVilkårResultater.find(
-        vilkårresultat => vilkårresultat.søkerHarMeldtFraOmBarnehageplass
-    )?.periode;
+    const senestePeriodeMedFramtidigOpphørPgaBarnehageplass = barnehageplassVilkårResultater
+        .toSorted((a, b) => parseFraOgMedDato(b.periode.fom).getTime() - parseFraOgMedDato(a.periode.fom).getTime())
+        .find(vilkårresultat => vilkårresultat.søkerHarMeldtFraOmBarnehageplass)?.periode;
 
     const sammenslåttBarnehageperiode = sammenSlåtteBarnehageperioder[0];
 
@@ -134,9 +134,9 @@ const barnetsAlderPeriodeManglerBarnehagePeriode = (
         parseFraOgMedDato(barnetsAlderPeriode.fom)
     );
     const sistePeriodeHarFramtidigOpphørPgaBarnehageplass =
-        periodeMedFramtidigOpphørPgaBarnehageplass &&
+        senestePeriodeMedFramtidigOpphørPgaBarnehageplass &&
         erEtterEllerSammeDato(
-            parseTilOgMedDato(periodeMedFramtidigOpphørPgaBarnehageplass.tom),
+            parseTilOgMedDato(senestePeriodeMedFramtidigOpphørPgaBarnehageplass.tom),
             parseTilOgMedDato(sammenslåttBarnehageperiode.tom)
         );
     const barnehageperiodeOverlapperTilSluttenAvBarnetsAlderPeriode = erEtterEllerSammeDato(

--- a/src/frontend/context/Vilkårsvurdering/test/hentFeilVilkårsvurdering.test.ts
+++ b/src/frontend/context/Vilkårsvurdering/test/hentFeilVilkårsvurdering.test.ts
@@ -1,6 +1,7 @@
 import barnehageperiodeErEtterBarnetsAlderMenIPeriodeForOvergangsordning from './testcaser/barnehageperiodeErEtterBarnetsAlderMenIPeriodeForOvergangsordning.json';
 import barnehageperiodeStarterEtter2årEllerSkole from './testcaser/barnehageperiodeStarterEtter2årEllerSkole.json';
 import bosattIRiketIkkeUtfylt from './testcaser/bosattIRiketIkkeUtfylt.json';
+import flereBarnehageperioderMedMeldtBarnehageplass from './testcaser/flereBarnehageperioderMedMeldtBarnehageplass.json';
 import happyCase from './testcaser/happyCase.json';
 import manglerBarnehageplassBarnetsAlderVilkårsvurdering from './testcaser/manglerBarnehageplassBarnetsAlderVilkårsvurdering.json';
 import type { IPersonResultat } from '../../../typer/vilkår';
@@ -44,6 +45,14 @@ describe('hentFeilIVilkårsvurdering', () => {
 
     test('Skal ikke gi feilmelding dersom ingenting er galt', () => {
         const feilIVilkåarsvurdering = hentFeilIVilkårsvurdering(happyCase as unknown as IPersonResultat[]);
+
+        expect(feilIVilkåarsvurdering.length).toEqual(0);
+    });
+
+    test('Skal ikke gi feilmelding ved flere barnehageperioder der en mellom periode og siste periode har meldt barnehageplass', () => {
+        const feilIVilkåarsvurdering = hentFeilIVilkårsvurdering(
+            flereBarnehageperioderMedMeldtBarnehageplass as unknown as IPersonResultat[]
+        );
 
         expect(feilIVilkåarsvurdering.length).toEqual(0);
     });

--- a/src/frontend/context/Vilkårsvurdering/test/testcaser/flereBarnehageperioderMedMeldtBarnehageplass.json
+++ b/src/frontend/context/Vilkårsvurdering/test/testcaser/flereBarnehageperioderMedMeldtBarnehageplass.json
@@ -1,0 +1,177 @@
+[
+  {
+    "person": {
+      "type": "BARN",
+      "fødselsdato": "2024-02-01",
+      "personIdent": "12345678910",
+      "navn": "Test Barn",
+      "kjønn": "MANN",
+      "registerhistorikk": {
+        "hentetTidspunkt": "2025-01-01T12:00:00.000",
+        "sivilstand": [],
+        "oppholdstillatelse": [],
+        "statsborgerskap": [
+          {
+            "fom": "2024-02-01",
+            "tom": null,
+            "verdi": "Norge"
+          }
+        ],
+        "bostedsadresse": [
+          {
+            "fom": "2024-02-01",
+            "tom": null,
+            "verdi": "Testveien 1, 0001 Oslo"
+          }
+        ],
+        "dødsboadresse": []
+      },
+      "målform": "NB",
+      "dødsfallDato": null
+    },
+    "personIdent": "12345678910",
+    "vilkårResultater": [
+      {
+        "begrunnelse": "",
+        "id": 1,
+        "periode": {
+          "fom": "2025-02-01",
+          "tom": "2026-02-01"
+        },
+        "resultat": "OPPFYLT",
+        "vilkårType": "BARNETS_ALDER",
+        "endretAv": "Z994294",
+        "erVurdert": true,
+        "erAutomatiskVurdert": true,
+        "erEksplisittAvslagPåSøknad": false,
+        "avslagBegrunnelser": [],
+        "endretTidspunkt": "2025-01-10T10:00:00.000",
+        "behandlingId": 1,
+        "vurderesEtter": null,
+        "utdypendeVilkårsvurderinger": [],
+        "antallTimer": null
+      },
+      {
+        "begrunnelse": "",
+        "id": 2,
+        "periode": {
+          "fom": "2025-01-02",
+          "tom": "2025-12-14"
+        },
+        "resultat": "OPPFYLT",
+        "vilkårType": "BARNEHAGEPLASS",
+        "endretAv": "Z994294",
+        "erVurdert": true,
+        "erAutomatiskVurdert": false,
+        "erEksplisittAvslagPåSøknad": false,
+        "avslagBegrunnelser": [],
+        "endretTidspunkt": "2025-01-10T10:00:00.000",
+        "behandlingId": 1,
+        "vurderesEtter": null,
+        "utdypendeVilkårsvurderinger": [],
+        "antallTimer": null,
+        "søkerHarMeldtFraOmBarnehageplass": false
+      },
+      {
+        "begrunnelse": "",
+        "id": 3,
+        "periode": {
+          "fom": "2025-12-15",
+          "tom": "2026-01-16"
+        },
+        "resultat": "OPPFYLT",
+        "vilkårType": "BARNEHAGEPLASS",
+        "endretAv": "Z994294",
+        "erVurdert": true,
+        "erAutomatiskVurdert": false,
+        "erEksplisittAvslagPåSøknad": false,
+        "avslagBegrunnelser": [],
+        "endretTidspunkt": "2025-01-10T10:00:00.000",
+        "behandlingId": 1,
+        "vurderesEtter": null,
+        "utdypendeVilkårsvurderinger": [],
+        "antallTimer": 19,
+        "søkerHarMeldtFraOmBarnehageplass": true
+      },
+      {
+        "begrunnelse": "",
+        "id": 4,
+        "periode": {
+          "fom": "2026-01-17",
+          "tom": "2026-08-06"
+        },
+        "resultat": "OPPFYLT",
+        "vilkårType": "BARNEHAGEPLASS",
+        "endretAv": "Z994294",
+        "erVurdert": true,
+        "erAutomatiskVurdert": false,
+        "erEksplisittAvslagPåSøknad": false,
+        "avslagBegrunnelser": [],
+        "endretTidspunkt": "2025-01-10T10:00:00.000",
+        "behandlingId": 1,
+        "vurderesEtter": null,
+        "utdypendeVilkårsvurderinger": [],
+        "antallTimer": 40,
+        "søkerHarMeldtFraOmBarnehageplass": true
+      },
+      {
+        "begrunnelse": "",
+        "id": 5,
+        "periode": {
+          "fom": "2024-02-01"
+        },
+        "resultat": "OPPFYLT",
+        "vilkårType": "BOSATT_I_RIKET",
+        "endretAv": "Z994294",
+        "erVurdert": true,
+        "erAutomatiskVurdert": false,
+        "erEksplisittAvslagPåSøknad": false,
+        "avslagBegrunnelser": [],
+        "endretTidspunkt": "2025-01-10T10:00:00.000",
+        "behandlingId": 1,
+        "vurderesEtter": "NASJONALE_REGLER",
+        "utdypendeVilkårsvurderinger": [],
+        "antallTimer": null
+      },
+      {
+        "begrunnelse": "",
+        "id": 6,
+        "periode": {
+          "fom": "2024-02-01"
+        },
+        "resultat": "OPPFYLT",
+        "vilkårType": "BOR_MED_SØKER",
+        "endretAv": "Z994294",
+        "erVurdert": true,
+        "erAutomatiskVurdert": false,
+        "erEksplisittAvslagPåSøknad": false,
+        "avslagBegrunnelser": [],
+        "endretTidspunkt": "2025-01-10T10:00:00.000",
+        "behandlingId": 1,
+        "vurderesEtter": "NASJONALE_REGLER",
+        "utdypendeVilkårsvurderinger": [],
+        "antallTimer": null
+      },
+      {
+        "begrunnelse": "",
+        "id": 7,
+        "periode": {
+          "fom": "2024-02-01"
+        },
+        "resultat": "OPPFYLT",
+        "vilkårType": "MEDLEMSKAP_ANNEN_FORELDER",
+        "endretAv": "Z994294",
+        "erVurdert": true,
+        "erAutomatiskVurdert": false,
+        "erEksplisittAvslagPåSøknad": false,
+        "avslagBegrunnelser": [],
+        "endretTidspunkt": "2025-01-10T10:00:00.000",
+        "behandlingId": 1,
+        "vurderesEtter": "NASJONALE_REGLER",
+        "utdypendeVilkårsvurderinger": [],
+        "antallTimer": null
+      }
+    ],
+    "andreVurderinger": []
+  }
+]


### PR DESCRIPTION
### 📮 Favro: NAV-28955

### 💰 Hva skal gjøres, og hvorfor?
Når vi validerer barnehageplass med fremtidig opphør, henter vi seneste periode med barnehageplass med fremtidig opphør i backend. 

I frontend derimot har vi ikke gjort dette, og det fører til at dersom det finnes flere perioder med fremtidig opphør, så vil det gå galt.

FØR:

https://github.com/user-attachments/assets/e259b3b8-d555-478e-b97d-924e38931b86


ETTER:

https://github.com/user-attachments/assets/c09e6dd2-e9be-4f56-ac5d-72565bd69cc0

