### PR TITLE
NAV-29007: Tar i bruk useErLesevisning for enkelte komponenter

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/OvergangsordningAndel/OvergangsordningAndelSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/OvergangsordningAndel/OvergangsordningAndelSkjema.tsx
@@ -1,3 +1,8 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { BehandlingÅrsak, type IBehandling } from '@typer/behandling';
+import { isNumeric } from '@utils/eøsValidators';
+import { lagPersonLabel } from '@utils/formatter';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
@@ -7,11 +12,6 @@ import { BorderAccent } from '@navikt/ds-tokens/dist/tokens';
 import { useOvergangsordningAndelContext } from './OvergangsordningAndelContext';
 import Månedvelger, { DagIMåneden } from '../../../../../../komponenter/Datovelger/Månedvelger';
 import Knapperekke from '../../../../../../komponenter/Knapperekke';
-import { BehandlingÅrsak, type IBehandling } from '../../../../../../typer/behandling';
-import { isNumeric } from '../../../../../../utils/eøsValidators';
-import { lagPersonLabel } from '../../../../../../utils/formatter';
-import { hentFrontendFeilmelding } from '../../../../../../utils/ressursUtils';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 const KnapperekkeVenstre = styled.div`
     display: flex;
@@ -55,8 +55,6 @@ interface IOvergangsordningAndelSkjemaProps {
 }
 
 const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndelSkjemaProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-
     const {
         overgangsordningAndel,
         skjema,
@@ -65,7 +63,9 @@ const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndel
         tilbakestillOgLukkOvergangsordningAndel,
     } = useOvergangsordningAndelContext();
 
-    const erLesevisning = vurderErLesevisning() || åpenBehandling.årsak !== BehandlingÅrsak.OVERGANGSORDNING_2024;
+    const erLesevisning = useErLesevisning();
+
+    const erRedigeringDeaktivert = erLesevisning || åpenBehandling.årsak !== BehandlingÅrsak.OVERGANGSORDNING_2024;
 
     return (
         <StyledFieldset
@@ -81,7 +81,7 @@ const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndel
                     onChange={event => {
                         skjema.felter.personIdent.validerOgSettFelt(event.target.value);
                     }}
-                    readOnly={erLesevisning}
+                    readOnly={erRedigeringDeaktivert}
                 >
                     <option value={''}>Velg person</option>
                     {åpenBehandling.personerMedAndelerTilkjentYtelse
@@ -102,7 +102,7 @@ const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndel
                         label={'F.o.m.'}
                         visFeilmeldinger={skjema.visFeilmeldinger}
                         dagIMåneden={DagIMåneden.FØRSTE_DAG}
-                        readOnly={erLesevisning}
+                        readOnly={erRedigeringDeaktivert}
                     />
                     <Månedvelger
                         felt={skjema.felter.tom}
@@ -110,7 +110,7 @@ const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndel
                         visFeilmeldinger={skjema.visFeilmeldinger}
                         dagIMåneden={DagIMåneden.SISTE_DAG}
                         tilhørendeFomFelt={skjema.felter.fom}
-                        readOnly={erLesevisning}
+                        readOnly={erRedigeringDeaktivert}
                     />
                 </FlexDiv>
             </Feltmargin>
@@ -121,7 +121,7 @@ const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndel
                         skjema.felter.deltBosted.validerOgSettFelt(event.target.checked);
                         skjema.felter.antallTimer.validerOgSettFelt('0');
                     }}
-                    readOnly={erLesevisning}
+                    readOnly={erRedigeringDeaktivert}
                 >
                     {'Barnet har delt bosted'}
                 </Checkbox>
@@ -136,10 +136,10 @@ const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndel
                             skjema.felter.antallTimer.validerOgSettFelt(event.target.value);
                         }
                     }}
-                    readOnly={erLesevisning || skjema.felter.deltBosted.verdi}
+                    readOnly={erRedigeringDeaktivert || skjema.felter.deltBosted.verdi}
                 />
             </Feltmargin>
-            {!erLesevisning && (
+            {!erRedigeringDeaktivert && (
                 <Knapperekke>
                     <KnapperekkeVenstre>
                         <StyledButton size={'small'} variant={'primary'} onClick={oppdaterOvergangsordningAndel}>
@@ -150,7 +150,7 @@ const OvergangsordningAndelSkjema = ({ åpenBehandling }: IOvergangsordningAndel
                         </Button>
                     </KnapperekkeVenstre>
 
-                    {!erLesevisning && (
+                    {!erRedigeringDeaktivert && (
                         <Button
                             variant={'tertiary'}
                             id={`sletteknapp-overgangsordning-andel-${overgangsordningAndel.id}`}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/endretUtbetaling/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/endretUtbetaling/EndretUtbetalingAndelSkjema.tsx
@@ -1,5 +1,18 @@
 import { type ChangeEvent, useEffect } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IBehandling } from '@typer/behandling';
+import {
+    AVSLAG_ALLEREDE_UTBETALT_ANNEN_FORELDER,
+    AVSLAG_ALLEREDE_UTBETALT_SØKER,
+    IEndretUtbetalingAndelÅrsak,
+    årsaker,
+    årsakTekst,
+} from '@typer/utbetalingAndel';
+import type { Begrunnelse } from '@typer/vedtak';
+import type { IsoMånedString } from '@utils/dato';
+import { lagPersonLabel } from '@utils/formatter';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import classNames from 'classnames';
 import styled from 'styled-components';
 
@@ -13,19 +26,6 @@ import { type IEndretUtbetalingAndelSkjema } from './useEndretUtbetalingAndel';
 import Datovelger from '../../../../../../komponenter/Datovelger/Datovelger';
 import Knapperekke from '../../../../../../komponenter/Knapperekke';
 import MånedÅrVelger from '../../../../../../komponenter/MånedÅrInput/MånedÅrVelger';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import {
-    AVSLAG_ALLEREDE_UTBETALT_ANNEN_FORELDER,
-    AVSLAG_ALLEREDE_UTBETALT_SØKER,
-    IEndretUtbetalingAndelÅrsak,
-    årsaker,
-    årsakTekst,
-} from '../../../../../../typer/utbetalingAndel';
-import type { Begrunnelse } from '../../../../../../typer/vedtak';
-import type { IsoMånedString } from '../../../../../../utils/dato';
-import { lagPersonLabel } from '../../../../../../utils/formatter';
-import { hentFrontendFeilmelding } from '../../../../../../utils/ressursUtils';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 const KnapperekkeVenstre = styled.div`
     display: flex;
