### PR TITLE
NAV-27893: Forbedrer logikk rundt genererte brevbegrunnelser

### DIFF
--- a/src/frontend/hooks/useHentGenererteBrevbegrunnelser.ts
+++ b/src/frontend/hooks/useHentGenererteBrevbegrunnelser.ts
@@ -1,22 +1,20 @@
+import { hentGenererteBrevbegrunnelser } from '@api/hentGenererteBrevbegrunnelser';
 import { type DefaultError, useQuery, type UseQueryOptions } from '@tanstack/react-query';
 
 import { useHttp } from '@navikt/familie-http';
-
-import { hentGenererteBrevbegrunnelser } from '../api/hentGenererteBrevbegrunnelser';
 
 export const HentGenererteBrevbegrunnelserQueryKeyFactory = {
     vedtaksperiode: (vedtaksperiodeId: number) => ['genererteBrevbegrunnelser', vedtaksperiodeId],
 };
 
-type Options = Omit<UseQueryOptions<string[], DefaultError, string[]>, 'queryKey' | 'queryFn' | 'gcTime'> & {
-    vedtaksperiodeId: number;
-};
+type Options = Omit<UseQueryOptions<string[], DefaultError, string[]>, 'queryKey' | 'queryFn' | 'select'>;
 
-export function useHentGenererteBrevbegrunnelser({ vedtaksperiodeId, ...options }: Options) {
+export function useHentGenererteBrevbegrunnelser(vedtaksperiodeId: number, options?: Options) {
     const { request } = useHttp();
     return useQuery({
         queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(vedtaksperiodeId),
         queryFn: () => hentGenererteBrevbegrunnelser(request, vedtaksperiodeId),
+        select: data => data.toSorted(),
         ...options,
     });
 }

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -1,3 +1,15 @@
+import { useFagsakId } from '@hooks/useFagsakId';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { BrevmottakereAlert } from '@komponenter/BrevmottakereAlert';
+import {
+    BehandlerRolle,
+    BehandlingStatus,
+    BehandlingSteg,
+    BehandlingÅrsak,
+    hentStegNummer,
+    type IBehandling,
+} from '@typer/behandling';
+import type { IPersonInfo } from '@typer/person';
 import { useNavigate } from 'react-router';
 
 import { FileTextIcon, InformationSquareIcon } from '@navikt/aksel-icons';
@@ -12,21 +24,9 @@ import { SammensattKontrollsak } from './SammensattKontrollsak/SammensattKontrol
 import { useSammensattKontrollsakContext } from './SammensattKontrollsak/SammensattKontrollsakContext';
 import { Vedtaksmeny } from './Vedtaksmeny/Vedtaksmeny';
 import { AlleBegrunnelserProvider } from './Vedtaksperioder/AlleBegrunnelserContext';
-import Vedtaksperioder from './Vedtaksperioder/Vedtaksperioder';
+import { Vedtaksperioder } from './Vedtaksperioder/Vedtaksperioder';
 import useDokument from '../../../../../hooks/useDokument';
-import { useFagsakId } from '../../../../../hooks/useFagsakId';
-import { useSaksbehandler } from '../../../../../hooks/useSaksbehandler';
-import { BrevmottakereAlert } from '../../../../../komponenter/BrevmottakereAlert';
 import PdfVisningModal from '../../../../../komponenter/PdfVisningModal/PdfVisningModal';
-import {
-    BehandlerRolle,
-    BehandlingStatus,
-    BehandlingSteg,
-    BehandlingÅrsak,
-    hentStegNummer,
-    type IBehandling,
-} from '../../../../../typer/behandling';
-import type { IPersonInfo } from '../../../../../typer/person';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
 interface IOppsummeringVedtakInnholdProps {
@@ -169,7 +169,7 @@ const OppsummeringVedtakInnhold = ({
                         ) : (
                             <>
                                 <AlleBegrunnelserProvider>
-                                    <Vedtaksperioder åpenBehandling={åpenBehandling} />
+                                    <Vedtaksperioder />
                                 </AlleBegrunnelserProvider>
                                 {erFeilutbetaltValutaTabellSynlig && <FeilutbetaltValutaTabell />}
                                 {erRefusjonEøsTabellSynlig && <RefusjonEøsTabell />}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
@@ -1,3 +1,9 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useOppdaterBegrunnelserMutationState } from '@hooks/useOppdaterStandardbegrunnelserMutationState';
+import type { OptionType } from '@typer/common';
+import { type Begrunnelse, type BegrunnelseType, Standardbegrunnelse } from '@typer/vedtak';
+import { begrunnelseTyper } from '@typer/vedtak';
+import { finnBegrunnelseType, hentBakgrunnsfarge, hentBorderfarge } from '@utils/vedtakUtils';
 import styled from 'styled-components';
 
 import { BodyShort, Label } from '@navikt/ds-react';
@@ -12,31 +18,28 @@ import {
 import { useAlleBegrunnelserContext } from './AlleBegrunnelserContext';
 import { mapBegrunnelserTilSelectOptions } from './utils';
 import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
-import { useOppdaterBegrunnelserMutationState } from '../../../../../../hooks/useOppdaterStandardbegrunnelserMutationState';
-import type { OptionType } from '../../../../../../typer/common';
-import type { Begrunnelse, BegrunnelseType } from '../../../../../../typer/vedtak';
-import { begrunnelseTyper } from '../../../../../../typer/vedtak';
-import { finnBegrunnelseType, hentBakgrunnsfarge, hentBorderfarge } from '../../../../../../utils/vedtakUtils';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
-
-interface IProps {
-    tillatKunLesevisning: boolean;
-}
 
 const GroupLabel = styled.div`
     color: black;
 `;
 
-const BegrunnelserMultiselect = ({ tillatKunLesevisning }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = tillatKunLesevisning || vurderErLesevisning();
-
-    const { id, onChangeBegrunnelse, grupperteBegrunnelser, vedtaksperiodeMedBegrunnelser } =
-        useVedtaksperiodeContext();
+export function BegrunnelserMultiselect() {
+    const { vedtaksperiodeMedBegrunnelser, onChangeBegrunnelse, grupperteBegrunnelser } = useVedtaksperiodeContext();
     const { alleBegrunnelser } = useAlleBegrunnelserContext();
+
+    const erLesevisning = useErLesevisning();
     const oppdaterBegrunnelserMutation = useOppdaterBegrunnelserMutationState(vedtaksperiodeMedBegrunnelser.id);
 
     const begrunnelser = mapBegrunnelserTilSelectOptions(vedtaksperiodeMedBegrunnelser, alleBegrunnelser);
+
+    const vedtaksperiodeInneholderFramtidigOpphørBegrunnelse =
+        vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
+            vedtaksBegrunnelser =>
+                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
+                Standardbegrunnelse.OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS
+        ).length > 0;
+
+    const erRedigeringDeaktivert = vedtaksperiodeInneholderFramtidigOpphørBegrunnelse || erLesevisning;
 
     const propSelectStyles: StylesConfig<OptionType, boolean, GroupBase<OptionType>> = {
         container: (provided, props) =>
@@ -70,15 +73,16 @@ const BegrunnelserMultiselect = ({ tillatKunLesevisning }: IProps) => {
 
     return (
         <FamilieReactSelect
-            id={`${id}`}
+            id={`${vedtaksperiodeMedBegrunnelser.id}`}
             value={begrunnelser}
             propSelectStyles={propSelectStyles}
             placeholder={'Velg begrunnelse(r)'}
-            isDisabled={erLesevisning || oppdaterBegrunnelserMutation?.status === 'pending'}
+            isLoading={oppdaterBegrunnelserMutation?.status === 'pending'}
+            isDisabled={erRedigeringDeaktivert || oppdaterBegrunnelserMutation?.status === 'pending'}
             feil={oppdaterBegrunnelserMutation?.error?.message}
             label="Velg standardtekst i brev"
             creatable={false}
-            erLesevisning={erLesevisning}
+            erLesevisning={erRedigeringDeaktivert}
             isMulti={true}
             menuPosition="fixed"
             menuPortalTarget={typeof document !== 'undefined' ? document.body : null}
@@ -110,6 +114,4 @@ const BegrunnelserMultiselect = ({ tillatKunLesevisning }: IProps) => {
             options={grupperteBegrunnelser}
         />
     );
-};
-
-export default BegrunnelserMultiselect;
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
@@ -1,12 +1,8 @@
 import type { PropsWithChildren } from 'react';
 
-import { endOfMonth, isAfter, isSameDay } from 'date-fns';
-import styled from 'styled-components';
-
-import { BodyShort, ExpansionCard, Label } from '@navikt/ds-react';
-
-import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../../typer/vedtaksperiode';
-import { hentVedtaksperiodeTittel, Vedtaksperiodetype } from '../../../../../../typer/vedtaksperiode';
+import { useVedtaksperiodeContext } from '@sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext';
+import { Standardbegrunnelse } from '@typer/vedtak';
+import { hentVedtaksperiodeTittel, Vedtaksperiodetype } from '@typer/vedtaksperiode';
 import {
     hentDagensDato,
     isoDatoPeriodeTilFormatertString,
@@ -14,8 +10,12 @@ import {
     isoStringTilDateMedFallback,
     parseFraOgMedDato,
     tidenesEnde,
-} from '../../../../../../utils/dato';
-import { formaterBeløp, summer } from '../../../../../../utils/formatter';
+} from '@utils/dato';
+import { formaterBeløp, summer } from '@utils/formatter';
+import { endOfMonth, isAfter, isSameDay } from 'date-fns';
+import styled from 'styled-components';
+
+import { BodyShort, ExpansionCard, Label } from '@navikt/ds-react';
 
 const StyledExpansionCard = styled(ExpansionCard)`
     margin-bottom: 1rem;
@@ -32,12 +32,8 @@ const StyledExpansionTitle = styled(ExpansionCard.Title)`
     margin-left: 0;
 `;
 
-interface EkspanderbarVedtaksperiodeProps extends PropsWithChildren {
-    vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
+interface Props extends PropsWithChildren {
     sisteVedtaksperiodeFom?: string;
-    vedtaksperiodeInneholderOvergangsordningBegrunnelse: boolean;
-    åpen: boolean;
-    onClick?: () => void;
 }
 
 const erSammeFom = (dato1?: IsoDatoString, dato2?: IsoDatoString): boolean =>
@@ -62,26 +58,33 @@ const finnPresentertTomDato = (
     return periodeTom;
 };
 
-const EkspanderbarVedtaksperiode = ({
-    vedtaksperiodeMedBegrunnelser,
-    sisteVedtaksperiodeFom,
-    vedtaksperiodeInneholderOvergangsordningBegrunnelse,
-    åpen,
-    onClick,
-    children,
-}: EkspanderbarVedtaksperiodeProps) => {
+export function EkspanderbarVedtaksperiode({ sisteVedtaksperiodeFom, children }: Props) {
+    const { vedtaksperiodeMedBegrunnelser, erPanelEkspandert, onPanelClose } = useVedtaksperiodeContext();
+
+    const vedtaksperiodeInneholderOvergangsordningBegrunnelse =
+        vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
+            vedtaksBegrunnelser =>
+                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
+                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING ||
+                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
+                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING ||
+                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
+                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING_DELT_BOSTED
+        ).length > 0;
+
     const periode = {
         fom: vedtaksperiodeMedBegrunnelser.fom,
         tom: vedtaksperiodeMedBegrunnelser.tom,
     };
+
     const vedtaksperiodeTittel = hentVedtaksperiodeTittel(vedtaksperiodeMedBegrunnelser);
 
     return (
         <StyledExpansionCard
             key={`${periode.fom}_${periode.tom}`}
             size={'small'}
-            open={åpen}
-            onToggle={onClick}
+            open={erPanelEkspandert}
+            onToggle={() => onPanelClose(true)}
             aria-label={`Periode ${periode.fom}_${periode.tom}`}
         >
             <StyledExpansionHeader>
@@ -117,6 +120,4 @@ const EkspanderbarVedtaksperiode = ({
             <ExpansionCard.Content>{children}</ExpansionCard.Content>
         </StyledExpansionCard>
     );
-};
-
-export default EkspanderbarVedtaksperiode;
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/FritekstVedtakbegrunnelser.tsx
@@ -69,14 +69,10 @@ const ItalicText = styled(BodyLong)`
     font-style: italic;
 `;
 
-const FritekstVedtakbegrunnelser = () => {
-    const behandling = useBehandling();
-    const erLesevisning = useErLesevisning();
-
+export function FritekstVedtakbegrunnelser() {
     const {
         skjema,
         leggTilFritekst,
-        id,
         makslengdeFritekst,
         maksAntallKulepunkter,
         onPanelClose,
@@ -84,13 +80,16 @@ const FritekstVedtakbegrunnelser = () => {
         vedtaksperiodeMedBegrunnelser,
     } = useVedtaksperiodeContext();
 
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+
     const oppdaterVedtaksperiodeMedFriteksterMutation = useOppdaterVedtaksperiodeMedFriteksterMutationState(
         vedtaksperiodeMedBegrunnelser.id
     );
 
     const erMaksAntallKulepunkter = skjema.felter.fritekster.verdi.length >= maksAntallKulepunkter;
 
-    const fieldsetId = `Fritekster ${id}`;
+    const fieldsetId = `Fritekster ${vedtaksperiodeMedBegrunnelser.id}`;
 
     const onChangeFritekst = (event: ChangeEvent<HTMLTextAreaElement>, fritekstId: number) =>
         skjema.felter.fritekster.validerOgSettFelt([
@@ -242,6 +241,4 @@ const FritekstVedtakbegrunnelser = () => {
             {'Legg til fritekst'}
         </Button>
     ) : null;
-};
-
-export default FritekstVedtakbegrunnelser;
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
@@ -46,7 +46,7 @@ export function GenererteBrevbegrunnelser() {
         <VStack gap={'space-0'}>
             <Label>Begrunnelse(r)</Label>
             <ul>
-                {(genererteBrevbegrunnelser ?? []).map((begrunnelse, index) => (
+                {genererteBrevbegrunnelser.map((begrunnelse, index) => (
                     <li key={`begrunnelse-${index}`}>
                         <BodyShort>{begrunnelse}</BodyShort>
                     </li>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
@@ -1,0 +1,57 @@
+import { useHentGenererteBrevbegrunnelser } from '@hooks/useHentGenererteBrevbegrunnelser';
+import { useVedtaksperiodeContext } from '@sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext';
+
+import { BodyShort, ErrorMessage, HStack, Label, Loader, VStack } from '@navikt/ds-react';
+
+export function GenererteBrevbegrunnelser() {
+    const { vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
+
+    const {
+        data: genererteBrevbegrunnelser,
+        isPending: genererteBrevbegrunnelserIsPending,
+        error: genererteBrevbegrunnelserError,
+    } = useHentGenererteBrevbegrunnelser(vedtaksperiodeMedBegrunnelser.id);
+
+    if (genererteBrevbegrunnelserIsPending) {
+        return (
+            <VStack gap={'space-4'}>
+                <Label>Begrunnelse(r)</Label>
+                <HStack gap={'space-6'}>
+                    <Loader size={'xsmall'} />
+                    Laster begrunnelse(r)...
+                </HStack>
+            </VStack>
+        );
+    }
+
+    if (genererteBrevbegrunnelserError) {
+        return (
+            <VStack gap={'space-4'}>
+                <Label>Begrunnelse(r)</Label>
+                <ErrorMessage>{genererteBrevbegrunnelserError.message}</ErrorMessage>
+            </VStack>
+        );
+    }
+
+    if (genererteBrevbegrunnelser.length === 0) {
+        return (
+            <VStack gap={'space-4'}>
+                <Label>Begrunnelse(r)</Label>
+                <BodyShort size={'small'}>Ingen begrunnelse(r).</BodyShort>
+            </VStack>
+        );
+    }
+
+    return (
+        <VStack gap={'space-0'}>
+            <Label>Begrunnelse(r)</Label>
+            <ul>
+                {(genererteBrevbegrunnelser ?? []).map((begrunnelse, index) => (
+                    <li key={`begrunnelse-${index}`}>
+                        <BodyShort>{begrunnelse}</BodyShort>
+                    </li>
+                ))}
+            </ul>
+        </VStack>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Utbetalingsresultat.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Utbetalingsresultat.tsx
@@ -1,41 +1,19 @@
-import styled from 'styled-components';
+import { useVedtaksperiodeContext } from '@sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext';
+import { formaterBeløp, formaterIdent, sorterUtbetaling } from '@utils/formatter';
 
-import { BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort, HStack, Label, VStack } from '@navikt/ds-react';
 
-import type { IUtbetalingsperiodeDetalj } from '../../../../../../typer/vedtaksperiode';
-import { formaterBeløp, formaterIdent, sorterUtbetaling } from '../../../../../../utils/formatter';
-
-interface IProps {
-    utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
-}
-
-const UtbetalingsperiodeDetalj = styled.div`
-    display: flex;
-    flex-direction: row;
-
-    p + p {
-        margin-left: 1.5rem;
-    }
-`;
-
-const Utbetalingsresultat = ({ utbetalingsperiodeDetaljer }: IProps) => {
-    if (utbetalingsperiodeDetaljer.length === 0) return null;
-
+export function Utbetalingsresultat() {
+    const { vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
     return (
-        <div style={{ marginBottom: '1rem' }}>
+        <VStack gap={'space-4'}>
             <Label>Resultat</Label>
-
-            {utbetalingsperiodeDetaljer
-                .sort(sorterUtbetaling)
-                .map((detalj: IUtbetalingsperiodeDetalj, index: number) => (
-                    <UtbetalingsperiodeDetalj key={`${index}_${detalj.person.fødselsdato}`}>
-                        <BodyShort title={detalj.person.navn}>{formaterIdent(detalj.person.personIdent)}</BodyShort>
-
-                        <BodyShort>{formaterBeløp(detalj.utbetaltPerMnd)}</BodyShort>
-                    </UtbetalingsperiodeDetalj>
-                ))}
-        </div>
+            {vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.sort(sorterUtbetaling).map((detalj, index) => (
+                <HStack key={`${index}_${detalj.person.fødselsdato}`} gap={'space-28'}>
+                    <BodyShort title={detalj.person.navn}>{formaterIdent(detalj.person.personIdent)}</BodyShort>
+                    <BodyShort>{formaterBeløp(detalj.utbetaltPerMnd)}</BodyShort>
+                </HStack>
+            ))}
+        </VStack>
     );
-};
-
-export default Utbetalingsresultat;
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
@@ -1,86 +1,36 @@
-import { BodyShort, ErrorMessage, HStack, Label, Loader } from '@navikt/ds-react';
+import { GenererteBrevbegrunnelser } from '@sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser';
+import { Vedtaksperiodetype } from '@typer/vedtaksperiode';
 
-import BegrunnelserMultiselect from './BegrunnelserMultiselect';
-import EkspanderbarVedtaksperiode from './EkspanderbarVedtaksperiode';
-import FritekstVedtakbegrunnelser from './FritekstVedtakbegrunnelser';
-import Utbetalingsresultat from './Utbetalingsresultat';
+import { VStack } from '@navikt/ds-react';
+
+import { BegrunnelserMultiselect } from './BegrunnelserMultiselect';
+import { EkspanderbarVedtaksperiode } from './EkspanderbarVedtaksperiode';
+import { FritekstVedtakbegrunnelser } from './FritekstVedtakbegrunnelser';
+import { Utbetalingsresultat } from './Utbetalingsresultat';
 import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
-import { useHentGenererteBrevbegrunnelser } from '../../../../../../hooks/useHentGenererteBrevbegrunnelser';
-import { Standardbegrunnelse } from '../../../../../../typer/vedtak';
-import { type IVedtaksperiodeMedBegrunnelser, Vedtaksperiodetype } from '../../../../../../typer/vedtaksperiode';
 
-interface IProps {
-    vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
+interface Props {
     sisteVedtaksperiodeFom?: string;
 }
 
-const Vedtaksperiode = ({ vedtaksperiodeMedBegrunnelser, sisteVedtaksperiodeFom }: IProps) => {
-    const { erPanelEkspandert, onPanelClose } = useVedtaksperiodeContext();
-    const {
-        data: genererteBrevbegrunnelser,
-        isPending: genererteBrevbegrunnelserPending,
-        error: genererteBrevbegrunnelserError,
-    } = useHentGenererteBrevbegrunnelser({ vedtaksperiodeId: vedtaksperiodeMedBegrunnelser.id });
-
-    const vedtaksperiodeInneholderFramtidigOpphørBegrunnelse =
-        vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
-            vedtaksBegrunnelser =>
-                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
-                Standardbegrunnelse.OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS
-        ).length > 0;
-
-    const vedtaksperiodeInneholderOvergangsordningBegrunnelse =
-        vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
-            vedtaksBegrunnelser =>
-                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
-                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING ||
-                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
-                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING ||
-                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
-                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING_DELT_BOSTED
-        ).length > 0;
+export function Vedtaksperiode({ sisteVedtaksperiodeFom }: Props) {
+    const { vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
 
     const vedtaksperiodeStøtterFritekst =
         vedtaksperiodeMedBegrunnelser.støtterFritekst || vedtaksperiodeMedBegrunnelser.fritekster.length > 0;
 
     return (
-        <EkspanderbarVedtaksperiode
-            vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
-            sisteVedtaksperiodeFom={sisteVedtaksperiodeFom}
-            vedtaksperiodeInneholderOvergangsordningBegrunnelse={vedtaksperiodeInneholderOvergangsordningBegrunnelse}
-            åpen={erPanelEkspandert}
-            onClick={() => onPanelClose(true)}
-        >
-            <Utbetalingsresultat
-                utbetalingsperiodeDetaljer={vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer}
-            />
-            {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.AVSLAG && (
-                <BegrunnelserMultiselect tillatKunLesevisning={vedtaksperiodeInneholderFramtidigOpphørBegrunnelse} />
-            )}
-            {genererteBrevbegrunnelserPending ? (
-                <HStack justify={'center'} align={'center'} paddingBlock={'space-32'} gap={'space-8'}>
-                    <Loader size={'small'} />
-                    <BodyShort>Laster genererte brevbegrunnelser...</BodyShort>
-                </HStack>
-            ) : genererteBrevbegrunnelserError ? (
-                <ErrorMessage>{genererteBrevbegrunnelserError.message}</ErrorMessage>
-            ) : (
-                genererteBrevbegrunnelser &&
-                genererteBrevbegrunnelser.length > 0 && (
-                    <>
-                        <Label>Begrunnelse(r)</Label>
-                        <ul>
-                            {genererteBrevbegrunnelser.map((begrunnelse: string, index: number) => (
-                                <li key={`begrunnelse-${index}`}>
-                                    <BodyShort children={begrunnelse} />
-                                </li>
-                            ))}
-                        </ul>
-                    </>
-                )
-            )}
-            {vedtaksperiodeStøtterFritekst && <FritekstVedtakbegrunnelser />}
+        <EkspanderbarVedtaksperiode sisteVedtaksperiodeFom={sisteVedtaksperiodeFom}>
+            <VStack gap={'space-20'}>
+                {vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.length !== 0 && <Utbetalingsresultat />}
+                {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.AVSLAG && <BegrunnelserMultiselect />}
+                <GenererteBrevbegrunnelser />
+                {vedtaksperiodeStøtterFritekst && (
+                    <div>
+                        <FritekstVedtakbegrunnelser />
+                    </div>
+                )}
+            </VStack>
         </EkspanderbarVedtaksperiode>
     );
-};
-export default Vedtaksperiode;
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
@@ -79,6 +79,7 @@ export function VedtaksperiodeProvider({ vedtaksperiodeMedBegrunnelser, children
                     ),
                 });
                 settÅpenBehandling(byggSuksessRessurs(behandling));
+                onPanelClose(false);
             },
         }
     );

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
@@ -1,7 +1,15 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
 
+import { HentGenererteBrevbegrunnelserQueryKeyFactory } from '@hooks/useHentGenererteBrevbegrunnelser';
+import { useOppdaterBegrunnelser } from '@hooks/useOppdaterBegrunnelser';
+import { useOppdaterVedtaksperiodeMedFritekster } from '@hooks/useOppdaterVedtaksperiodeMedFritekster';
 import { useQueryClient } from '@tanstack/react-query';
+import { Behandlingstype, type IBehandling } from '@typer/behandling';
+import type { Begrunnelse } from '@typer/vedtak';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
+import type { IIsoDatoPeriode } from '@utils/dato';
+import { genererIdBasertPåAndreFritekster, type IFritekstFelt, lagInitiellFritekst } from '@utils/fritekstfelter';
 import deepEqual from 'deep-equal';
 
 import type { ActionMeta, GroupBase, OptionType } from '@navikt/familie-form-elements';
@@ -11,23 +19,13 @@ import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { useAlleBegrunnelserContext } from './AlleBegrunnelserContext';
 import { grupperteBegrunnelser } from './utils';
-import { HentGenererteBrevbegrunnelserQueryKeyFactory } from '../../../../../../hooks/useHentGenererteBrevbegrunnelser';
-import { useOppdaterBegrunnelser } from '../../../../../../hooks/useOppdaterBegrunnelser';
-import { useOppdaterVedtaksperiodeMedFritekster } from '../../../../../../hooks/useOppdaterVedtaksperiodeMedFritekster';
-import { Behandlingstype, type IBehandling } from '../../../../../../typer/behandling';
-import type { Begrunnelse } from '../../../../../../typer/vedtak';
-import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../../typer/vedtaksperiode';
-import type { IIsoDatoPeriode } from '../../../../../../utils/dato';
-import {
-    genererIdBasertPåAndreFritekster,
-    type IFritekstFelt,
-    lagInitiellFritekst,
-} from '../../../../../../utils/fritekstfelter';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 
-interface IProps extends PropsWithChildren {
+const maksAntallKulepunkter = 3;
+const makslengdeFritekst = 350;
+
+interface Props extends PropsWithChildren {
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
-    åpenBehandling: IBehandling;
 }
 
 interface BegrunnelserSkjema {
@@ -39,7 +37,6 @@ interface VedtaksperiodeContextValue {
     erPanelEkspandert: boolean;
     grupperteBegrunnelser: GroupBase<OptionType>[];
     hentFeilTilOppsummering: () => FeiloppsummeringFeil[];
-    id: number;
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
     leggTilFritekst: () => void;
     maksAntallKulepunkter: number;
@@ -48,46 +45,43 @@ interface VedtaksperiodeContextValue {
     onPanelClose: (visAlert: boolean) => void;
     putVedtaksperiodeMedFritekster: () => void;
     skjema: ISkjema<BegrunnelserSkjema, IBehandling>;
-    åpenBehandling: IBehandling;
 }
 
 const VedtaksperiodeContext = createContext<VedtaksperiodeContextValue | undefined>(undefined);
 
-export const VedtaksperiodeProvider = ({ åpenBehandling, vedtaksperiodeMedBegrunnelser, children }: IProps) => {
-    const { settÅpenBehandling } = useBehandlingContext();
+export function VedtaksperiodeProvider({ vedtaksperiodeMedBegrunnelser, children }: Props) {
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
+
     const queryClient = useQueryClient();
+
     const [erPanelEkspandert, settErPanelEkspandert] = useState(
-        åpenBehandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING &&
+        behandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING &&
             vedtaksperiodeMedBegrunnelser.begrunnelser.length === 0 &&
             vedtaksperiodeMedBegrunnelser.fritekster.length === 0
     );
 
     const { mutate: oppdaterBegrunnelser } = useOppdaterBegrunnelser(vedtaksperiodeMedBegrunnelser.id, {
-        onSuccess: behandling => {
-            settÅpenBehandling(byggSuksessRessurs(behandling));
-            queryClient.invalidateQueries({
+        onSuccess: async behandling => {
+            await queryClient.invalidateQueries({
                 queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(vedtaksperiodeMedBegrunnelser.id),
             });
+            settÅpenBehandling(byggSuksessRessurs(behandling));
         },
     });
 
     const { mutate: oppdaterVedtaksperiodeMedFritekster } = useOppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeMedBegrunnelser.id,
         {
-            onSuccess: (behandling: IBehandling) => {
-                settÅpenBehandling(byggSuksessRessurs(behandling));
-                queryClient.invalidateQueries({
+            onSuccess: async (behandling: IBehandling) => {
+                await queryClient.invalidateQueries({
                     queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(
                         vedtaksperiodeMedBegrunnelser.id
                     ),
                 });
-                onPanelClose(false);
+                settÅpenBehandling(byggSuksessRessurs(behandling));
             },
         }
     );
-
-    const maksAntallKulepunkter = 3;
-    const makslengdeFritekst = 350;
 
     const valgteBegrunnelser = [
         ...vedtaksperiodeMedBegrunnelser.begrunnelser,
@@ -217,7 +211,6 @@ export const VedtaksperiodeProvider = ({ åpenBehandling, vedtaksperiodeMedBegru
                 erPanelEkspandert,
                 grupperteBegrunnelser: grupperteBegrunnelser(vedtaksperiodeMedBegrunnelser, alleBegrunnelser),
                 hentFeilTilOppsummering,
-                id: vedtaksperiodeMedBegrunnelser.id,
                 vedtaksperiodeMedBegrunnelser,
                 leggTilFritekst,
                 maksAntallKulepunkter,
@@ -226,19 +219,17 @@ export const VedtaksperiodeProvider = ({ åpenBehandling, vedtaksperiodeMedBegru
                 onPanelClose,
                 putVedtaksperiodeMedFritekster,
                 skjema,
-                åpenBehandling,
             }}
         >
             {children}
         </VedtaksperiodeContext.Provider>
     );
-};
+}
 
-export const useVedtaksperiodeContext = () => {
+export function useVedtaksperiodeContext() {
     const context = useContext(VedtaksperiodeContext);
-
     if (context === undefined) {
         throw new Error('useVedtaksperiodeContext må brukes inne i en VedtaksperiodeProvider');
     }
     return context;
-};
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
@@ -1,16 +1,16 @@
 import { Fragment } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
+import { Vedtaksperiodetype } from '@typer/vedtaksperiode';
+import { partition } from '@utils/commons';
 import styled from 'styled-components';
 
 import { Heading, HelpText } from '@navikt/ds-react';
 
 import { filtrerOgSorterPerioderMedBegrunnelseBehov } from './utils';
-import Vedtaksperiode from './Vedtaksperiode';
+import { Vedtaksperiode } from './Vedtaksperiode';
 import { VedtaksperiodeProvider } from './VedtaksperiodeContext';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../../typer/vedtaksperiode';
-import { Vedtaksperiodetype } from '../../../../../../typer/vedtaksperiode';
-import { partition } from '../../../../../../utils/commons';
 
 const StyledHeading = styled(Heading)`
     display: flex;
@@ -26,16 +26,14 @@ const StyledHelpText = styled(HelpText)`
     }
 `;
 
-interface VedtaksperioderProps {
-    åpenBehandling: IBehandling;
-}
+export function Vedtaksperioder() {
+    const behandling = useBehandling();
 
-const Vedtaksperioder = ({ åpenBehandling }: VedtaksperioderProps) => {
     const sorterteVedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
-        åpenBehandling.vedtak?.vedtaksperioderMedBegrunnelser ?? [],
-        åpenBehandling.resultat,
-        åpenBehandling.status,
-        åpenBehandling.sisteVedtaksperiodeVisningDato
+        behandling.vedtak?.vedtaksperioderMedBegrunnelser ?? [],
+        behandling.resultat,
+        behandling.status,
+        behandling.sisteVedtaksperiodeVisningDato
     );
 
     const [sorterteAvslagsperioder, sorterteAndreVedtaksperioder] = partition(
@@ -49,31 +47,27 @@ const Vedtaksperioder = ({ åpenBehandling }: VedtaksperioderProps) => {
                 sorterteVedtaksperioderMedBegrunnelser={sorterteAndreVedtaksperioder}
                 overskrift={'Begrunnelser i vedtaksbrev'}
                 hjelpetekst={'Her skal du sette begrunnelsestekster for innvilgelse, reduksjon og opphør.'}
-                åpenBehandling={åpenBehandling}
             />
 
             <GrupperteVedtaksperioder
                 sorterteVedtaksperioderMedBegrunnelser={sorterteAvslagsperioder}
                 overskrift={'Begrunnelser for avslag i vedtaksbrev'}
                 hjelpetekst={'Her har vi hentet begrunnelser for avslag som er satt tidligere i behandlingen.'}
-                åpenBehandling={åpenBehandling}
             />
         </>
     ) : (
         <Fragment />
     );
-};
+}
 
 const GrupperteVedtaksperioder = ({
     sorterteVedtaksperioderMedBegrunnelser,
     overskrift,
     hjelpetekst,
-    åpenBehandling,
 }: {
     sorterteVedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBegrunnelser[];
     overskrift: string;
     hjelpetekst: string;
-    åpenBehandling: IBehandling;
 }) => {
     if (sorterteVedtaksperioderMedBegrunnelser.length === 0) {
         return null;
@@ -92,13 +86,9 @@ const GrupperteVedtaksperioder = ({
                 (vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser) => (
                     <VedtaksperiodeProvider
                         key={vedtaksperiodeMedBegrunnelser.id}
-                        åpenBehandling={åpenBehandling}
                         vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
                     >
-                        <Vedtaksperiode
-                            vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
-                            sisteVedtaksperiodeFom={sisteVedtaksperiodeFom}
-                        />
+                        <Vedtaksperiode sisteVedtaksperiodeFom={sisteVedtaksperiodeFom} />
                     </VedtaksperiodeProvider>
                 )
             )}


### PR DESCRIPTION
### 📮 Favro
NAV-27893

### 💰 Hva skal gjøres, og hvorfor?
Forbedrer tilstandshåndtering rundt henting av vedtaksperiode genererte begrunnelser. Gjør også listen stabil ved å sortere den slik at `useEffect` hooks som lytter på listen ikke blir trigget hvis rekkefølgen endrer seg. Rydder også generelt bare opp i koden en del. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ingen tidligere tester, legger dem ikke til nå. 

### 👀 Screen shots
Før:

https://github.com/user-attachments/assets/7386583a-45ee-419d-a7b5-3988c931d367

Etter:

https://github.com/user-attachments/assets/6514bd19-afb2-423a-8e23-bbf624a57b6d


