### PR TITLE
NAV-29007: Tar i bruk useErLesevisning del 4

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -2,16 +2,13 @@ import { createContext, type PropsWithChildren, useContext, useEffect, useState 
 
 import { useNavigerAutomatiskTilSideForBehandlingssteg } from '@hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
-import { BehandlerRolle, BehandlingStatus, BehandlingÅrsak, type IBehandling } from '@typer/behandling';
-import { harTilgangTilEnhet } from '@typer/enhet';
-import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '@utils/behandling';
+import { BehandlerRolle, BehandlingStatus, type IBehandling } from '@typer/behandling';
 import { hentSideHref } from '@utils/miljø';
 import { useLocation } from 'react-router';
 
 import { type Ressurs } from '@navikt/familie-typer';
 
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
-import { saksbehandlerHarKunLesevisning } from './utils';
 import { hentTrinnForBehandling, type ITrinn, KontrollertStatus, type SideId } from '../sider/sider';
 
 interface Props extends PropsWithChildren {
@@ -19,10 +16,6 @@ interface Props extends PropsWithChildren {
 }
 
 interface BehandlingContextValue {
-    /**
-     * @Deprecated - Erstattes av {@link useErLesevisning}.
-     */
-    vurderErLesevisning: (sjekkTilgangTilEnhet?: boolean, skalIgnorereOmEnhetErMidlertidig?: boolean) => boolean;
     leggTilBesøktSide: (besøktSide: SideId) => void;
     settIkkeKontrollerteSiderTilManglerKontroll: () => void;
     trinnPåBehandling: { [sideId: string]: ITrinn };
@@ -88,50 +81,14 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
         );
     };
 
-    /**
-     * @Deprecated - Erstattes av {@link useErLesevisning}.
-     */
-    const vurderErLesevisning = (sjekkTilgangTilEnhet = true, skalIgnorereOmEnhetErMidlertidig = false): boolean => {
-        if (behandling.behandlingPåVent || behandling.status === BehandlingStatus.SATT_PÅ_MASKINELL_VENT) {
-            return true;
-        }
-        if (erBehandleneEnhetMidlertidig && !skalIgnorereOmEnhetErMidlertidig) {
-            return true;
-        }
-
-        const behandlingsårsak = behandling.årsak;
-        const behandlingsårsakErÅpenForAlleMedTilgangTilÅOppretteÅrsak =
-            behandlingsårsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV;
-
-        const saksbehandlerHarTilgangTilEnhet =
-            saksbehandler.harSuperbrukertilgang ||
-            behandlingsårsakErÅpenForAlleMedTilgangTilÅOppretteÅrsak ||
-            harTilgangTilEnhet(behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId ?? '', saksbehandler.groups);
-
-        const steg = behandling.steg;
-        const status = behandling.status;
-
-        return saksbehandlerHarKunLesevisning(
-            saksbehandler.harSkrivetilgang,
-            saksbehandlerHarTilgangTilEnhet,
-            steg,
-            status,
-            sjekkTilgangTilEnhet
-        );
-    };
-
     const kanBeslutteVedtak =
         behandling.status === BehandlingStatus.FATTER_VEDTAK &&
         BehandlerRolle.BESLUTTER === saksbehandler.rolle &&
         saksbehandler.email !== behandling.endretAv;
 
-    const erBehandleneEnhetMidlertidig =
-        behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId === MIDLERTIDIG_BEHANDLENDE_ENHET_ID;
-
     return (
         <BehandlingContext.Provider
             value={{
-                vurderErLesevisning,
                 leggTilBesøktSide,
                 settIkkeKontrollerteSiderTilManglerKontroll,
                 trinnPåBehandling,

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
@@ -1,11 +1,12 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { OptionType } from '@typer/common';
+import type { Begrunnelse } from '@typer/vedtak';
+import type { Regelverk, VilkårType } from '@typer/vilkår';
+
 import { UNSAFE_Combobox } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import useAvslagBegrunnelseMultiselect from './useAvslagBegrunnelseMultiselect';
-import type { OptionType } from '../../../../../../typer/common';
-import type { Begrunnelse } from '../../../../../../typer/vedtak';
-import type { Regelverk, VilkårType } from '../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface IProps {
     vilkårType: VilkårType;
@@ -14,7 +15,7 @@ interface IProps {
 }
 
 const AvslagBegrunnelseMultiselect = ({ vilkårType, begrunnelser, regelverk }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = useErLesevisning();
 
     const { grupperteAvslagsbegrunnelser } = useAvslagBegrunnelseMultiselect(vilkårType, regelverk);
 
@@ -42,7 +43,7 @@ const AvslagBegrunnelseMultiselect = ({ vilkårType, begrunnelser, regelverk }: 
             selectedOptions={valgteBegrunnlser}
             label={'Velg standardtekst i brev'}
             placeholder={'Velg begrunnelse(r)'}
-            readOnly={vurderErLesevisning()}
+            readOnly={erLesevisning}
             isMultiSelect
             onToggleSelected={onChangeBegrunnelse}
             options={grupperteAvslagsbegrunnelser}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/AvslagSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/AvslagSkjema.tsx
@@ -1,3 +1,6 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { Begrunnelse } from '@typer/vedtak';
+import type { IVilkårResultat } from '@typer/vilkår';
 import classNames from 'classnames';
 import styled from 'styled-components';
 
@@ -5,9 +8,6 @@ import { BodyShort, Checkbox, Fieldset } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import AvslagBegrunnelseMultiselect from './AvslagBegrunnelseMultiselect';
-import type { Begrunnelse } from '../../../../../../typer/vedtak';
-import type { IVilkårResultat } from '../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { AlleBegrunnelserProvider } from '../../Vedtak/Vedtaksperioder/AlleBegrunnelserContext';
 
 interface IProps {
@@ -29,8 +29,7 @@ const StyledFieldset = styled(Fieldset)`
 `;
 
 const AvslagSkjema = ({ erEksplisittAvslagPåSøknad, lagretVilkår, avslagBegrunnelser, visFeilmeldinger }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const lesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     return (
         <StyledFieldset
@@ -38,7 +37,7 @@ const AvslagSkjema = ({ erEksplisittAvslagPåSøknad, lagretVilkår, avslagBegru
             hideLegend
             error={visFeilmeldinger ? avslagBegrunnelser.feilmelding : ''}
         >
-            {lesevisning ? (
+            {erLesevisning ? (
                 erEksplisittAvslagPåSøknad.verdi && (
                     <BodyShort
                         className={classNames('skjemaelement', 'lese-felt')}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IGrunnlagPerson } from '@typer/person';
+import type { IVilkårConfig, IVilkårResultat, VilkårType } from '@typer/vilkår';
+import { Resultat } from '@typer/vilkår';
 import styled from 'styled-components';
 
 import { PlusCircleIcon } from '@navikt/aksel-icons';
@@ -7,10 +11,6 @@ import { Button, Fieldset, Heading } from '@navikt/ds-react';
 import { Space20, Space32, Space64 } from '@navikt/ds-tokens/dist/tokens';
 
 import VilkårTabell from './VilkårTabell';
-import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import type { IVilkårConfig, IVilkårResultat, VilkårType } from '../../../../../../typer/vilkår';
-import { Resultat } from '../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { useVilkårsvurderingApi } from '../useVilkårsvurderingApi';
 
 interface IProps {
@@ -33,8 +33,8 @@ const UtførKnapp = styled(Button)`
 `;
 
 const GeneriskVilkår = ({ person, vilkårFraConfig, vilkårResultater, generiskVilkårKey }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
     const vilkårsvurderingApi = useVilkårsvurderingApi();
+    const erLesevisning = useErLesevisning();
 
     const [visFeilmeldingerForVilkår, settVisFeilmeldingerForVilkår] = useState(false);
 
@@ -45,7 +45,7 @@ const GeneriskVilkår = ({ person, vilkårFraConfig, vilkårResultater, generisk
     };
 
     const skalViseLeggTilKnapp = () => {
-        if (vurderErLesevisning()) {
+        if (erLesevisning) {
             return false;
         }
         const uvurdertPeriodePåVilkår = vilkårResultater.find(vilkår => vilkår.resultat === Resultat.IKKE_VURDERT);

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -1,15 +1,15 @@
 import type { PropsWithChildren } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { Resultat } from '@typer/vilkår';
+import type { IIsoDatoPeriode, IsoDatoString } from '@utils/dato';
+import { nyIsoDatoPeriode } from '@utils/dato';
 import styled from 'styled-components';
 
 import { Fieldset, HelpText, Label } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import DatovelgerForGammelSkjemaløsning from '../../../../../../komponenter/Datovelger/DatovelgerForGammelSkjemaløsning';
-import { Resultat } from '../../../../../../typer/vilkår';
-import type { IIsoDatoPeriode, IsoDatoString } from '../../../../../../utils/dato';
-import { nyIsoDatoPeriode } from '../../../../../../utils/dato';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface IProps extends PropsWithChildren {
     periode: Felt<IIsoDatoPeriode>;
@@ -47,8 +47,7 @@ const VelgPeriode = ({
     children,
     tomErPåkrevd,
 }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const lesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     return (
         <MarginFieldset
@@ -56,7 +55,7 @@ const VelgPeriode = ({
             legend={'Periode for vurderingen'}
             hideLegend
         >
-            {!lesevisning && (
+            {!erLesevisning && (
                 <StyledLegend>
                     <StyledLabel>Velg periode</StyledLabel>
                     <HelpText title="Hvordan fastsette periode">
@@ -78,12 +77,12 @@ const VelgPeriode = ({
                         periode.validerOgSettFelt(nyIsoDatoPeriode(dato, periode.verdi.tom));
                     }}
                     visFeilmeldinger={false}
-                    readOnly={lesevisning}
+                    readOnly={erLesevisning}
                 />
                 <DatovelgerForGammelSkjemaløsning
                     label={tomErPåkrevd ? 'T.o.m' : 'T.o.m (valgfri)'}
                     value={periode.verdi.tom}
-                    readOnly={lesevisning}
+                    readOnly={erLesevisning}
                     onDateChange={(dato?: IsoDatoString) => {
                         periode.validerOgSettFelt(nyIsoDatoPeriode(periode.verdi.fom, dato));
                     }}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/Barnehageplass/Barnehageplass.tsx
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { Resultat, UtdypendeVilkårsvurderingGenerell } from '@typer/vilkår';
 import styled from 'styled-components';
 
 import { BodyShort, Checkbox, Radio, RadioGroup, TextField } from '@navikt/ds-react';
 
 import { muligeUtdypendeVilkårsvurderinger, useBarnehageplass } from './BarnehageplassContext';
 import { antallTimerKvalifiserer } from './BarnehageplassUtils';
-import { Resultat, UtdypendeVilkårsvurderingGenerell } from '../../../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../../../context/BehandlingContext';
 import { useVilkårEkspanderbarRad } from '../../useVilkårEkspanderbarRad';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
@@ -25,8 +25,7 @@ export const Barnehageplass = ({
     person,
     settFokusPåLeggTilPeriodeKnapp,
 }: BarnehageplassProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const { vilkårSkjemaContext, finnesEndringerSomIkkeErLagret, harBarnehageplass, settHarBarnehageplass } =
         useBarnehageplass(lagretVilkårResultat, person);

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BarnetsAlder/BarnetsAlder.tsx
@@ -1,19 +1,19 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { Lovverk } from '@typer/lovverk';
+import { Resultat } from '@typer/vilkår';
+import {
+    datoForLovendringAugust24,
+    type IIsoDatoPeriode,
+    isoStringTilDate,
+    isoStringTilDateEllerUndefinedHvisUgyldigDato,
+} from '@utils/dato';
+import { utledLovverk } from '@utils/lovverk';
 import { isBefore } from 'date-fns';
 
 import { Label, Radio, RadioGroup } from '@navikt/ds-react';
 
 import { muligeUtdypendeVilkårsvurderinger, useBarnetsAlder } from './BarnetsAlderContext';
 import Datovelger from '../../../../../../../../komponenter/Datovelger/Datovelger';
-import { Lovverk } from '../../../../../../../../typer/lovverk';
-import { Resultat } from '../../../../../../../../typer/vilkår';
-import {
-    datoForLovendringAugust24,
-    type IIsoDatoPeriode,
-    isoStringTilDate,
-    isoStringTilDateEllerUndefinedHvisUgyldigDato,
-} from '../../../../../../../../utils/dato';
-import { utledLovverk } from '../../../../../../../../utils/lovverk';
-import { useBehandlingContext } from '../../../../../context/BehandlingContext';
 import { useVilkårEkspanderbarRad } from '../../useVilkårEkspanderbarRad';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
@@ -48,8 +48,7 @@ export const BarnetsAlder = ({
     person,
     settFokusPåLeggTilPeriodeKnapp,
 }: BarnetsAlderProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const { vilkårSkjemaContext, finnesEndringerSomIkkeErLagret } = useBarnetsAlder(lagretVilkårResultat, person);
 

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BorMedSøker/BorMedSøker.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/BorMedSøker/BorMedSøker.tsx
@@ -1,6 +1,7 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { Regelverk } from '@typer/vilkår';
+
 import { bestemMuligeUtdypendeVilkårsvurderingerIBorMedSøkerVilkår, useBorMedSøker } from './BorMedSøkerContext';
-import type { Regelverk } from '../../../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../../../context/BehandlingContext';
 import { useVilkårEkspanderbarRad } from '../../useVilkårEkspanderbarRad';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
@@ -14,8 +15,7 @@ export const BorMedSøker = ({
     person,
     settFokusPåLeggTilPeriodeKnapp,
 }: BosattIRiketProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const {
         vilkårSkjemaContext,

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOpphold.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/Vilkår/LovligOpphold/LovligOpphold.tsx
@@ -1,8 +1,9 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { Resultat } from '@typer/vilkår';
+
 import { Box, InlineMessage, Label, Radio, RadioGroup } from '@navikt/ds-react';
 
 import { useLovligOpphold } from './LovligOppholdContext';
-import { Resultat } from '../../../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../../../context/BehandlingContext';
 import { useVilkårEkspanderbarRad } from '../../useVilkårEkspanderbarRad';
 import type { IVilkårSkjemaBaseProps } from '../../VilkårSkjema';
 import { VilkårSkjema } from '../../VilkårSkjema';
@@ -16,8 +17,7 @@ export const LovligOpphold = ({
     person,
     settFokusPåLeggTilPeriodeKnapp,
 }: LovligOppholdProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const { vilkårSkjemaContext, finnesEndringerSomIkkeErLagret, skalViseDatoVarsel } = useLovligOpphold(
         lagretVilkårResultat,

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/OppdaterRegisteropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/OppdaterRegisteropplysninger.tsx
@@ -1,10 +1,12 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useOppdaterRegisteropplysninger } from '@hooks/useOppdaterRegisteropplysninger';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
+
 import { ArrowsSquarepathIcon } from '@navikt/aksel-icons';
 import { Button, Detail, ErrorMessage, HStack, VStack } from '@navikt/ds-react';
 import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { useVilkårsvurderingContext } from './VilkårsvurderingContext';
-import { useOppdaterRegisteropplysninger } from '../../../../../hooks/useOppdaterRegisteropplysninger';
-import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
 const FALLBACK_MESSAGE =
@@ -22,16 +24,16 @@ function formaterTidspunkt(registeropplysningerHentetTidpsunkt: string | undefin
 }
 
 export function OppdaterRegisteropplysninger() {
-    const { behandling, settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
     const { vilkårsvurdering } = useVilkårsvurderingContext();
+
+    const erLesevisning = useErLesevisning();
 
     const { mutate, isPending, error } = useOppdaterRegisteropplysninger({
         onSuccess: behandling => settÅpenBehandling(byggSuksessRessurs(behandling)),
     });
 
     const registeropplysningerHentetTidpsunkt = vilkårsvurdering[0]?.person?.registerhistorikk?.hentetTidspunkt;
-
-    const erLesevisning = vurderErLesevisning();
 
     return (
         <VStack gap={'space-8'}>


### PR DESCRIPTION
### 📮 Favro
NAV-29007

### 💰 Hva skal gjøres, og hvorfor?
- Tar i bruk `useErLesevisning` hooken. 
- Bytter til `useFagsak`, `useBehandling`, og `useBruker` hvor det gir mening. 
- Forenkler imports

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 