### PR TITLE
NAV-29007: Tar i bruk useErLesevisning for enkelte komponenter

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaRad.tsx
@@ -1,29 +1,28 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IRestFeilutbetaltValuta } from '@typer/eøs-feilutbetalt-valuta';
+import { isoDatoPeriodeTilFormatertString } from '@utils/dato';
+
 import { Table } from '@navikt/ds-react';
 
 import { FeilutbetaltValutaForm } from './form/FeilutbetaltValutaForm';
 import { Type } from './form/useFeilutbetaltValutaForm';
 import { SlettFeilutbetaltValuta } from './SlettFeilutbetaltValuta';
 import { useSlettFeilutbetaltValutaIsPending } from './useSlettFeilutbetaltValutaIsPending';
-import type { IRestFeilutbetaltValuta } from '../../../../../../typer/eøs-feilutbetalt-valuta';
-import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface Props {
     feilutbetaltValuta: IRestFeilutbetaltValuta;
 }
 
 export function FeilutbetaltValutaRad({ feilutbetaltValuta }: Props) {
-    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = useErLesevisning();
 
     const slettFeilutbetaltValutaIsPending = useSlettFeilutbetaltValutaIsPending({
         feilutbetaltValutaId: feilutbetaltValuta.id,
     });
 
     const [erRadEkspandert, settErRadEkspandert] = useState<boolean>(false);
-
-    const readOnly = vurderErLesevisning() || slettFeilutbetaltValutaIsPending;
 
     return (
         <Table.ExpandableRow
@@ -35,7 +34,7 @@ export function FeilutbetaltValutaRad({ feilutbetaltValuta }: Props) {
                     type={Type.OPPDATER}
                     feilutbetaltValuta={feilutbetaltValuta}
                     skjulForm={() => settErRadEkspandert(false)}
-                    readOnly={readOnly}
+                    readOnly={erLesevisning || slettFeilutbetaltValutaIsPending}
                 />
             }
         >

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/FeilutbetaltValuta/SlettFeilutbetaltValuta.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/FeilutbetaltValuta/SlettFeilutbetaltValuta.tsx
@@ -1,9 +1,11 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useSlettFeilutbetaltValuta } from '@hooks/useSlettFeilutbetaltValuta';
+
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Tooltip } from '@navikt/ds-react';
 import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { useFeilutbetaltValutaTabellContext } from './FeilutbetaltValutaTabellContext';
