### PR TITLE
NAV-29011: Flytter toast-state til ToastContext

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,18 +1,19 @@
 import '@navikt/ds-css';
 import './index.css';
 
+import { AppProvider } from '@context/AppContext';
+import { AuthContextProvider } from '@context/AuthContext';
+import { FeatureTogglesProvider } from '@context/FeatureTogglesContext';
+import { HttpContextProvider } from '@context/HttpContext';
+import { ModalProvider } from '@context/ModalContext';
+import { SaksbehandlerProvider } from '@context/SaksbehandlerContext';
+import { ToastProvider } from '@context/ToastContext';
+import { ErrorBoundary, ErrorBoundaryMedSaksbehandler } from '@komponenter/ErrorBoundary/ErrorBoundary';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { erProd } from '@utils/miljø';
 
 import { Container } from './Container';
-import { AppProvider } from './context/AppContext';
-import { AuthContextProvider } from './context/AuthContext';
-import { FeatureTogglesProvider } from './context/FeatureTogglesContext';
-import { HttpContextProvider } from './context/HttpContext';
-import { ModalProvider } from './context/ModalContext';
-import { SaksbehandlerProvider } from './context/SaksbehandlerContext';
-import { ErrorBoundary, ErrorBoundaryMedSaksbehandler } from './komponenter/ErrorBoundary/ErrorBoundary';
-import { erProd } from './utils/miljø';
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -34,7 +35,9 @@ export function App() {
                                 <FeatureTogglesProvider>
                                     <AppProvider>
                                         <ModalProvider>
-                                            <Container />
+                                            <ToastProvider>
+                                                <Container />
+                                            </ToastProvider>
                                         </ModalProvider>
                                     </AppProvider>
                                 </FeatureTogglesProvider>

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -1,24 +1,13 @@
-import {
-    createContext,
-    type Dispatch,
-    type JSX,
-    type PropsWithChildren,
-    type ReactNode,
-    type SetStateAction,
-    useContext,
-    useState,
-} from 'react';
+import { createContext, type JSX, type PropsWithChildren, type ReactNode, useContext, useState } from 'react';
 
+import type { IRestTilgang } from '@typer/person';
+import { adressebeskyttelsestyper } from '@typer/person';
 import type { AxiosRequestConfig } from 'axios';
 
 import { Button, InlineMessage } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
-
-import type { IToast, ToastTyper } from '../komponenter/Toast/typer';
-import type { IRestTilgang } from '../typer/person';
-import { adressebeskyttelsestyper } from '../typer/person';
 
 export type FamilieAxiosRequestConfig<D> = AxiosRequestConfig & {
     data?: D;
@@ -41,16 +30,7 @@ const initalState: IModal = {
 interface AppContextValue {
     lukkModal: () => void;
     appInfoModal: IModal;
-    settToast: (toastId: ToastTyper, toast: IToast) => void;
-    settToasts: Dispatch<
-        SetStateAction<{
-            [toastId: string]: IToast;
-        }>
-    >;
     sjekkTilgang: (brukerIdent: string, visSystemetLaster?: boolean) => Promise<boolean>;
-    toasts: {
-        [toastId: string]: IToast;
-    };
 }
 
 const AppContext = createContext<AppContextValue | undefined>(undefined);
@@ -59,7 +39,6 @@ const AppProvider = (props: PropsWithChildren) => {
     const { request } = useHttp();
 
     const [appInfoModal, settAppInfoModal] = useState<IModal>(initalState);
-    const [toasts, settToasts] = useState<{ [toastId: string]: IToast }>({});
 
     const lukkModal = () => {
         settAppInfoModal(initalState);
@@ -108,14 +87,7 @@ const AppProvider = (props: PropsWithChildren) => {
             value={{
                 lukkModal,
                 appInfoModal,
-                settToast: (toastId: ToastTyper, toast: IToast) =>
-                    settToasts({
-                        ...toasts,
-                        [toastId]: toast,
-                    }),
-                settToasts,
                 sjekkTilgang,
-                toasts,
             }}
         >
             {props.children}

--- a/src/frontend/context/ToastContext.test.tsx
+++ b/src/frontend/context/ToastContext.test.tsx
@@ -1,0 +1,78 @@
+import type { PropsWithChildren } from 'react';
+
+import { AlertType, type IToast, ToastTyper } from '@komponenter/Toast/typer';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { ToastProvider, useToastContext } from './ToastContext';
+
+const wrapper = ({ children }: PropsWithChildren) => <ToastProvider>{children}</ToastProvider>;
+
+describe('ToastContext', () => {
+    test('kaster feil når useToastContext brukes utenfor ToastProvider', () => {
+        // Act & assert
+        expect(() => renderHook(() => useToastContext())).toThrowError(
+            'useToastContext må brukes innenfor en ToastProvider.'
+        );
+    });
+
+    test('gir tilgang til toasts som er tom ved oppstart', () => {
+        // Act
+        const { result } = renderHook(() => useToastContext(), { wrapper });
+
+        // Assert
+        expect(result.current.toasts).toEqual({});
+    });
+
+    test('settToast legger til en toast i toasts', () => {
+        // Arrange
+        const toast: IToast = { tekst: 'Noe gikk galt', alertType: AlertType.ERROR };
+        const { result } = renderHook(() => useToastContext(), { wrapper });
+
+        // Act
+        act(() => {
+            result.current.settToast(ToastTyper.FANT_IKKE_FAGSAK, toast);
+        });
+
+        // Assert
+        expect(result.current.toasts).toEqual({ [ToastTyper.FANT_IKKE_FAGSAK]: toast });
+    });
+
+    test('settToast bevarer eksisterende toasts når en ny legges til', () => {
+        // Arrange
+        const toast1: IToast = { tekst: 'Noe gikk galt', alertType: AlertType.ERROR };
+        const toast2: IToast = { tekst: 'Ingen tilgang!', alertType: AlertType.ERROR };
+
+        const { result } = renderHook(() => useToastContext(), { wrapper });
+
+        act(() => {
+            result.current.settToast(ToastTyper.FANT_IKKE_FAGSAK, toast1);
+        });
+
+        // Act
+        act(() => {
+            result.current.settToast(ToastTyper.MANGLER_TILGANG, toast2);
+        });
+
+        // Assert
+        expect(result.current.toasts).toEqual({
+            [ToastTyper.FANT_IKKE_FAGSAK]: toast1,
+            [ToastTyper.MANGLER_TILGANG]: toast2,
+        });
+    });
+
+    test('settToasts kan overskrive hele toasts-tilstanden direkte', () => {
+        // Arrange
+        const toast: IToast = { tekst: 'Noe gikk galt', alertType: AlertType.ERROR };
+        const nyeToasts = { [ToastTyper.FANT_IKKE_FAGSAK]: toast };
+        const { result } = renderHook(() => useToastContext(), { wrapper });
+
+        // Act
+        act(() => {
+            result.current.settToasts(nyeToasts);
+        });
+
+        // Assert
+        expect(result.current.toasts).toEqual(nyeToasts);
+    });
+});

--- a/src/frontend/context/ToastContext.tsx
+++ b/src/frontend/context/ToastContext.tsx
@@ -1,0 +1,32 @@
+import { type Dispatch, type PropsWithChildren, type SetStateAction, useMemo, useState } from 'react';
+import { createContext, useContext } from 'react';
+
+import type { IToast, ToastTyper } from '@komponenter/Toast/typer';
+
+interface ToastContext {
+    settToast: (toastId: ToastTyper, toast: IToast) => void;
+    settToasts: Dispatch<SetStateAction<{ [toastId: string]: IToast }>>;
+    toasts: { [toastId: string]: IToast };
+}
+
+const ToastContext = createContext<ToastContext | undefined>(undefined);
+
+export function ToastProvider({ children }: PropsWithChildren) {
+    const [toasts, settToasts] = useState<{ [toastId: string]: IToast }>({});
+
+    function settToast(toastId: ToastTyper, toast: IToast) {
+        settToasts(prev => ({ ...prev, [toastId]: toast }));
+    }
+
+    const value = useMemo(() => ({ settToast, settToasts, toasts }), [toasts]);
+
+    return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+}
+
+export function useToastContext() {
+    const context = useContext(ToastContext);
+    if (context === undefined) {
+        throw new Error('useToastContext må brukes innenfor en ToastProvider.');
+    }
+    return context;
+}

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useLagreOgFjernMottakerPåBehandling.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useLagreOgFjernMottakerPåBehandling.ts
@@ -1,11 +1,12 @@
+import { useToastContext } from '@context/ToastContext';
+import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
+import type { IBehandling } from '@typer/behandling';
+
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggHenterRessurs, RessursStatus } from '@navikt/familie-typer';
 
 import type { BrevmottakerUseSkjema, IRestBrevmottaker } from './useBrevmottakerSkjema';
-import { useAppContext } from '../../../../context/AppContext';
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
-import type { IBehandling } from '../../../../typer/behandling';
 import { AlertType, ToastTyper } from '../../../Toast/typer';
 
 interface Props {
@@ -14,7 +15,7 @@ interface Props {
 
 export const useLagreEllerFjernMottakerPåBehandling = ({ behandlingId }: Props) => {
     const { settÅpenBehandling } = useBehandlingContext();
-    const { settToast } = useAppContext();
+    const { settToast } = useToastContext();
     const { request } = useHttp();
 
     const lagreMottaker = (verdierFraBrevmottakerUseSkjema: BrevmottakerUseSkjema) => {

--- a/src/frontend/komponenter/Toast/Toast.tsx
+++ b/src/frontend/komponenter/Toast/Toast.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import { useAppContext } from '@context/AppContext';
+import { useToastContext } from '@context/ToastContext';
 
 import { LocalAlert } from '@navikt/ds-react';
 
@@ -8,7 +8,7 @@ import styles from './Toast.module.css';
 import type { IToast } from './typer';
 
 const Toast = ({ toastId, toast }: { toastId: string; toast: IToast }) => {
-    const { toasts, settToasts } = useAppContext();
+    const { toasts, settToasts } = useToastContext();
     const toastRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {

--- a/src/frontend/komponenter/Toast/Toasts.tsx
+++ b/src/frontend/komponenter/Toast/Toasts.tsx
@@ -1,10 +1,10 @@
-import { useAppContext } from '@context/AppContext';
+import { useToastContext } from '@context/ToastContext';
 
 import Toast from './Toast';
 import styles from './Toasts.module.css';
 
 const Toasts = () => {
-    const { toasts } = useAppContext();
+    const { toasts } = useToastContext();
 
     return (
         <div className={styles.container}>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerEtterbetaling/useKorrigerEtterbetalingForm.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/KorrigerEtterbetaling/useKorrigerEtterbetalingForm.ts
@@ -1,16 +1,16 @@
+import { ModalType } from '@context/ModalContext';
+import { useToastContext } from '@context/ToastContext';
+import { useAngreKorrigertEtterbetaling } from '@hooks/useAngreKorrigertEtterbetaling';
+import { useKorrigerEtterbetaling } from '@hooks/useKorrigerEtterbetaling';
+import { useModal } from '@hooks/useModal';
+import { AlertType, ToastTyper } from '@komponenter/Toast/typer';
+import type { IBehandling } from '@typer/behandling';
+import type { OptionType } from '@typer/common';
+import { KorrigertEtterbetalingÅrsak } from '@typer/vedtak';
 import { useForm } from 'react-hook-form';
 
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useAppContext } from '../../../../../../context/AppContext';
-import { ModalType } from '../../../../../../context/ModalContext';
-import { useAngreKorrigertEtterbetaling } from '../../../../../../hooks/useAngreKorrigertEtterbetaling';
-import { useKorrigerEtterbetaling } from '../../../../../../hooks/useKorrigerEtterbetaling';
-import { useModal } from '../../../../../../hooks/useModal';
-import { AlertType, ToastTyper } from '../../../../../../komponenter/Toast/typer';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import type { OptionType } from '../../../../../../typer/common';
-import { KorrigertEtterbetalingÅrsak } from '../../../../../../typer/vedtak';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface KorrigerEtterbetalingFormValues {
@@ -42,7 +42,7 @@ export function useKorrigerEtterbetalingForm(behandling: IBehandling) {
     const { settÅpenBehandling } = useBehandlingContext();
     const korrigertEtterbetaling = behandling.korrigertEtterbetaling;
 
-    const { settToast } = useAppContext();
+    const { settToast } = useToastContext();
 
     const { mutateAsync: korrigerEtterbetalingAsync } = useKorrigerEtterbetaling();
 

--- a/src/frontend/sider/Oppgavebenk/OppgaveDirektelenke.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveDirektelenke.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { useAppContext } from '@context/AppContext';
+import { useToastContext } from '@context/ToastContext';
 import { AlertType, ToastTyper } from '@komponenter/Toast/typer';
 import type { IOppgave } from '@typer/oppgave';
 import { oppgaveTypeFilter, OppgavetypeFilter } from '@typer/oppgave';
@@ -17,7 +18,7 @@ interface IOppgaveDirektelenke {
 }
 
 export function OppgaveDirektelenke({ oppgave }: IOppgaveDirektelenke) {
-    const { settToast } = useAppContext();
+    const { settToast } = useToastContext();
     const { hentFagsakForPerson } = useFagsakApi();
     const { sjekkTilgang } = useAppContext();
     const [laster, settLaster] = useState<boolean>(false);

--- a/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
-import { useAppContext } from '@context/AppContext';
+import { useToastContext } from '@context/ToastContext';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { AlertType, ToastTyper } from '@komponenter/Toast/typer';
 import type { IMinimalFagsak } from '@typer/fagsak';
@@ -56,7 +56,7 @@ const OppgavebenkContext = createContext<OppgavebenkContextValue | undefined>(un
 
 export const OppgavebenkProvider = (props: PropsWithChildren) => {
     const navigate = useNavigate();
-    const { settToast } = useAppContext();
+    const { settToast } = useToastContext();
     const { request } = useHttp();
     const { opprettEllerHentFagsak } = useOpprettEllerHentFagsak();
     const saksbehandler = useSaksbehandler();

--- a/src/frontend/testutils/testrender.tsx
+++ b/src/frontend/testutils/testrender.tsx
@@ -1,20 +1,21 @@
 import type { PropsWithChildren } from 'react';
 
+import { AppProvider } from '@context/AppContext';
+import { AuthContextProvider } from '@context/AuthContext';
+import { FeatureTogglesProvider } from '@context/FeatureTogglesContext';
+import { HttpContextProvider } from '@context/HttpContext';
+import { ModalProvider } from '@context/ModalContext';
+import { SaksbehandlerProvider } from '@context/SaksbehandlerContext';
+import { ToastProvider } from '@context/ToastContext';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as rtlRender, type RenderOptions, screen as rtlScreen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { FeatureToggles } from '@typer/featureToggles';
+import type { Saksbehandler } from '@typer/saksbehandler';
 import { MemoryRouter } from 'react-router';
 
-import { AppProvider } from '../context/AppContext';
-import { AuthContextProvider } from '../context/AuthContext';
-import { ModalProvider } from '../context/ModalContext';
-import { lagSaksbehandler } from './testdata/saksbehandlerTestdata';
-import { FeatureTogglesProvider } from '../context/FeatureTogglesContext';
-import { HttpContextProvider } from '../context/HttpContext';
-import { SaksbehandlerProvider } from '../context/SaksbehandlerContext';
-import type { FeatureToggles } from '../typer/featureToggles';
-import type { Saksbehandler } from '../typer/saksbehandler';
 import { skruPåAlleToggles } from './mocks/handlers/featureToggleHandlers';
+import { lagSaksbehandler } from './testdata/saksbehandlerTestdata';
 
 function lagQueryClient() {
     return new QueryClient({
@@ -50,7 +51,9 @@ export function TestProviders({
                         <FeatureTogglesProvider featureToggles={featureToggles}>
                             <AppProvider>
                                 <ModalProvider>
-                                    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+                                    <ToastProvider>
+                                        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+                                    </ToastProvider>
                                 </ModalProvider>
                             </AppProvider>
                         </FeatureTogglesProvider>


### PR DESCRIPTION
### 📮 Favro
NAV-29011

### 💰 Hva skal gjøres, og hvorfor?
Flytter toast-staten fra AppContext til en egen ToastContext.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 