### PR TITLE
NAV-27893: Rydder opp i kode relatert til vedtaksperiode

### DIFF
--- a/src/frontend/hooks/useHentAlleBegrunnelser.ts
+++ b/src/frontend/hooks/useHentAlleBegrunnelser.ts
@@ -1,8 +1,7 @@
+import { hentAlleBegrunnelser } from '@api/hentAlleBegrunnelser';
 import { useQuery } from '@tanstack/react-query';
 
 import { useHttp } from '@navikt/familie-http';
-
-import { hentAlleBegrunnelser } from '../api/hentAlleBegrunnelser';
 
 export const HentAlleBegrunnelserQueryKeyFactory = {
     alleBegrunnelser: () => ['alleBegrunnelser'],

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/AlleBegrunnelserContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/AlleBegrunnelserContext.tsx
@@ -1,10 +1,10 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext } from 'react';
 
-import { BodyShort, Box, ErrorMessage, Loader, LocalAlert, Stack } from '@navikt/ds-react';
+import { useHentAlleBegrunnelser } from '@hooks/useHentAlleBegrunnelser';
+import type { AlleBegrunnelser } from '@typer/vilkår';
 
-import { useHentAlleBegrunnelser } from '../../../../../../hooks/useHentAlleBegrunnelser';
-import type { AlleBegrunnelser } from '../../../../../../typer/vilkår';
+import { BodyShort, Box, ErrorMessage, Loader, LocalAlert, Stack } from '@navikt/ds-react';
 
 interface AlleBegrunnelserContextValue {
     alleBegrunnelser: AlleBegrunnelser;

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
@@ -13,111 +13,84 @@ import {
 } from '@utils/dato';
 import { formaterBeløp, summer } from '@utils/formatter';
 import { endOfMonth, isAfter, isSameDay } from 'date-fns';
-import styled from 'styled-components';
 
-import { BodyShort, ExpansionCard, Label } from '@navikt/ds-react';
-
-const StyledExpansionCard = styled(ExpansionCard)`
-    margin-bottom: 1rem;
-`;
-
-const StyledExpansionHeader = styled(ExpansionCard.Header)`
-    align-items: center;
-`;
-
-const StyledExpansionTitle = styled(ExpansionCard.Title)`
-    display: grid;
-    grid-template-columns: minmax(6rem, 12rem) minmax(6rem, 15rem) auto;
-    grid-gap: 0.5rem;
-    margin-left: 0;
-`;
+import { BodyShort, ExpansionCard, HGrid, Label } from '@navikt/ds-react';
 
 interface Props extends PropsWithChildren {
     sisteVedtaksperiodeFom?: string;
 }
 
-const erSammeFom = (dato1?: IsoDatoString, dato2?: IsoDatoString): boolean =>
-    isSameDay(parseFraOgMedDato(dato1), parseFraOgMedDato(dato2));
+function erSammeFom(dato1?: IsoDatoString, dato2?: IsoDatoString): boolean {
+    return isSameDay(parseFraOgMedDato(dato1), parseFraOgMedDato(dato2));
+}
 
-const slutterSenereEnnInneværendeMåned = (tom?: string) =>
-    isAfter(isoStringTilDateMedFallback({ isoString: tom, fallbackDate: tidenesEnde }), endOfMonth(hentDagensDato()));
+function slutterSenereEnnInneværendeMåned(tom?: string) {
+    return isAfter(
+        isoStringTilDateMedFallback({ isoString: tom, fallbackDate: tidenesEnde }),
+        endOfMonth(hentDagensDato())
+    );
+}
 
-const finnPresentertTomDato = (
+function finnPresentertTomDato(
     vedtaksperiodeInneholderOvergangsordningBegrunnelse: boolean,
     periodeFom?: string,
     periodeTom?: string,
     sisteVedtaksperiodeFom?: string
-) => {
+) {
     if (vedtaksperiodeInneholderOvergangsordningBegrunnelse) {
         return periodeTom;
     }
-
     if (erSammeFom(periodeFom, sisteVedtaksperiodeFom)) {
         return slutterSenereEnnInneværendeMåned(periodeTom) ? '' : periodeTom;
     }
     return periodeTom;
-};
+}
 
 export function EkspanderbarVedtaksperiode({ sisteVedtaksperiodeFom, children }: Props) {
     const { vedtaksperiodeMedBegrunnelser, erPanelEkspandert, onPanelClose } = useVedtaksperiodeContext();
 
-    const vedtaksperiodeInneholderOvergangsordningBegrunnelse =
-        vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
-            vedtaksBegrunnelser =>
-                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
-                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING ||
-                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
-                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING ||
-                (vedtaksBegrunnelser.begrunnelse as Standardbegrunnelse) ===
-                    Standardbegrunnelse.INNVILGET_OVERGANGSORDNING_DELT_BOSTED
-        ).length > 0;
+    const { begrunnelser, type, utbetalingsperiodeDetaljer, fom, tom } = vedtaksperiodeMedBegrunnelser;
 
-    const periode = {
-        fom: vedtaksperiodeMedBegrunnelser.fom,
-        tom: vedtaksperiodeMedBegrunnelser.tom,
-    };
+    const vedtaksperiodeInneholderOvergangsordningBegrunnelse = begrunnelser.some(
+        ({ begrunnelse }) =>
+            begrunnelse === Standardbegrunnelse.INNVILGET_OVERGANGSORDNING ||
+            begrunnelse === Standardbegrunnelse.INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING ||
+            begrunnelse === Standardbegrunnelse.INNVILGET_OVERGANGSORDNING_DELT_BOSTED
+    );
 
-    const vedtaksperiodeTittel = hentVedtaksperiodeTittel(vedtaksperiodeMedBegrunnelser);
+    const erUtbetaling = type === Vedtaksperiodetype.UTBETALING;
+    const harUtbetalingsperiodeDetaljer = utbetalingsperiodeDetaljer.length > 0;
+    const skalViseSum = erUtbetaling && harUtbetalingsperiodeDetaljer;
+    const sum = summer(utbetalingsperiodeDetaljer.map(detalj => detalj.utbetaltPerMnd));
+    const tittel = hentVedtaksperiodeTittel(vedtaksperiodeMedBegrunnelser);
+
+    const periode = isoDatoPeriodeTilFormatertString({
+        fom: fom,
+        tom: finnPresentertTomDato(
+            vedtaksperiodeInneholderOvergangsordningBegrunnelse,
+            fom,
+            tom,
+            sisteVedtaksperiodeFom
+        ),
+    });
 
     return (
-        <StyledExpansionCard
-            key={`${periode.fom}_${periode.tom}`}
+        <ExpansionCard
+            aria-label={`Begrunnelse - Periode ${fom}_${tom}`}
             size={'small'}
             open={erPanelEkspandert}
             onToggle={() => onPanelClose(true)}
-            aria-label={`Periode ${periode.fom}_${periode.tom}`}
         >
-            <StyledExpansionHeader>
-                <StyledExpansionTitle>
-                    {periode.fom && (
-                        <Label>
-                            {isoDatoPeriodeTilFormatertString({
-                                fom: periode.fom,
-                                tom: finnPresentertTomDato(
-                                    vedtaksperiodeInneholderOvergangsordningBegrunnelse,
-                                    periode.fom,
-                                    periode.tom,
-                                    sisteVedtaksperiodeFom
-                                ),
-                            })}
-                        </Label>
-                    )}
-                    <BodyShort>{vedtaksperiodeTittel}</BodyShort>
-                    {vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.UTBETALING &&
-                        vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.length > 0 && (
-                            <BodyShort>
-                                {formaterBeløp(
-                                    summer(
-                                        vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.map(
-                                            utbetalingsperiodeDetalj => utbetalingsperiodeDetalj.utbetaltPerMnd
-                                        )
-                                    )
-                                )}
-                            </BodyShort>
-                        )}
-                </StyledExpansionTitle>
-            </StyledExpansionHeader>
+            <ExpansionCard.Header>
+                <ExpansionCard.Title>
+                    <HGrid columns={'minmax(6rem, 12rem) minmax(6rem, 15rem) auto'} gap={'space-8'}>
+                        {fom && <Label>{periode}</Label>}
+                        <BodyShort>{tittel}</BodyShort>
+                        {skalViseSum && <BodyShort>{formaterBeløp(sum)}</BodyShort>}
+                    </HGrid>
+                </ExpansionCard.Title>
+            </ExpansionCard.Header>
             <ExpansionCard.Content>{children}</ExpansionCard.Content>
-        </StyledExpansionCard>
+        </ExpansionCard>
     );
 }

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
@@ -46,11 +46,13 @@ export function GenererteBrevbegrunnelser() {
         <VStack gap={'space-0'}>
             <Label>Begrunnelse(r)</Label>
             <ul>
-                {genererteBrevbegrunnelser.map((begrunnelse, index) => (
-                    <li key={`begrunnelse-${index}`}>
-                        <BodyShort>{begrunnelse}</BodyShort>
-                    </li>
-                ))}
+                {genererteBrevbegrunnelser
+                    .toSorted((b1, b2) => b1.localeCompare(b2))
+                    .map((begrunnelse, index) => (
+                        <li key={`begrunnelse-${index}`}>
+                            <BodyShort>{begrunnelse}</BodyShort>
+                        </li>
+                    ))}
             </ul>
         </VStack>
     );

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
@@ -1,30 +1,13 @@
-import { Fragment } from 'react';
-
 import { useBehandling } from '@hooks/useBehandling';
 import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
 import { Vedtaksperiodetype } from '@typer/vedtaksperiode';
 import { partition } from '@utils/commons';
