### PR TITLE
NAV-29334: Fjerner props fra komponenter som brukes av Routes

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingRouter.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingRouter.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 
+import { TidslinjeProvider } from '@komponenter/Tidslinje/TidslinjeContext';
+import { hentSideHref } from '@utils/miljø';
 import { Route, Routes, useLocation } from 'react-router';
 
 import { useBehandlingContext } from './context/BehandlingContext';
@@ -10,16 +12,14 @@ import { type SideId, sider } from './sider/sider';
 import Simulering from './sider/Simulering/Simulering';
 import { SimuleringProvider } from './sider/Simulering/SimuleringContext';
 import { FeilutbetaltValutaTabellProvider } from './sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabellContext';
+import { RefusjonEøsTabellProvider } from './sider/Vedtak/RefusjonEøs/RefusjonEøsTabellContext';
 import { SammensattKontrollsakProvider } from './sider/Vedtak/SammensattKontrollsak/SammensattKontrollsakContext';
 import { Vedtak } from './sider/Vedtak/Vedtak';
 import { Vilkårsvurdering } from './sider/Vilkårsvurdering/Vilkårsvurdering';
 import { VilkårsvurderingProvider } from './sider/Vilkårsvurdering/VilkårsvurderingContext';
-import { TidslinjeProvider } from '../../../komponenter/Tidslinje/TidslinjeContext';
-import { hentSideHref } from '../../../utils/miljø';
-import { RefusjonEøsTabellProvider } from './sider/Vedtak/RefusjonEøs/RefusjonEøsTabellContext';
 
 export function BehandlingRouter() {
-    const { behandling, leggTilBesøktSide } = useBehandlingContext();
+    const { leggTilBesøktSide } = useBehandlingContext();
 
     const location = useLocation();
 
@@ -36,7 +36,7 @@ export function BehandlingRouter() {
             <Route
                 path="/registrer-soknad"
                 element={
-                    <SøknadProvider åpenBehandling={behandling}>
+                    <SøknadProvider>
                         <RegistrerSøknad />
                     </SøknadProvider>
                 }
@@ -44,7 +44,7 @@ export function BehandlingRouter() {
             <Route
                 path="/vilkaarsvurdering"
                 element={
-                    <VilkårsvurderingProvider åpenBehandling={behandling}>
+                    <VilkårsvurderingProvider>
                         <Vilkårsvurdering />
                     </VilkårsvurderingProvider>
                 }
@@ -53,15 +53,15 @@ export function BehandlingRouter() {
                 path="/tilkjent-ytelse"
                 element={
                     <TidslinjeProvider>
-                        <Behandlingsresultat åpenBehandling={behandling} />
+                        <Behandlingsresultat />
                     </TidslinjeProvider>
                 }
             />
             <Route
                 path="/simulering"
                 element={
-                    <SimuleringProvider åpenBehandling={behandling}>
-                        <Simulering åpenBehandling={behandling} />
+                    <SimuleringProvider>
+                        <Simulering />
                     </SimuleringProvider>
                 }
             />
@@ -70,7 +70,7 @@ export function BehandlingRouter() {
                 element={
                     <FeilutbetaltValutaTabellProvider>
                         <RefusjonEøsTabellProvider>
-                            <SammensattKontrollsakProvider åpenBehandling={behandling}>
+                            <SammensattKontrollsakProvider>
                                 <Vedtak />
                             </SammensattKontrollsakProvider>
                         </RefusjonEøsTabellProvider>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Behandlingsresultat.tsx
@@ -4,7 +4,7 @@ import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsakId } from '@hooks/useFagsakId';
 import { useOppdaterBehandlingsresultat } from '@hooks/useOppdaterBehandlingsresultat';
 import { useTidslinjeContext } from '@komponenter/Tidslinje/TidslinjeContext';
-import { BehandlingResultat, BehandlingSteg, BehandlingÅrsak, type IBehandling } from '@typer/behandling';
+import { BehandlingResultat, BehandlingSteg, BehandlingÅrsak } from '@typer/behandling';
 import { type IRestKompetanse, type IRestUtenlandskPeriodeBeløp, type IRestValutakurs } from '@typer/eøsPerioder';
 import { formaterIdent, slåSammenListeTilStreng } from '@utils/formatter';
 import { useNavigate } from 'react-router';
@@ -55,12 +55,8 @@ const StyledErrorSummary = styled(ErrorSummary)`
     margin-top: 5rem;
 `;
 
-interface IBehandlingsresultatProps {
-    åpenBehandling: IBehandling;
-}
-
-const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => {
-    const { settÅpenBehandling } = useBehandlingContext();
+const Behandlingsresultat = () => {
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
 
     const fagsakId = useFagsakId();
     const erLesevisning = useErLesevisning();
@@ -74,7 +70,7 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
         settVisFeilmeldinger,
         hentPersonerMedUgyldigEtterbetalingsperiode,
         personerMedUgyldigEtterbetalingsperiode,
-    } = useBehandlingContextsresultat(åpenBehandling);
+    } = useBehandlingContextsresultat(behandling);
 
     const {
         mutate: oppdaterBehandlingsresultat,
@@ -104,44 +100,44 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
         valutakurser,
         erValutakurserGyldige,
         hentValutakurserMedFeil,
-    } = useEøs(åpenBehandling);
+    } = useEøs(behandling);
 
     useEffect(() => {
         hentPersonerMedUgyldigEtterbetalingsperiode();
-    }, [åpenBehandling]);
+    }, [behandling]);
 
     const grunnlagPersoner = filterOgSorterGrunnlagPersonerMedAndeler(
-        åpenBehandling.personer,
-        åpenBehandling.personerMedAndelerTilkjentYtelse
+        behandling.personer,
+        behandling.personerMedAndelerTilkjentYtelse
     );
     const tidslinjePersoner = filterOgSorterAndelPersonerIGrunnlag(
         grunnlagPersoner,
-        åpenBehandling.personerMedAndelerTilkjentYtelse
+        behandling.personerMedAndelerTilkjentYtelse
     );
 
-    const harKompetanser = åpenBehandling.kompetanser?.length > 0;
-    const harUtenlandskeBeløper = åpenBehandling.utenlandskePeriodebeløp?.length > 0;
-    const harValutakurser = åpenBehandling.utenlandskePeriodebeløp?.length > 0;
+    const harKompetanser = behandling.kompetanser?.length > 0;
+    const harUtenlandskeBeløper = behandling.utenlandskePeriodebeløp?.length > 0;
+    const harValutakurser = behandling.utenlandskePeriodebeløp?.length > 0;
 
     const harEøs = harKompetanser || harUtenlandskeBeløper || harValutakurser;
 
     const skalViseNesteKnapp =
-        åpenBehandling.årsak !== BehandlingÅrsak.LOVENDRING_2024 ||
-        åpenBehandling.stegTilstand.some(steg => steg.behandlingSteg === BehandlingSteg.SIMULERING);
+        behandling.årsak !== BehandlingÅrsak.LOVENDRING_2024 ||
+        behandling.stegTilstand.some(steg => steg.behandlingSteg === BehandlingSteg.SIMULERING);
 
     return (
         <Skjemasteg
             senderInn={oppdaterBehandlingsresultatIsPending}
             tittel="Behandlingsresultat"
             className="behandlingsresultat"
-            forrigeOnClick={() => navigate(`/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/vilkaarsvurdering`)}
+            forrigeOnClick={() => navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/vilkaarsvurdering`)}
             nesteOnClick={() => {
                 if (erLesevisning) {
-                    navigate(`/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/simulering`);
+                    navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/simulering`);
                 } else if (harEøs && !erEøsInformasjonGyldig()) {
                     settVisFeilmeldinger(true);
                 } else {
-                    oppdaterBehandlingsresultat({ behandlingId: åpenBehandling.behandlingId });
+                    oppdaterBehandlingsresultat({ behandlingId: behandling.behandlingId });
                 }
             }}
             maxWidthStyle={'80rem'}
