### PR TITLE
NAV-28953: Rydder opp litt i korriger vedtak skjemaet.

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
@@ -1,20 +1,18 @@
-import type { IRestKorrigertVedtak } from '@typer/vedtak';
+import { useBehandling } from '@hooks/useBehandling';
 
 import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
 import { ActionMenu } from '@navikt/ds-react';
 
-interface IKorrigerVedtak {
+interface Props {
     åpneModal: () => void;
-    korrigertVedtak?: IRestKorrigertVedtak;
 }
 
-const KorrigerVedtak = ({ åpneModal, korrigertVedtak }: IKorrigerVedtak) => {
+export function KorrigerVedtak({ åpneModal }: Props) {
+    const behandling = useBehandling();
     return (
         <ActionMenu.Item onClick={åpneModal}>
             <ExclamationmarkTriangleIcon fontSize={'1.4rem'} />
-            {korrigertVedtak ? <>Vis korrigert vedtak</> : <>Korriger vedtak</>}
+            {behandling.korrigertVedtak ? <>Vis korrigert vedtak</> : <>Korriger vedtak</>}
         </ActionMenu.Item>
     );
-};
-
-export default KorrigerVedtak;
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerVedtakModal/KorrigerVedtakModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerVedtakModal/KorrigerVedtakModal.tsx
@@ -1,84 +1,106 @@
-import { useBehandling } from '@hooks/useBehandling';
+import { useAngreKorrigertVedtak } from '@hooks/useAngreKorrigertVedtak';
 import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
 import { BegrunnelseFelt } from '@sider/Fagsak/Behandling/sider/Vedtak/KorrigerVedtakModal/BegrunnelseFelt';
 import { VedtaksdatoFelt } from '@sider/Fagsak/Behandling/sider/Vedtak/KorrigerVedtakModal/VedtaksdatoFelt';
 import { FormProvider } from 'react-hook-form';
 
 import { ArrowUndoIcon } from '@navikt/aksel-icons';
-import { BodyLong, Button, Fieldset, Modal } from '@navikt/ds-react';
+import { BodyLong, Button, Fieldset, Modal, VStack } from '@navikt/ds-react';
+import { byggSuksessRessurs } from '@navikt/familie-typer';
 
-import { useKorrigerVedtakSkjema } from './useKorrigerVedtakSkjema';
+import { KORRIGER_VEDTAK_FORM_ID, useKorrigerVedtakSkjema } from './useKorrigerVedtakSkjema';
 
 interface Props {
     lukkModal: () => void;
 }
 
 export function KorrigerVedtakModal({ lukkModal }: Props) {
-    const behandling = useBehandling();
-    const korrigertVedtak = behandling.korrigertVedtak;
-
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
     const erLesevisning = useErLesevisning();
 
-    const { form, onKorrigerVedtak, onAngreKorrigertVedtak } = useKorrigerVedtakSkjema({ lukkModal });
+    const {
+        mutate: angreKorrigertVedtak,
+        isPending: angreKorrigertVedtakIsPending,
+        error: angreKorrigertVedtakError,
+    } = useAngreKorrigertVedtak({
+        onSuccess: behandling => {
+            settÅpenBehandling(byggSuksessRessurs(behandling));
+            lukkModal();
+        },
+    });
+
+    const { form, onSubmit } = useKorrigerVedtakSkjema({ lukkModal });
 
     const {
         handleSubmit,
         formState: { isSubmitting, errors },
     } = form;
 
+    const korrigertVedtak = behandling.korrigertVedtak;
     const visAngreKnapp = korrigertVedtak != null;
 
     return (
-        <Modal open onClose={lukkModal} header={{ heading: 'Korriger vedtak', size: 'medium' }} width={'35rem'} portal>
-            <FormProvider {...form}>
-                <form onSubmit={handleSubmit(onKorrigerVedtak)}>
-                    <Modal.Body>
-                        <BodyLong>
-                            Dersom det har blitt gjort feil tidligere vedtak, kan denne teksten legges til i
-                            vedtaksbrevet:
-                        </BodyLong>
-                        <ul>
-                            <li>
-                                Vi har oppdaget en feil i vedtaket vi gjorde [DATO]. Derfor har vi vurdert saken din på
-                                nytt.
-                            </li>
-                        </ul>
-                        <Fieldset
-                            legend="Korriger vedtak"
-                            hideLegend
-                            errorPropagation={false}
-                            error={errors.root?.message}
+        <Modal open={true} onClose={lukkModal} header={{ heading: 'Korriger vedtak' }} width={'35rem'} portal={true}>
+            <Modal.Body>
+                <BodyLong>
+                    Dersom det har blitt gjort feil tidligere vedtak, kan denne teksten legges til i vedtaksbrevet:
+                </BodyLong>
+                <ul>
+                    <li>
+                        Vi har oppdaget en feil i vedtaket vi gjorde [DATO]. Derfor har vi vurdert saken din på nytt.
+                    </li>
+                </ul>
+                <Fieldset
+                    legend={'Korriger vedtak'}
+                    hideLegend={true}
+                    errorPropagation={false}
+                    error={errors.root?.message ?? angreKorrigertVedtakError?.message}
+                >
+                    <FormProvider {...form}>
+                        <form id={KORRIGER_VEDTAK_FORM_ID} onSubmit={handleSubmit(onSubmit)}>
+                            <VStack gap={'space-16'}>
+                                <VedtaksdatoFelt erLesevisning={erLesevisning || angreKorrigertVedtakIsPending} />
+                                <BegrunnelseFelt erLesevisning={erLesevisning || angreKorrigertVedtakIsPending} />
+                            </VStack>
+                        </form>
+                    </FormProvider>
+                </Fieldset>
+            </Modal.Body>
+            <Modal.Footer>
+                {!erLesevisning && (
+                    <>
+                        <Button
+                            form={KORRIGER_VEDTAK_FORM_ID}
+                            type={'submit'}
+                            variant={'primary'}
+                            loading={isSubmitting}
+                            disabled={angreKorrigertVedtakIsPending}
                         >
-                            <VedtaksdatoFelt erLesevisning={erLesevisning} />
-                            <BegrunnelseFelt erLesevisning={erLesevisning} />
-                        </Fieldset>
-                    </Modal.Body>
-                    <Modal.Footer>
-                        {!erLesevisning && (
-                            <>
-                                <Button type={'submit'} variant={'primary'} loading={isSubmitting}>
-                                    {korrigertVedtak ? 'Oppdater' : 'Legg til'}
-                                </Button>
-                                <Button onClick={lukkModal} variant={'tertiary'}>
-                                    Avbryt
-                                </Button>
-                                {visAngreKnapp && (
-                                    <Button
-                                        size={'small'}
-                                        onClick={handleSubmit(onAngreKorrigertVedtak)}
-                                        variant={'tertiary'}
-                                        loading={isSubmitting}
-                                        icon={<ArrowUndoIcon />}
-                                    >
-                                        Fjern korrigering
-                                    </Button>
-                                )}
-                            </>
+                            {korrigertVedtak ? 'Oppdater' : 'Legg til'}
+                        </Button>
+                        <Button onClick={lukkModal} variant={'tertiary'}>
+                            Avbryt
+                        </Button>
+                        {visAngreKnapp && (
+                            <Button
+                                size={'small'}
+                                onClick={() => angreKorrigertVedtak(behandling.behandlingId)}
+                                variant={'tertiary'}
+                                loading={angreKorrigertVedtakIsPending}
+                                icon={<ArrowUndoIcon />}
+                            >
+                                Fjern korrigering
+                            </Button>
                         )}
-                        {erLesevisning && <Button onClick={lukkModal}>Lukk</Button>}
-                    </Modal.Footer>
-                </form>
-            </FormProvider>
+                    </>
+                )}
+                {erLesevisning && (
+                    <Button variant={'primary'} onClick={lukkModal}>
+                        Lukk
+                    </Button>
+                )}
+            </Modal.Footer>
         </Modal>
     );
 }

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerVedtakModal/useKorrigerVedtakSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerVedtakModal/useKorrigerVedtakSkjema.ts
@@ -1,4 +1,3 @@
-import { useAngreKorrigertVedtak } from '@hooks/useAngreKorrigertVedtak';
 import { useKorrigerVedtak } from '@hooks/useKorrigerVedtak';
 import { dateTilIsoDatoString, type IsoDatoString } from '@utils/dato';
 import { useForm } from 'react-hook-form';
@@ -6,6 +5,8 @@ import { useForm } from 'react-hook-form';
 import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { useBehandlingContext } from '../../../context/BehandlingContext';
+
+export const KORRIGER_VEDTAK_FORM_ID = 'korriger_vedtak_form_id';
 
 export enum KorrigerVedtakFelt {
     VEDTAKSDATO = 'vedtaksdato',
@@ -28,59 +29,35 @@ interface Props {
 
 export function useKorrigerVedtakSkjema({ lukkModal }: Props) {
     const { behandling, settÅpenBehandling } = useBehandlingContext();
+
     const korrigertVedtak = behandling.korrigertVedtak;
 
-    const { mutateAsync: korrigerVedtak } = useKorrigerVedtak();
-    const { mutateAsync: angreKorrigertVedtak } = useAngreKorrigertVedtak();
+    const { mutateAsync: korrigerVedtak } = useKorrigerVedtak({
+        onSuccess: behandling => {
+            settÅpenBehandling(byggSuksessRessurs(behandling));
+            lukkModal();
+        },
+        onError: error => {
+            setError('root', { message: error.message ?? 'Teknisk feil ved lagring av korrigert vedtak.' });
+        },
+    });
 
     const form = useForm<KorrigerVedtakFormValues, unknown, TransformedKorrigerVedtakFormValues>({
         values: {
             [KorrigerVedtakFelt.VEDTAKSDATO]: korrigertVedtak?.vedtaksdato
                 ? dateTilIsoDatoString(new Date(korrigertVedtak.vedtaksdato))
                 : null,
-            [KorrigerVedtakFelt.BEGRUNNELSE]: '',
+            [KorrigerVedtakFelt.BEGRUNNELSE]: korrigertVedtak?.begrunnelse ?? '',
         },
     });
 
     const { setError } = form;
 
-    const onKorrigerVedtak = async (values: TransformedKorrigerVedtakFormValues) => {
+    function onSubmit(values: TransformedKorrigerVedtakFormValues) {
         const { vedtaksdato, begrunnelse } = values;
+        const korrigerVedtakParameters = { vedtaksdato, begrunnelse, behandlingId: behandling.behandlingId };
+        return korrigerVedtak(korrigerVedtakParameters);
+    }
 
-        const korrigerVedtakParameters = {
-            vedtaksdato,
-            begrunnelse,
-            behandlingId: behandling.behandlingId,
-        };
-
-        return korrigerVedtak(korrigerVedtakParameters)
-            .then(behandling => {
-                settÅpenBehandling(byggSuksessRessurs(behandling));
-                lukkModal();
-            })
-            .catch((e: unknown) => {
-                setError('root', {
-                    message: e instanceof Error ? e.message : 'Teknisk feil ved lagring av korrigert vedtak.',
-                });
-            });
-    };
-
-    const onAngreKorrigertVedtak = () => {
-        return angreKorrigertVedtak(behandling.behandlingId)
-            .then(behandling => {
-                settÅpenBehandling(byggSuksessRessurs(behandling));
-                lukkModal();
-            })
-            .catch((e: unknown) => {
-                setError('root', {
-                    message: e instanceof Error ? e.message : 'Teknisk feil ved fjerning av korrigert vedtak.',
-                });
-            });
-    };
-
-    return {
-        form,
-        onKorrigerVedtak,
-        onAngreKorrigertVedtak,
-    };
+    return { form, onSubmit };
 }

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksmeny/Vedtaksmeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksmeny/Vedtaksmeny.tsx
@@ -13,7 +13,7 @@ import EndreEndringstidspunkt from '../endringstidspunkt/EndreEndringstidspunkt'
 import { OppdaterEndringstidspunktModal } from '../endringstidspunkt/OppdaterEndringstidspunktModal';
 import { useFeilutbetaltValutaTabellContext } from '../FeilutbetaltValuta/FeilutbetaltValutaTabellContext';
 import KorrigerEtterbetaling from '../KorrigerEtterbetaling/KorrigerEtterbetaling';
-import KorrigerVedtak from '../KorrigerVedtakModal/KorrigerVedtak';
+import { KorrigerVedtak } from '../KorrigerVedtakModal/KorrigerVedtak';
 import { useRefusjonEøsTabellContext } from '../RefusjonEøs/RefusjonEøsTabellContext';
 import { useSammensattKontrollsakContext } from '../SammensattKontrollsak/SammensattKontrollsakContext';
 
@@ -52,10 +52,7 @@ export function Vedtaksmeny({ erBehandlingMedVedtaksbrevutsending }: Props) {
                     {erBehandlingMedVedtaksbrevutsending && (
                         <>
                             <KorrigerEtterbetaling korrigertEtterbetaling={behandling.korrigertEtterbetaling} />
-                            <KorrigerVedtak
-                                åpneModal={() => settVisKorrigerVedtakModal(true)}
-                                korrigertVedtak={behandling.korrigertVedtak}
-                            />
+                            <KorrigerVedtak åpneModal={() => settVisKorrigerVedtakModal(true)} />
                         </>
                     )}
                     {behandling.endringstidspunkt && (


### PR DESCRIPTION
### 📮 Favro:
NAV-28953

### 💰 Hva skal gjøres, og hvorfor?
Refaktorerer UI-flyten for «Korriger vedtak» for å forenkle håndtering av props/state og samle mutation-bivirkninger (oppdatering av behandling + lukking av modal) nærmere de relevante mutation-hooksene.

Endringer:

* Konverterer `KorrigerVedtak`-menypunktet til en navngitt eksport og leser `korrigertVedtak` fra behandling-context i stedet for via props.
* Flytter håndteringen av «angre korrigering» ut av `useKorrigerVedtakSkjema` og inn i `KorrigerVedtakModal`, samtidig som vellykkede mutations fortsatt har ansvar for å oppdatere behandling + lukke modal.
* Introduserer en delt `KORRIGER_VEDTAK_FORM_ID` for å koble submit-knappen i modal-footeren til skjemaet.


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ingen eksisterende tester.

### 👀 Screen shots
Ingen visuelle endringer. 