@@ -75,7 +75,7 @@ const EndretUtbetalingAndelSkjema = ({
     oppdaterEndretUtbetaling,
     slettEndretUtbetaling,
 }: IEndretUtbetalingAndelSkjemaProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = useErLesevisning();
 
     const finnÅrTilbakeTilStønadFra = (): number => {
         return (
@@ -126,7 +126,6 @@ const EndretUtbetalingAndelSkjema = ({
         }
     }, [skjema.felter.årsak.verdi]);
 
-    const erLesevisning = vurderErLesevisning();
     const skalViseEksplisittAvslagsfelt =
         skjema.felter.årsak.verdi === IEndretUtbetalingAndelÅrsak.ALLEREDE_UTBETALT ||
         !skjema.felter.periodeSkalUtbetalesTilSøker.verdi;

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/endretUtbetaling/EndretUtbetalingAvslagBegrunnelse.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/endretUtbetaling/EndretUtbetalingAvslagBegrunnelse.tsx
@@ -1,14 +1,15 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IBehandling } from '@typer/behandling';
+import type { OptionType } from '@typer/common';
+import { IEndretUtbetalingAndelÅrsak } from '@typer/utbetalingAndel';
+import { type Begrunnelse, BegrunnelseType, begrunnelseTyper } from '@typer/vedtak';
+
 import { LocalAlert, Select } from '@navikt/ds-react';
 import type { GroupBase } from '@navikt/familie-form-elements';
 import type { ISkjema } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { type IEndretUtbetalingAndelSkjema } from './useEndretUtbetalingAndel';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import type { OptionType } from '../../../../../../typer/common';
-import { IEndretUtbetalingAndelÅrsak } from '../../../../../../typer/utbetalingAndel';
-import { type Begrunnelse, BegrunnelseType, begrunnelseTyper } from '../../../../../../typer/vedtak';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { useHentEndretUtbetalingBegrunnelser } from '../useHentEndretUtbetalingBegrunnelser';
 
 interface IProps {
@@ -16,8 +17,9 @@ interface IProps {
 }
 
 export const EndretUtbetalingAvslagBegrunnelse = ({ skjema }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
     const { endretUtbetalingsbegrunnelser } = useHentEndretUtbetalingBegrunnelser();
+
+    const erLesevisning = useErLesevisning();
 
     const prevalgtBegrunnelse =
         skjema.felter.vedtaksbegrunnelser.verdi && skjema.felter.vedtaksbegrunnelser.verdi.length > 0
@@ -86,7 +88,7 @@ export const EndretUtbetalingAvslagBegrunnelse = ({ skjema }: IProps) => {
             {...skjema.felter.vedtaksbegrunnelser.hentNavInputProps(skjema.visFeilmeldinger)}
             value={finnBegrunnelseForSelect(prevalgtBegrunnelse).value}
             label={'Velg standardtekst i brev'}
-            readOnly={vurderErLesevisning()}
+            readOnly={erLesevisning}
             onChange={event => {
                 if (event) {
                     /* 

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/Annet.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/Annet.tsx
@@ -1,12 +1,13 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+
 import { Heading, Textarea, VStack } from '@navikt/ds-react';
 
 import { useSøknadContext } from './SøknadContext';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 
 const Annet = () => {
-    const { vurderErLesevisning } = useBehandlingContext();
     const { skjema } = useSøknadContext();
-    const lesevisning = vurderErLesevisning();
+
+    const erLesevisning = useErLesevisning();
 
     return (
         <VStack marginBlock={'space-32'}>
@@ -14,8 +15,8 @@ const Annet = () => {
             <br />
             <Textarea
                 {...skjema.felter.endringAvOpplysningerBegrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
-                readOnly={lesevisning}
-                label={!lesevisning && 'Ved endring av opplysningene er begrunnelse obligatorisk'}
+                readOnly={erLesevisning}
+                label={!erLesevisning && 'Ved endring av opplysningene er begrunnelse obligatorisk'}
                 maxLength={2000}
             />
         </VStack>

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/BarnMedOpplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/BarnMedOpplysninger.tsx
@@ -1,3 +1,6 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IBarnMedOpplysninger } from '@typer/søknad';
+import { formaterIdent, hentAlderSomString } from '@utils/formatter';
 import classNames from 'classnames';
 
 import { BodyShort, Box, Button, Checkbox, HStack } from '@navikt/ds-react';
@@ -5,9 +8,6 @@ import { BodyShort, Box, Button, Checkbox, HStack } from '@navikt/ds-react';
 import styles from './BarnMedOpplysninger.module.css';
 import { useSøknadContext } from './SøknadContext';
 import Slett from '../../../../../ikoner/Slett';
-import type { IBarnMedOpplysninger } from '../../../../../typer/søknad';
-import { formaterIdent, hentAlderSomString } from '../../../../../utils/formatter';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 
 interface IProps {
     barn: IBarnMedOpplysninger;
@@ -15,8 +15,9 @@ interface IProps {
 
 const BarnMedOpplysninger = ({ barn }: IProps) => {
     const { skjema, barnMedLøpendeUtbetaling } = useSøknadContext();
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+
+    const erLesevisning = useErLesevisning();
+
     const barnetHarLøpendeUtbetaling = barnMedLøpendeUtbetaling.has(barn.ident);
 
     const navnOgIdentTekst = `${barn.navn ?? 'Navn ukjent'} (${hentAlderSomString(

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/Barna.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/Barna.tsx
@@ -1,3 +1,9 @@
+import { useBruker } from '@hooks/useBruker';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IForelderBarnRelasjonMaskert } from '@typer/person';
+import { adressebeskyttelsestyper, ForelderBarnRelasjonRolle } from '@typer/person';
+import type { IBarnMedOpplysninger } from '@typer/søknad';
+import { isoStringTilDate } from '@utils/dato';
 import { differenceInMilliseconds } from 'date-fns';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
@@ -6,18 +12,12 @@ import { CheckboxGroup, Heading, HStack, InfoCard, Label, VStack } from '@navikt
 import BarnMedOpplysninger from './BarnMedOpplysninger';
 import { useSøknadContext } from './SøknadContext';
 import RødError from '../../../../../ikoner/RødError';
-import type { IForelderBarnRelasjonMaskert } from '../../../../../typer/person';
-import { adressebeskyttelsestyper, ForelderBarnRelasjonRolle } from '../../../../../typer/person';
-import type { IBarnMedOpplysninger } from '../../../../../typer/søknad';
-import { isoStringTilDate } from '../../../../../utils/dato';
-import { useBrukerContext } from '../../../BrukerContext';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 
 const Barna = () => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const lesevisning = vurderErLesevisning();
-    const { bruker } = useBrukerContext();
     const { skjema } = useSøknadContext();
+
+    const bruker = useBruker();
+    const lesevisning = useErLesevisning();
 
     const sorterteBarnMedOpplysninger = skjema.felter.barnaMedOpplysninger.verdi.sort(
         (a: IBarnMedOpplysninger, b: IBarnMedOpplysninger) => {

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/LeggTilBarnKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/LeggTilBarnKnapp.tsx
@@ -1,14 +1,13 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useLeggTilBarnModalContext } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
+
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 
-import { useLeggTilBarnModalContext } from '../../../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
-import { useBehandlingContext } from '../../context/BehandlingContext';
-
 export function LeggTilBarnKnapp() {
-    const { vurderErLesevisning } = useBehandlingContext();
     const { åpneModal } = useLeggTilBarnModalContext();
 
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     if (erLesevisning) {
         return null;

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/RegistrerSøknad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/RegistrerSøknad.tsx
@@ -1,3 +1,10 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { LeggTilBarnModal } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
+import { LeggTilBarnModalContextProvider } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
+import { BehandlingSteg } from '@typer/behandling';
+import type { IBarnMedOpplysninger } from '@typer/søknad';
+
 import { ErrorSummary, LocalAlert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -5,17 +12,12 @@ import Annet from './Annet';
 import Barna from './Barna';
 import { LeggTilBarnKnapp } from './LeggTilBarnKnapp';
 import { useSøknadContext } from './SøknadContext';
-import { LeggTilBarnModal } from '../../../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
-import { LeggTilBarnModalContextProvider } from '../../../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
 import MålformVelger from '../../../../../komponenter/MålformVelger';
 import Skjemasteg from '../../../../../komponenter/Skjemasteg/Skjemasteg';
-import { BehandlingSteg } from '../../../../../typer/behandling';
-import type { IBarnMedOpplysninger } from '../../../../../typer/søknad';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 
 const RegistrerSøknad = () => {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     const { hentFeilTilOppsummering, nesteAction, skjema, søknadErLastetFraBackend } = useSøknadContext();
 

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/SøknadContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/SøknadContext.tsx
@@ -1,5 +1,12 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
 
+import { useBruker } from '@hooks/useBruker';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import type { IBehandling } from '@typer/behandling';
+import { ForelderBarnRelasjonRolle, type IForelderBarnRelasjon } from '@typer/person';
+import type { IBarnMedOpplysninger, IBarnMedOpplysningerBackend, IRestRegistrerSøknad, Målform } from '@typer/søknad';
+import { hentBarnMedLøpendeUtbetaling } from '@utils/fagsak';
 import { useNavigate } from 'react-router';
 
 import type { Avhengigheter, FeiloppsummeringFeil, ISkjema } from '@navikt/familie-skjema';
@@ -7,17 +14,6 @@ import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useFagsak } from '../../../../../hooks/useFagsak';
-import type { IBehandling } from '../../../../../typer/behandling';
-import { ForelderBarnRelasjonRolle, type IForelderBarnRelasjon } from '../../../../../typer/person';
-import type {
-    IBarnMedOpplysninger,
-    IBarnMedOpplysningerBackend,
-    IRestRegistrerSøknad,
-    Målform,
-} from '../../../../../typer/søknad';
-import { hentBarnMedLøpendeUtbetaling } from '../../../../../utils/fagsak';
-import { useBrukerContext } from '../../../BrukerContext';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
 interface Props extends PropsWithChildren {
@@ -41,10 +37,11 @@ interface SøknadContextValue {
 const SøknadContext = createContext<SøknadContextValue | undefined>(undefined);
 
 export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
-    const { vurderErLesevisning, settÅpenBehandling } = useBehandlingContext();
-    const { bruker } = useBrukerContext();
+    const { settÅpenBehandling } = useBehandlingContext();
 
     const fagsak = useFagsak();
+    const bruker = useBruker();
+    const erLesevisning = useErLesevisning();
     const navigate = useNavigate();
 
     const barnMedLøpendeUtbetaling = hentBarnMedLøpendeUtbetaling(fagsak);
@@ -121,7 +118,7 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
     }, [åpenBehandling]);
 
     const nesteAction = (bekreftEndringerViaFrontend: boolean) => {
-        if (vurderErLesevisning()) {
+        if (erLesevisning) {
             navigate(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/vilkaarsvurdering`);
         } else {
             onSubmit<IRestRegistrerSøknad>(

--- a/src/frontend/sider/Fagsak/Behandling/sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Simulering/Simulering.tsx
@@ -1,3 +1,9 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsakId } from '@hooks/useFagsakId';
+import type { IBehandling } from '@typer/behandling';
+import { BehandlingResultat, BehandlingSteg } from '@typer/behandling';
+import type { ITilbakekreving } from '@typer/simulering';
+import { hentSøkersMålform } from '@utils/behandling';
 import { useNavigate } from 'react-router';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
@@ -9,12 +15,7 @@ import { useSimuleringContext } from './SimuleringContext';
 import SimuleringPanel from './SimuleringPanel';
 import SimuleringTabell from './SimuleringTabell';
 import TilbakekrevingSkjema from './TilbakekrevingSkjema';
-import { useFagsakId } from '../../../../../hooks/useFagsakId';
 import Skjemasteg from '../../../../../komponenter/Skjemasteg/Skjemasteg';
-import type { IBehandling } from '../../../../../typer/behandling';
-import { BehandlingResultat, BehandlingSteg } from '../../../../../typer/behandling';
-import type { ITilbakekreving } from '../../../../../typer/simulering';
-import { hentSøkersMålform } from '../../../../../utils/behandling';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
 interface ISimuleringProps {
@@ -31,13 +32,14 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
         erFeilutbetaling,
     } = useSimuleringContext();
 
-    const { vurderErLesevisning, settÅpenBehandling } = useBehandlingContext();
+    const { settÅpenBehandling } = useBehandlingContext();
 
     const fagsakId = useFagsakId();
+    const erLesevisning = useErLesevisning();
     const navigate = useNavigate();
 
     const nesteOnClick = () => {
-        if (vurderErLesevisning() || åpenBehandling?.resultat == BehandlingResultat.AVSLÅTT) {
+        if (erLesevisning || åpenBehandling?.resultat == BehandlingResultat.AVSLÅTT) {
             navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/vedtak`);
         } else {
             onSubmit<ITilbakekreving | undefined>(

--- a/src/frontend/sider/Fagsak/Behandling/sider/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Simulering/TilbakekrevingSkjema.tsx
@@ -1,3 +1,17 @@
+import { ModalType } from '@context/ModalContext';
+import { useBehandling } from '@hooks/useBehandling';
+import { useBruker } from '@hooks/useBruker';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useModal } from '@hooks/useModal';
+import {
+    mutationKey,
+    useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf,
+} from '@hooks/useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf';
+import { BrevmottakereAlert } from '@komponenter/BrevmottakereAlert';
+import { Tilbakekrevingsvalg, visTilbakekrevingsvalg } from '@typer/simulering';
+import type { Målform } from '@typer/søknad';
+import { målform } from '@typer/søknad';
+
 import { ExternalLinkIcon, FileTextIcon } from '@navikt/aksel-icons';
 import {
     BodyLong,
@@ -24,18 +38,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { useSimuleringContext } from './SimuleringContext';
 import styles from './TilbakekrevingSkjema.module.css';
-import { ModalType } from '../../../../../context/ModalContext';
-import { useModal } from '../../../../../hooks/useModal';
-import {
-    mutationKey,
-    useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf,
-} from '../../../../../hooks/useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf';
-import { BrevmottakereAlert } from '../../../../../komponenter/BrevmottakereAlert';
-import { Tilbakekrevingsvalg, visTilbakekrevingsvalg } from '../../../../../typer/simulering';
-import type { Målform } from '../../../../../typer/søknad';
-import { målform } from '../../../../../typer/søknad';
-import { useBrukerContext } from '../../../BrukerContext';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 
 const TilbakekrevingSkjema = ({
     søkerMålform,
@@ -44,7 +46,6 @@ const TilbakekrevingSkjema = ({
     søkerMålform: Målform;
     harÅpenTilbakekrevingRessurs: Ressurs<boolean>;
 }) => {
-    const { vurderErLesevisning, behandling } = useBehandlingContext();
     const { tilbakekrevingSkjema, hentFeilTilOppsummering, maksLengdeTekst } = useSimuleringContext();
     const { fritekstVarsel, begrunnelse, tilbakekrevingsvalg } = tilbakekrevingSkjema.felter;
 
@@ -55,9 +56,9 @@ const TilbakekrevingSkjema = ({
             onMutate: () => åpneForhåndsvisOpprettingAvPdfModal({ mutationKey }),
         });
 
-    const { bruker } = useBrukerContext();
-
-    const erLesevisning = vurderErLesevisning();
+    const bruker = useBruker();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     const radioOnChange = (tilbakekrevingsalternativ: Tilbakekrevingsvalg) => {
         tilbakekrevingSkjema.felter.tilbakekrevingsvalg.validerOgSettFelt(tilbakekrevingsalternativ);
@@ -83,7 +84,7 @@ const TilbakekrevingSkjema = ({
     if (
         harÅpenTilbakekrevingRessurs.status === RessursStatus.SUKSESS &&
         harÅpenTilbakekrevingRessurs.data &&
-        !vurderErLesevisning()
+        !erLesevisning
     ) {
         return (
             <VStack marginBlock={'space-64 space-0'} gap={'space-24'}>
@@ -100,7 +101,7 @@ const TilbakekrevingSkjema = ({
         );
     }
 
-    if (vurderErLesevisning() && !tilbakekrevingSkjema.felter.tilbakekrevingsvalg.verdi) {
+    if (erLesevisning && !tilbakekrevingSkjema.felter.tilbakekrevingsvalg.verdi) {
         return (
             <VStack marginBlock={'space-64 space-0'} gap={'space-24'}>
                 <Label>Tilbakekrevingsvalg</Label>
@@ -153,7 +154,7 @@ const TilbakekrevingSkjema = ({
                     {...begrunnelse.hentNavInputProps(
                         tilbakekrevingSkjema.visFeilmeldinger || begrunnelse.verdi.length > maksLengdeTekst
                     )}
-                    readOnly={vurderErLesevisning()}
+                    readOnly={erLesevisning}
                     maxLength={maksLengdeTekst}
                     description="Hva er årsaken til feilutbetaling? Hvordan og når ble feilutbetalingen oppdaget? Begrunn hvordan feilutbetalingen skal behandles videre."
                 />
@@ -269,7 +270,7 @@ const TilbakekrevingSkjema = ({
                                                 tilbakekrevingSkjema.visFeilmeldinger ||
                                                     fritekstVarsel.verdi.length > maksLengdeTekst
                                             )}
-                                            readOnly={vurderErLesevisning()}
+                                            readOnly={erLesevisning}
                                             maxLength={maksLengdeTekst}
                                         />
                                         <HStack justify={'end'} marginBlock={'space-0 space-16'}>
@@ -309,11 +310,11 @@ const TilbakekrevingSkjema = ({
                         </Radio>
                     </RadioGroup>
                 )}
-                {vurderErLesevisning() && fritekstVarsel.erSynlig && (
+                {erLesevisning && fritekstVarsel.erSynlig && (
                     <Textarea
                         label="Fritekst i varselet"
                         {...fritekstVarsel.hentNavInputProps(tilbakekrevingSkjema.visFeilmeldinger)}
-                        readOnly={vurderErLesevisning()}
+                        readOnly={erLesevisning}
                     />
                 )}
 

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabell.tsx
@@ -1,3 +1,10 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import type { IBehandling } from '@typer/behandling';
+import type { IMinimalFagsak } from '@typer/fagsak';
+import { isoDatoPeriodeTilFormatertString } from '@utils/dato';
+
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, CopyButton, Heading, Stack, Table } from '@navikt/ds-react';
 
@@ -6,11 +13,6 @@ import { useFeilutbetaltValutaTabellContext } from './FeilutbetaltValutaTabellCo
 import { FeilutbetaltValutaForm } from './form/FeilutbetaltValutaForm';
 import { Type } from './form/useFeilutbetaltValutaForm';
 import { SlettFeilutbetaltValutaError } from './SlettFeilutbetaltValutaError';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import type { IMinimalFagsak } from '../../../../../../typer/fagsak';
-import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
-import { useFagsakContext } from '../../../../FagsakContext';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 function lagTekstTilNøs(fagsak: IMinimalFagsak, behandling: IBehandling) {
     const url = `https://kontantstotte.intern.nav.no/fagsak/${fagsak.id}/${behandling.behandlingId}/vedtak`;
@@ -37,16 +39,15 @@ function lagTekstTilNøs(fagsak: IMinimalFagsak, behandling: IBehandling) {
 }
 
 export function FeilutbetaltValutaTabell() {
-    const { fagsak } = useFagsakContext();
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
-
     const {
         erLeggTilFeilutbetaltValutaFormÅpen,
         visLeggTilFeilutbetaltValutaForm,
         skjulLeggTilFeilutbetaltValutaForm,
     } = useFeilutbetaltValutaTabellContext();
 
-    const erLesevisning = vurderErLesevisning();
+    const fagsak = useFagsak();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     return (
         <Stack direction={'column'} gap={'space-20'} marginBlock={'space-48 space-48'}>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal.tsx
@@ -1,3 +1,8 @@
+import { ModalType } from '@context/ModalContext';
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useModal } from '@hooks/useModal';
+
 import { ArrowUndoIcon } from '@navikt/aksel-icons';
 import {
     Button,
@@ -14,12 +19,11 @@ import {
 
 import { useKorrigerEtterbetalingForm, årsaker } from './useKorrigerEtterbetalingForm';
 import { erEtterbetalingsbeløpGyldig, erÅrsakForKorrigeringGyldig } from './validering';
-import { ModalType } from '../../../../../../context/ModalContext';
-import { useModal } from '../../../../../../hooks/useModal';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 export function KorrigerEtterbetalingModal() {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+
     const {
         form,
         korrigerEtterbetaling,
@@ -31,7 +35,6 @@ export function KorrigerEtterbetalingModal() {
     const { lukkModal, erModalÅpen, tittel, bredde } = useModal(ModalType.KORRIGER_ETTERBETALING);
 
     const korrigertEtterbetaling = behandling.korrigertEtterbetaling;
-    const erLesevisning = vurderErLesevisning();
 
     function handleLukkModal() {
         form.reset();

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiket.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BosattIRiket/BosattIRiket.tsx
@@ -1,6 +1,7 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { Regelverk } from '@typer/vilkår';
+
 import { bestemMuligeUtdypendeVilkårsvurderingerIBosattIRiketVilkår, useBosattIRiket } from './BosattIRiketContext';
-import type { Regelverk } from '../../../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../../../context/BehandlingContext';
 import { useVilkårEkspanderbarRad } from '../../useVilkårEkspanderbarRad';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
@@ -14,8 +15,7 @@ export const BosattIRiket = ({
     person,
     settFokusPåLeggTilPeriodeKnapp,
 }: BosattIRiketProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const {
         vilkårSkjemaContext,

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/Medlemskap/Medlemskap.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/Medlemskap/Medlemskap.tsx
@@ -1,8 +1,9 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { Regelverk, Resultat } from '@typer/vilkår';
+
 import { Box, InlineMessage, Label, Radio, RadioGroup } from '@navikt/ds-react';
 
 import { useMedlemskap } from './MedlemskapContext';
-import { Regelverk, Resultat } from '../../../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../../../context/BehandlingContext';
 import { useVilkårEkspanderbarRad } from '../../useVilkårEkspanderbarRad';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
@@ -16,8 +17,7 @@ export const Medlemskap = ({
     person,
     settFokusPåLeggTilPeriodeKnapp,
 }: MedlemskapProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const { vilkårSkjemaContext, finnesEndringerSomIkkeErLagret, skalViseDatoVarsel } = useMedlemskap(
         lagretVilkårResultat,


### PR DESCRIPTION
### 📮 Favro
NAV-29007

### 💰 Hva skal gjøres, og hvorfor?
- Tar i bruk `useErLesevisning` hooken. 
- Bytter til `useFagsak`, `useBehandling`, og `useBruker` hvor det gir mening. 
- Forenkler imports

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 