-import styled from 'styled-components';
 
-import { Heading, HelpText } from '@navikt/ds-react';
+import { Heading, HelpText, HStack, VStack } from '@navikt/ds-react';
 
 import { filtrerOgSorterPerioderMedBegrunnelseBehov } from './utils';
 import { Vedtaksperiode } from './Vedtaksperiode';
 import { VedtaksperiodeProvider } from './VedtaksperiodeContext';
-
-const StyledHeading = styled(Heading)`
-    display: flex;
-    margin-top: 1rem;
-`;
-
-const StyledHelpText = styled(HelpText)`
-    margin-top: 0.1rem;
-    margin-left: 0.6rem;
-
-    & + .aksel-popover {
-        max-width: 20rem;
-    }
-`;
 
 export function Vedtaksperioder() {
     const behandling = useBehandling();
@@ -41,59 +24,59 @@ export function Vedtaksperioder() {
         sorterteVedtaksperioderSomSkalvises
     );
 
-    return sorterteVedtaksperioderSomSkalvises.length > 0 ? (
-        <>
-            <GrupperteVedtaksperioder
-                sorterteVedtaksperioderMedBegrunnelser={sorterteAndreVedtaksperioder}
-                overskrift={'Begrunnelser i vedtaksbrev'}
-                hjelpetekst={'Her skal du sette begrunnelsestekster for innvilgelse, reduksjon og opphør.'}
-            />
-
-            <GrupperteVedtaksperioder
-                sorterteVedtaksperioderMedBegrunnelser={sorterteAvslagsperioder}
-                overskrift={'Begrunnelser for avslag i vedtaksbrev'}
-                hjelpetekst={'Her har vi hentet begrunnelser for avslag som er satt tidligere i behandlingen.'}
-            />
-        </>
-    ) : (
-        <Fragment />
-    );
-}
-
-const GrupperteVedtaksperioder = ({
-    sorterteVedtaksperioderMedBegrunnelser,
-    overskrift,
-    hjelpetekst,
-}: {
-    sorterteVedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBegrunnelser[];
-    overskrift: string;
-    hjelpetekst: string;
-}) => {
-    if (sorterteVedtaksperioderMedBegrunnelser.length === 0) {
+    if (sorterteVedtaksperioderSomSkalvises.length <= 0) {
         return null;
     }
 
-    const sisteVedtaksperiodeFom =
-        sorterteVedtaksperioderMedBegrunnelser[sorterteVedtaksperioderMedBegrunnelser.length - 1].fom;
+    return (
+        <VStack gap={'space-32'} marginBlock={'space-32'}>
+            <GrupperteVedtaksperioder
+                vedtaksperioderMedBegrunnelser={sorterteAndreVedtaksperioder}
+                overskrift={'Begrunnelser i vedtaksbrev'}
+                hjelpetekst={'Her skal du sette begrunnelsestekster for innvilgelse, reduksjon og opphør.'}
+            />
+            <GrupperteVedtaksperioder
+                vedtaksperioderMedBegrunnelser={sorterteAvslagsperioder}
+                overskrift={'Begrunnelser for avslag i vedtaksbrev'}
+                hjelpetekst={'Her har vi hentet begrunnelser for avslag som er satt tidligere i behandlingen.'}
+            />
+        </VStack>
+    );
+}
+
+function GrupperteVedtaksperioder({
+    vedtaksperioderMedBegrunnelser,
+    overskrift,
+    hjelpetekst,
+}: {
+    vedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBegrunnelser[];
+    overskrift: string;
+    hjelpetekst: string;
+}) {
+    if (vedtaksperioderMedBegrunnelser.length === 0) {
+        return null;
+    }
+
+    const sisteVedtaksperiodeFom = vedtaksperioderMedBegrunnelser[vedtaksperioderMedBegrunnelser.length - 1].fom;
 
     return (
-        <>
-            <StyledHeading level="2" size="small" spacing>
-                {overskrift}
-                <StyledHelpText placement="right">{hjelpetekst}</StyledHelpText>
-            </StyledHeading>
-            {sorterteVedtaksperioderMedBegrunnelser.map(
-                (vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser) => (
+        <VStack gap={'space-0'}>
+            <Heading level={'2'} size={'small'} spacing={true}>
+                <HStack align={'center'} justify={'start'} gap={'space-4'}>
+                    {overskrift}
+                    <HelpText placement={'right'}>{hjelpetekst}</HelpText>
+                </HStack>
+            </Heading>
+            <VStack gap={'space-20'}>
+                {vedtaksperioderMedBegrunnelser.map(vedtaksperiodeMedBegrunnelser => (
                     <VedtaksperiodeProvider
                         key={vedtaksperiodeMedBegrunnelser.id}
                         vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
                     >
                         <Vedtaksperiode sisteVedtaksperiodeFom={sisteVedtaksperiodeFom} />
                     </VedtaksperiodeProvider>
-                )
-            )}
-        </>
+                ))}
+            </VStack>
+        </VStack>
     );
-};
-
-export default Vedtaksperioder;
+}


### PR DESCRIPTION
### 📮 Favro
NAV-27893

### 💰 Hva skal gjøres, og hvorfor?
- Rydder opp i imports.
- Erstatter styled-components med Aksel komponenter.
- Lar sortering av begrunnelser skje i UI istendefor i cache.
- Gjør eksisterende logikk mer lesbar. 
- Samsvarer kode mellom ba-sak-frontend og ks-sak-frontend.  

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Bare refaktorere eksisterende logikk, skal ikke være logiske endringer. 

### 👀 Screen shots
Før:
<img width="712" height="765" alt="image" src="https://github.com/user-attachments/assets/f8a27ed2-8974-4585-9c8c-5e535f46c002" />

Etter:
<img width="720" height="797" alt="image" src="https://github.com/user-attachments/assets/ad6253da-0dc9-4e00-a42a-5e5ddc83ebba" />