-import { useSlettFeilutbetaltValuta } from '../../../../../../hooks/useSlettFeilutbetaltValuta';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface Props {
@@ -11,8 +13,10 @@ interface Props {
 }
 
 export function SlettFeilutbetaltValuta({ feilutbetaltValutaId }: Props) {
-    const { behandling, settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
     const { erLeggTilFeilutbetaltValutaFormÅpen, skjulFeilutbetaltValutaTabell } = useFeilutbetaltValutaTabellContext();
+
+    const erLesevisning = useErLesevisning();
 
     const { mutate, isPending } = useSlettFeilutbetaltValuta({
         feilutbetaltValutaId: feilutbetaltValutaId,
@@ -23,8 +27,6 @@ export function SlettFeilutbetaltValuta({ feilutbetaltValutaId }: Props) {
             }
         },
     });
-
-    const erLesevisning = vurderErLesevisning();
 
     if (erLesevisning) {
         return null;

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -1,3 +1,4 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsakId } from '@hooks/useFagsakId';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { BrevmottakereAlert } from '@komponenter/BrevmottakereAlert';
@@ -27,7 +28,6 @@ import { AlleBegrunnelserProvider } from './Vedtaksperioder/AlleBegrunnelserCont
 import { Vedtaksperioder } from './Vedtaksperioder/Vedtaksperioder';
 import useDokument from '../../../../../hooks/useDokument';
 import PdfVisningModal from '../../../../../komponenter/PdfVisningModal/PdfVisningModal';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 
 interface IOppsummeringVedtakInnholdProps {
     åpenBehandling: IBehandling;
@@ -44,13 +44,10 @@ const OppsummeringVedtakInnhold = ({
     settVisModal,
     bruker,
 }: IOppsummeringVedtakInnholdProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-
-    const fagsakId = useFagsakId();
-    const navigate = useNavigate();
     const saksbehandler = useSaksbehandler();
-
-    const erLesevisning = vurderErLesevisning();
+    const fagsakId = useFagsakId();
+    const erLesevisning = useErLesevisning();
+    const navigate = useNavigate();
 
     const { hentForhåndsvisning, nullstillDokument, visDokumentModal, hentetDokument, settVisDokumentModal } =
         useDokument();

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/RefusjonEøsRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/RefusjonEøsRad.tsx
@@ -1,27 +1,26 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IRestRefusjonEøs } from '@typer/refusjon-eøs';
+import { isoDatoPeriodeTilFormatertString } from '@utils/dato';
+
 import { Table } from '@navikt/ds-react';
 
 import { RefusjonEøsForm } from './form/RefusjonEøsForm';
 import { Type } from './form/useRefusjonEøsForm';
 import { SlettRefusjonEøs } from './SlettRefusjonEøs';
 import { useSlettRefusjonEøsIsPending } from './useSlettRefusjonEøsIsPending';
-import type { IRestRefusjonEøs } from '../../../../../../typer/refusjon-eøs';
-import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface Props {
     refusjonEøs: IRestRefusjonEøs;
 }
 
 export function RefusjonEøsRad({ refusjonEøs }: Props) {
-    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = useErLesevisning();
 
     const slettRefusjonEøsIsPending = useSlettRefusjonEøsIsPending({ refusjonEøsId: refusjonEøs.id });
 
     const [erRadEkspandert, settErRadEkspandert] = useState<boolean>(false);
-
-    const readOnly = vurderErLesevisning() || slettRefusjonEøsIsPending;
 
     return (
         <Table.ExpandableRow
@@ -33,7 +32,7 @@ export function RefusjonEøsRad({ refusjonEøs }: Props) {
                     type={Type.OPPDATER}
                     refusjonEøs={refusjonEøs}
                     skjulForm={() => settErRadEkspandert(false)}
-                    readOnly={readOnly}
+                    readOnly={erLesevisning || slettRefusjonEøsIsPending}
                 />
             }
         >

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/RefusjonEøsTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/RefusjonEøsTabell.tsx
@@ -1,3 +1,10 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import type { IBehandling } from '@typer/behandling';
+import type { IMinimalFagsak } from '@typer/fagsak';
+import { isoDatoPeriodeTilFormatertString } from '@utils/dato';
+
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, CopyButton, Heading, Stack, Table } from '@navikt/ds-react';
 
@@ -5,11 +12,6 @@ import { RefusjonEøsForm } from './form/RefusjonEøsForm';
 import { Type } from './form/useRefusjonEøsForm';
 import { RefusjonEøsRad } from './RefusjonEøsRad';
 import { useRefusjonEøsTabellContext } from './RefusjonEøsTabellContext';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import type { IMinimalFagsak } from '../../../../../../typer/fagsak';
-import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
-import { useFagsakContext } from '../../../../FagsakContext';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { summerBeløpForPerioder } from '../utils';
 import { SlettRefusjonEøsError } from './SlettRefusjonEøsError';
 
@@ -37,13 +39,12 @@ function lagKopieringstekstTilNØS(fagsak: IMinimalFagsak, behandling: IBehandli
 }
 
 export function RefusjonEøsTabell() {
-    const { fagsak } = useFagsakContext();
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const fagsak = useFagsak();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     const { erLeggTilRefusjonEøsFormÅpen, visLeggTilRefusjonEøsForm, skjulLeggTilRefusjonEøsForm } =
         useRefusjonEøsTabellContext();
-
-    const erLesevisning = vurderErLesevisning();
 
     return (
         <Stack direction={'column'} gap={'space-20'} marginBlock={'space-48 space-48'}>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/SlettRefusjonEøs.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/SlettRefusjonEøs.tsx
@@ -1,9 +1,11 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useSlettRefusjonEøs } from '@hooks/useSlettRefusjonEøs';
+
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Tooltip } from '@navikt/ds-react';
 import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { useRefusjonEøsTabellContext } from './RefusjonEøsTabellContext';
-import { useSlettRefusjonEøs } from '../../../../../../hooks/useSlettRefusjonEøs';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface Props {
@@ -11,8 +13,10 @@ interface Props {
 }
 
 export function SlettRefusjonEøs({ refusjonEøsId }: Props) {
-    const { behandling, settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
     const { erLeggTilRefusjonEøsFormÅpen, skjulRefusjonEøsTabell } = useRefusjonEøsTabellContext();
+
+    const erLesevisning = useErLesevisning();
 
     const { mutate, isPending } = useSlettRefusjonEøs({
         refusjonEøsId: refusjonEøsId,
@@ -23,8 +27,6 @@ export function SlettRefusjonEøs({ refusjonEøsId }: Props) {
             }
         },
     });
-
-    const erLesevisning = vurderErLesevisning();
 
     if (erLesevisning) {
         return null;

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/SammensattKontrollsak/SammensattKontrollsak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/SammensattKontrollsak/SammensattKontrollsak.tsx
@@ -1,20 +1,20 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+
 import { Button, ErrorMessage, LocalAlert, Textarea, VStack } from '@navikt/ds-react';
 
 import { useSammensattKontrollsakContext } from './SammensattKontrollsakContext';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 export function SammensattKontrollsak() {
-    const { vurderErLesevisning } = useBehandlingContext();
     const { sammensattKontrollsak, opprettEllerOppdaterSammensattKontrollsak, feilmelding } =
         useSammensattKontrollsakContext();
+
+    const erLesevisning = useErLesevisning();
 
     const [fritekst, settFritekst] = useState<string>(sammensattKontrollsak?.fritekst ?? '');
 
     const fritekstErEndret = fritekst !== (sammensattKontrollsak?.fritekst ?? '');
-
-    const erLesevisning = vurderErLesevisning();
 
     return (
         <VStack gap="space-20" marginBlock={'space-0 space-24'} align={'start'}>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksmeny/Vedtaksmeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksmeny/Vedtaksmeny.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { BehandlingKategori } from '@typer/behandlingstema';
+import { vedtakHarFortsattUtbetaling } from '@utils/vedtakUtils';
+
 import { ArrowUndoIcon, CalculatorIcon, ChevronDownIcon, StarsEuIcon, TasklistStartIcon } from '@navikt/aksel-icons';
 import { ActionMenu, Button, Stack } from '@navikt/ds-react';
 
 import Styles from './Vedtaksmeny.module.css';
-import { BehandlingKategori } from '../../../../../../typer/behandlingstema';
-import { vedtakHarFortsattUtbetaling } from '../../../../../../utils/vedtakUtils';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import EndreEndringstidspunkt from '../endringstidspunkt/EndreEndringstidspunkt';
 import { OppdaterEndringstidspunktModal } from '../endringstidspunkt/OppdaterEndringstidspunktModal';
 import { useFeilutbetaltValutaTabellContext } from '../FeilutbetaltValuta/FeilutbetaltValutaTabellContext';
@@ -21,11 +23,8 @@ interface Props {
 }
 
 export function Vedtaksmeny({ erBehandlingMedVedtaksbrevutsending }: Props) {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
     const { erFeilutbetaltValutaTabellSynlig, visFeilutbetaltValutaTabell } = useFeilutbetaltValutaTabellContext();
     const { erRefusjonEøsTabellSynlig, visRefusjonEøsTabell } = useRefusjonEøsTabellContext();
-    const [visKorrigerVedtakModal, settVisKorrigerVedtakModal] = useState<boolean>(false);
-    const [visEndreEndringstidspunktModal, settVisEndreEndringstidspunktModal] = useState<boolean>(false);
     const {
         skalViseSammensattKontrollsakMenyvalg,
         erSammensattKontrollsak,
@@ -33,7 +32,11 @@ export function Vedtaksmeny({ erBehandlingMedVedtaksbrevutsending }: Props) {
         slettSammensattKontrollsak,
     } = useSammensattKontrollsakContext();
 
-    const erLesevisning = vurderErLesevisning();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+
+    const [visKorrigerVedtakModal, settVisKorrigerVedtakModal] = useState<boolean>(false);
+    const [visEndreEndringstidspunktModal, settVisEndreEndringstidspunktModal] = useState<boolean>(false);
 
     return (
         <Stack width={'100%'} justify={'end'} align={'center'}>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/endringstidspunkt/OppdaterEndringstidspunktModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/endringstidspunkt/OppdaterEndringstidspunktModal.tsx
@@ -1,13 +1,14 @@
 import { useId } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
 import { FormProvider } from 'react-hook-form';
 
 import { BodyShort, Button, Fieldset, InlineMessage, Label, Modal, VStack } from '@navikt/ds-react';
 
 import { EndringstidspunktFelt } from './EndringstidspunktFelt';
 import { useEndringstidspunktForm } from './useEndringstidspunktForm';
-import { Datoformat, isoStringTilFormatertString } from '../../../../../../utils/dato';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 function formaterDato(endringstidspunkt: string) {
     return isoStringTilFormatertString({ isoString: endringstidspunkt, tilFormat: Datoformat.DATO });
@@ -18,7 +19,8 @@ interface Props {
 }
 
 export function OppdaterEndringstidspunktModal({ lukkModal }: Props) {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
     const hentetEndringstidspunktId = useId();
 
     const { form, onSubmit } = useEndringstidspunktForm({ lukkModal });
@@ -28,7 +30,6 @@ export function OppdaterEndringstidspunktModal({ lukkModal }: Props) {
         formState: { errors, isSubmitting },
     } = form;
 
-    const erLesevisning = vurderErLesevisning();
     const endringstidspunkt = behandling.endringstidspunkt;
 
     return (

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/MedlemskapAnnenForelder/MedlemskapAnnenForelder.tsx
@@ -1,8 +1,9 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { Regelverk, Resultat } from '@typer/vilkår';
+
 import { Box, InlineMessage, Label, Radio, RadioGroup } from '@navikt/ds-react';
 
 import { useMedlemskapAnnenForelder } from './MedlemskapAnnenForelderContext';
-import { Regelverk, Resultat } from '../../../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../../../context/BehandlingContext';
 import { useVilkårEkspanderbarRad } from '../../useVilkårEkspanderbarRad';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
@@ -16,8 +17,7 @@ export const MedlemskapAnnenForelder = ({
     person,
     settFokusPåLeggTilPeriodeKnapp,
 }: MedlemskapAnnenForelderProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const { vilkårSkjemaContext, finnesEndringerSomIkkeErLagret } = useMedlemskapAnnenForelder(
         lagretVilkårResultat,


### PR DESCRIPTION
### 📮 Favro
NAV-29007

### 💰 Hva skal gjøres, og hvorfor?
- Tar i bruk `useErLesevisning` hooken. 
- Bytter til `useFagsak`, `useBehandling`, og `useBruker` hvor det gir mening. 
- Forenkler imports

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 