### PR TITLE
fix: feil payload på hent-fagsak-paa-person

### DIFF
--- a/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
@@ -368,11 +368,11 @@ export const OppgavebenkProvider = (props: PropsWithChildren) => {
     const gåTilTilbakekreving = (oppgave: IOppgave) => {
         const brukerident = hentFnrFraOppgaveIdenter(oppgave.identer);
         if (brukerident) {
-            request<{ personIdent: string }, IMinimalFagsak | undefined>({
+            request<{ ident: string }, IMinimalFagsak | undefined>({
                 method: 'POST',
                 url: `/familie-ks-sak/api/fagsaker/hent-fagsak-paa-person`,
                 data: {
-                    personIdent: brukerident,
+                    ident: brukerident,
                 },
             }).then((fagsak: Ressurs<IMinimalFagsak | undefined>) => {
                 if (fagsak.status === RessursStatus.SUKSESS && !!fagsak.data) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Jeg oppdaget ukonsistent bruk av POST-kall til samme endepunkt `/familie-ks-sak/api/fagsaker/hent-fagsak-paa-person`, men alle stedene sendte inn data med objekt av ident: string, mens kun denne instansen sendte inn personIdent: string. Av det jeg kan se funket ikke kallene som det var, men det ser ut til å virke etter endringen. Kanskje noen kan sjekke i backenden at dette er riktig ved review.

Det ser riktig utifra det jeg kan se i backend: 
<img width="533" height="153" alt="image" src="https://github.com/user-attachments/assets/2cc5a1ab-36fa-4c1f-8029-b454f1465163" />


Får 400 Bad Request og feilmeldingen: "Mangler verdi for felt no.nav.familie.kontrakter.felles.PersonIdent[\"ident\"]""