@@ -149,7 +145,7 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
             steg={BehandlingSteg.BEHANDLINGSRESULTAT}
             skalViseNesteKnapp={skalViseNesteKnapp}
         >
-            <FulltidBarnehageplassAugust2024Alert utbetalingsperioder={åpenBehandling.utbetalingsperioder} />
+            <FulltidBarnehageplassAugust2024Alert utbetalingsperioder={behandling.utbetalingsperioder} />
             {personerMedUgyldigEtterbetalingsperiode.length > 0 && (
                 <Box marginBlock={'space-0 space-16'}>
                     <LocalAlert status="warning">
@@ -178,21 +174,21 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
             )}
             {aktivEtikett && (
                 <Oppsummeringsboks
-                    åpenBehandling={åpenBehandling}
+                    åpenBehandling={behandling}
                     aktivEtikett={aktivEtikett}
                     kompetanser={kompetanser}
                     utbetaltAnnetLandBeløp={utbetaltAnnetLandBeløp}
                     valutakurser={valutakurser}
                 />
             )}
-            {åpenBehandling.endretUtbetalingAndeler.length > 0 && (
-                <EndretUtbetalingAndelTabell åpenBehandling={åpenBehandling} />
+            {behandling.endretUtbetalingAndeler.length > 0 && (
+                <EndretUtbetalingAndelTabell åpenBehandling={behandling} />
             )}
-            {(åpenBehandling.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024 ||
-                åpenBehandling.overgangsordningAndeler.length > 0) && (
+            {(behandling.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024 ||
+                behandling.overgangsordningAndeler.length > 0) && (
                 <>
-                    <OvergangsordningAndelTabell åpenBehandling={åpenBehandling} />
-                    {åpenBehandling.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024 && !erLesevisning && (
+                    <OvergangsordningAndelTabell åpenBehandling={behandling} />
+                    {behandling.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024 && !erLesevisning && (
                         <OvergangsordningAndel>
                             <Button
                                 variant="primary"
@@ -210,7 +206,7 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
                 <KompetanseSkjema
                     kompetanser={kompetanser}
                     visFeilmeldinger={visFeilmeldinger}
-                    åpenBehandling={åpenBehandling}
+                    åpenBehandling={behandling}
                 />
             )}
             {harUtenlandskeBeløper && (
@@ -218,7 +214,7 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
                     utbetaltAnnetLandBeløp={utbetaltAnnetLandBeløp}
                     erUtbetaltAnnetLandBeløpGyldige={erUtbetaltAnnetLandBeløpGyldige}
                     visFeilmeldinger={visFeilmeldinger}
-                    åpenBehandling={åpenBehandling}
+                    åpenBehandling={behandling}
                 />
             )}
             {harValutakurser && (
@@ -226,7 +222,7 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
                     valutakurser={valutakurser}
                     erValutakurserGyldige={erValutakurserGyldige}
                     visFeilmeldinger={visFeilmeldinger}
-                    åpenBehandling={åpenBehandling}
+                    åpenBehandling={behandling}
                 />
             )}
             {visFeilmeldinger && !erEøsInformasjonGyldig() && (

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/SøknadContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/SøknadContext.tsx
@@ -16,10 +16,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-interface Props extends PropsWithChildren {
-    åpenBehandling: IBehandling;
-}
-
 interface SøknadSkjema {
     barnaMedOpplysninger: IBarnMedOpplysninger[];
     endringAvOpplysningerBegrunnelse: string;
@@ -36,8 +32,8 @@ interface SøknadContextValue {
 
 const SøknadContext = createContext<SøknadContextValue | undefined>(undefined);
 
-export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
-    const { settÅpenBehandling } = useBehandlingContext();
+export const SøknadProvider = ({ children }: PropsWithChildren) => {
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
 
     const fagsak = useFagsak();
     const bruker = useBruker();
@@ -96,10 +92,10 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
     }, [bruker]);
 
     useEffect(() => {
-        if (åpenBehandling.søknadsgrunnlag) {
+        if (behandling.søknadsgrunnlag) {
             settSøknadErLastetFraBackend(true);
             skjema.felter.barnaMedOpplysninger.validerOgSettFelt(
-                åpenBehandling.søknadsgrunnlag.barnaMedOpplysninger.map(
+                behandling.søknadsgrunnlag.barnaMedOpplysninger.map(
                     (barnMedOpplysninger: IBarnMedOpplysningerBackend) => ({
                         ...barnMedOpplysninger,
                         merket: barnMedOpplysninger.inkludertISøknaden,
@@ -107,19 +103,19 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
                 )
             );
 
-            skjema.felter.målform.validerOgSettFelt(åpenBehandling.søknadsgrunnlag.søkerMedOpplysninger.målform);
+            skjema.felter.målform.validerOgSettFelt(behandling.søknadsgrunnlag.søkerMedOpplysninger.målform);
             skjema.felter.endringAvOpplysningerBegrunnelse.validerOgSettFelt(
-                åpenBehandling.søknadsgrunnlag.endringAvOpplysningerBegrunnelse
+                behandling.søknadsgrunnlag.endringAvOpplysningerBegrunnelse
             );
         } else {
             // Ny behandling er lastet som ikke har fullført søknad-steget.
             tilbakestillSøknad();
         }
-    }, [åpenBehandling]);
+    }, [behandling]);
 
     const nesteAction = (bekreftEndringerViaFrontend: boolean) => {
         if (erLesevisning) {
-            navigate(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/vilkaarsvurdering`);
+            navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
         } else {
             onSubmit<IRestRegistrerSøknad>(
                 {
@@ -141,12 +137,12 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
                         },
                         bekreftEndringerViaFrontend,
                     },
-                    url: `/familie-ks-sak/api/behandlinger/${åpenBehandling.behandlingId}/steg/registrer-søknad`,
+                    url: `/familie-ks-sak/api/behandlinger/${behandling.behandlingId}/steg/registrer-søknad`,
                 },
                 (response: Ressurs<IBehandling>) => {
                     if (response.status === RessursStatus.SUKSESS) {
                         settÅpenBehandling(response);
-                        navigate(`/fagsak/${fagsak.id}/${åpenBehandling.behandlingId}/vilkaarsvurdering`);
+                        navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
                     }
                 }
             );

--- a/src/frontend/sider/Fagsak/Behandling/sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Simulering/Simulering.tsx
@@ -18,11 +18,7 @@ import TilbakekrevingSkjema from './TilbakekrevingSkjema';
 import Skjemasteg from '../../../../../komponenter/Skjemasteg/Skjemasteg';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-interface ISimuleringProps {
-    åpenBehandling: IBehandling;
-}
-
-const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
+const Simulering = () => {
     const {
         hentSkjemadata,
         onSubmit,
@@ -32,26 +28,26 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
         erFeilutbetaling,
     } = useSimuleringContext();
 
-    const { settÅpenBehandling } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
 
     const fagsakId = useFagsakId();
     const erLesevisning = useErLesevisning();
     const navigate = useNavigate();
 
     const nesteOnClick = () => {
-        if (erLesevisning || åpenBehandling?.resultat == BehandlingResultat.AVSLÅTT) {
-            navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/vedtak`);
+        if (erLesevisning || behandling.resultat == BehandlingResultat.AVSLÅTT) {
+            navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/vedtak`);
         } else {
             onSubmit<ITilbakekreving | undefined>(
                 {
                     data: hentSkjemadata(),
                     method: 'POST',
-                    url: `/familie-ks-sak/api/behandlinger/${åpenBehandling.behandlingId}/steg/simulering`,
+                    url: `/familie-ks-sak/api/behandlinger/${behandling.behandlingId}/steg/simulering`,
                 },
                 (ressurs: Ressurs<IBehandling>) => {
                     if (ressurs.status === RessursStatus.SUKSESS) {
                         settÅpenBehandling(ressurs);
-                        navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/vedtak`);
+                        navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/vedtak`);
                     }
                 }
             );
@@ -59,7 +55,7 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
     };
 
     const forrigeOnClick = () => {
-        navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/tilkjent-ytelse`);
+        navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/tilkjent-ytelse`);
     };
 
     if (
@@ -92,7 +88,7 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
                         <SimuleringTabell simulering={simuleringsresultat.data} />
                         {erFeilutbetaling && (
                             <TilbakekrevingSkjema
-                                søkerMålform={hentSøkersMålform(åpenBehandling)}
+                                søkerMålform={hentSøkersMålform(behandling)}
                                 harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
                             />
                         )}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Simulering/SimuleringContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Simulering/SimuleringContext.tsx
@@ -1,5 +1,15 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useFagsakId } from '@hooks/useFagsakId';
+import type { IBehandling } from '@typer/behandling';
+import {
+    type ISimuleringDTO,
+    type ISimuleringPeriode,
+    type ITilbakekreving,
+    Tilbakekrevingsvalg,
+} from '@typer/simulering';
+import { isoStringTilDateMedFallback, tidenesMorgen } from '@utils/dato';
 import { isAfter } from 'date-fns';
 
 import { type FamilieRequestConfig, useHttp } from '@navikt/familie-http';
@@ -7,20 +17,6 @@ import type { Avhengigheter, FeiloppsummeringFeil, ISkjema } from '@navikt/famil
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
-
-import { useFagsakId } from '../../../../../hooks/useFagsakId';
-import type { IBehandling } from '../../../../../typer/behandling';
-import {
-    type ISimuleringDTO,
-    type ISimuleringPeriode,
-    type ITilbakekreving,
-    Tilbakekrevingsvalg,
-} from '../../../../../typer/simulering';
-import { isoStringTilDateMedFallback, tidenesMorgen } from '../../../../../utils/dato';
-
-interface IProps extends PropsWithChildren {
-    åpenBehandling: IBehandling;
-}
 
 interface Tilbakekrevingsskjema {
     tilbakekrevingsvalg: Tilbakekrevingsvalg | undefined;
@@ -45,10 +41,11 @@ interface SimuleringContextValue {
 
 const SimuleringContext = createContext<SimuleringContextValue | undefined>(undefined);
 
-export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
+export const SimuleringProvider = ({ children }: PropsWithChildren) => {
     const { request } = useHttp();
 
     const fagsakId = useFagsakId();
+    const behandling = useBehandling();
 
     const [simuleringsresultat, settSimuleringresultat] = useState<Ressurs<ISimuleringDTO>>({
         status: RessursStatus.HENTER,
@@ -60,12 +57,12 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
 
     const maksLengdeTekst = 1500;
 
-    const vedtak = åpenBehandling.vedtak;
+    const vedtak = behandling.vedtak;
 
     useEffect(() => {
         request<IBehandling, ISimuleringDTO>({
             method: 'GET',
-            url: `/familie-ks-sak/api/behandlinger/${åpenBehandling.behandlingId}/simulering`,
+            url: `/familie-ks-sak/api/behandlinger/${behandling.behandlingId}/simulering`,
             påvirkerSystemLaster: true,
         }).then(response =>
             response.status === RessursStatus.SUKSESS
@@ -83,7 +80,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
                   })
                 : settSimuleringresultat(response)
         );
-    }, [åpenBehandling]);
+    }, [behandling]);
 
     useEffect(() => {
         if (erFeilutbetaling) {
@@ -104,7 +101,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
     const erFeilutbetaling = simResultat && simResultat.feilutbetaling > 0;
 
     const tilbakekrevingsvalg = useFelt<Tilbakekrevingsvalg | undefined>({
-        verdi: åpenBehandling.tilbakekreving?.valg,
+        verdi: behandling.tilbakekreving?.valg,
         avhengigheter: {
             erFeilutbetaling,
             harÅpenTilbakekreving,
@@ -119,7 +116,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
                 : ok(felt),
     });
     const fritekstVarsel = useFelt<string>({
-        verdi: åpenBehandling.tilbakekreving?.varsel ?? '',
+        verdi: behandling.tilbakekreving?.varsel ?? '',
         avhengigheter: {
             tilbakekreving: tilbakekrevingsvalg,
             erFeilutbetaling,
@@ -138,7 +135,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
             avhengigheter?.tilbakekreving?.verdi === Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL,
     });
     const begrunnelse = useFelt<string>({
-        verdi: åpenBehandling.tilbakekreving?.begrunnelse ?? '',
+        verdi: behandling.tilbakekreving?.begrunnelse ?? '',
         avhengigheter: {
             erFeilutbetaling,
             maksLengdeTekst: maksLengdeTekst,

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/SammensattKontrollsak/SammensattKontrollsakContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/SammensattKontrollsak/SammensattKontrollsakContext.tsx
@@ -8,28 +8,20 @@ import {
     useState,
 } from 'react';
 
-import { useHttp } from '@navikt/familie-http';
-import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
-
-import { useFeatureToggles } from '../../../../../../hooks/useFeatureToggles';
-import {
-    Behandlingstype,
-    erBehandlingAvslått,
-    erBehandlingFortsattInnvilget,
-    type IBehandling,
-} from '../../../../../../typer/behandling';
-import { FeatureToggle } from '../../../../../../typer/featureToggles';
+import { useBehandling } from '@hooks/useBehandling';
+import { useFeatureToggles } from '@hooks/useFeatureToggles';
+import { Behandlingstype, erBehandlingAvslått, erBehandlingFortsattInnvilget } from '@typer/behandling';
+import { FeatureToggle } from '@typer/featureToggles';
 import type {
     OppdaterSammensattKontrollsakDto,
     OpprettSammensattKontrollsakDto,
     SammensattKontrollsakDto,
     SlettSammensattKontrollsakDto,
-} from '../../../../../../typer/sammensatt-kontrollsak';
-import { erDefinert } from '../../../../../../utils/commons';
+} from '@typer/sammensatt-kontrollsak';
+import { erDefinert } from '@utils/commons';
 
-interface ISammensattKontrollsakProps extends PropsWithChildren {
-    åpenBehandling: IBehandling;
-}
+import { useHttp } from '@navikt/familie-http';
+import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 interface SammensattKontrollsakContextValue {
     opprettEllerOppdaterSammensattKontrollsak: (fritekst: string) => void;
@@ -43,8 +35,8 @@ interface SammensattKontrollsakContextValue {
 
 const SammensattKontrollsakContext = createContext<SammensattKontrollsakContextValue | undefined>(undefined);
 
-export const SammensattKontrollsakProvider = ({ åpenBehandling, children }: ISammensattKontrollsakProps) => {
-    const { behandlingId, type, resultat } = åpenBehandling;
+export const SammensattKontrollsakProvider = ({ children }: PropsWithChildren) => {
+    const { behandlingId, type, resultat } = useBehandling();
     const { request } = useHttp();
     const toggles = useFeatureToggles();
     const [feilmelding, settFeilmelding] = useState<string | undefined>(undefined);

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/VilkårsvurderingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/VilkårsvurderingContext.tsx
@@ -1,15 +1,12 @@
 import { createContext, type PropsWithChildren, useContext } from 'react';
 
+import { hentFeilIVilkårsvurdering } from '@context/Vilkårsvurdering/hentFeilIVilkårsvurdering';
+import { useBehandling } from '@hooks/useBehandling';
+import type { IPersonResultat, IRestPersonResultat } from '@typer/vilkår';
+
 import type { FeiloppsummeringFeil } from '@navikt/familie-skjema';
 
 import { mapFraRestVilkårsvurderingTilUi } from './utils';
-import { hentFeilIVilkårsvurdering } from '../../../../../context/Vilkårsvurdering/hentFeilIVilkårsvurdering';
-import type { IBehandling } from '../../../../../typer/behandling';
-import type { IPersonResultat, IRestPersonResultat } from '../../../../../typer/vilkår';
-
-interface IProps extends PropsWithChildren {
-    åpenBehandling: IBehandling;
-}
 
 interface VilkårsvurderingContextValue {
     feiloppsummeringFeil: FeiloppsummeringFeil[];
@@ -19,12 +16,14 @@ interface VilkårsvurderingContextValue {
 
 const VilkårsvurderingContext = createContext<VilkårsvurderingContextValue | undefined>(undefined);
 
-export function VilkårsvurderingProvider({ åpenBehandling, children }: IProps) {
-    const vilkårsvurdering = åpenBehandling
-        ? mapFraRestVilkårsvurderingTilUi(åpenBehandling.personResultater, åpenBehandling.personer)
+export function VilkårsvurderingProvider({ children }: PropsWithChildren) {
+    const behandling = useBehandling();
+
+    const vilkårsvurdering = behandling
+        ? mapFraRestVilkårsvurderingTilUi(behandling.personResultater, behandling.personer)
         : [];
 
-    const personResultater = åpenBehandling.personResultater;
+    const personResultater = behandling.personResultater;
 
     const feiloppsummeringFeil: FeiloppsummeringFeil[] = hentFeilIVilkårsvurdering(vilkårsvurdering);
 

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -1,4 +1,11 @@
-import { Navigate, Route, Routes } from 'react-router';
+import { useFagsakIdParam } from '@hooks/useFagsakIdParam';
+import { useHentFagsak } from '@hooks/useHentFagsak';
+import { useHentPerson } from '@hooks/useHentPerson';
+import { useScrollTilAnker } from '@hooks/useScrollTilAnker';
+import { Personlinje } from '@komponenter/Personlinje/Personlinje';
+import { Fagsaklinje } from '@komponenter/Saklinje/Fagsaklinje';
+import { RedirectTilSaksoversikt } from '@sider/Fagsak/Saksoversikt/RedirectTilSaksoversikt';
+import { Route, Routes } from 'react-router';
 
 import { Box, GlobalAlert, HStack, Loader } from '@navikt/ds-react';
 
@@ -12,12 +19,6 @@ import { FagsakProvider } from './FagsakContext';
 import { JournalpostListe } from './journalposter/JournalpostListe';
 import { ManuelleBrevmottakerePåFagsakProvider } from './ManuelleBrevmottakerePåFagsakContext';
 import { Saksoversikt } from './Saksoversikt/Saksoversikt';
-import { useFagsakIdParam } from '../../hooks/useFagsakIdParam';
-import { useHentFagsak } from '../../hooks/useHentFagsak';
-import { useHentPerson } from '../../hooks/useHentPerson';
-import { useScrollTilAnker } from '../../hooks/useScrollTilAnker';
-import { Personlinje } from '../../komponenter/Personlinje/Personlinje';
-import { Fagsaklinje } from '../../komponenter/Saklinje/Fagsaklinje';
 
 export function FagsakContainer() {
     const fagsakIdParam = useFagsakIdParam();
@@ -120,7 +121,7 @@ export function FagsakContainer() {
                                     </HentOgSettBehandlingProvider>
                                 }
                             />
-                            <Route path="/" element={<Navigate to={`/fagsak/${fagsak.id}/saksoversikt`} />} />
+                            <Route path="/" element={<RedirectTilSaksoversikt />} />
                         </Routes>
                     </ManuelleBrevmottakerePåFagsakProvider>
                 </BrukerProvider>

--- a/src/frontend/sider/Fagsak/Saksoversikt/RedirectTilSaksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/RedirectTilSaksoversikt.tsx
@@ -1,0 +1,7 @@
+import { useFagsakId } from '@hooks/useFagsakId';
+import { Navigate } from 'react-router';
+
+export function RedirectTilSaksoversikt() {
+    const fagsakId = useFagsakId();
+    return <Navigate to={`/fagsak/${fagsakId}/saksoversikt`} replace={true} />;
+}


### PR DESCRIPTION
### 📮 Favro
NAV-29334

### 💰 Hva skal gjøres, og hvorfor?
Fjerner props fra komponenter som brukes av Routes. Det vil gjøre det lettere å skrive om til `createBrowserRouter` senere. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
Ingen visuelle endringer. 