### PR TITLE
Samkjør api for begrunnelser og fritekster lik BA-sak

### DIFF
--- a/src/frontend/api/client/apiClient.test.ts
+++ b/src/frontend/api/client/apiClient.test.ts
@@ -44,7 +44,7 @@ describe('ApiClient', () => {
                     http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
                 );
 
-                await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+                await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
             }
         );
     });
@@ -76,7 +76,7 @@ describe('ApiClient', () => {
                     http.post(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
                 );
 
-                await expect(client.post({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+                await expect(client.post({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
             }
         );
     });
@@ -98,7 +98,7 @@ describe('ApiClient', () => {
                     http.put(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
                 );
 
-                await expect(client.put({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+                await expect(client.put({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
             }
         );
     });
@@ -120,7 +120,7 @@ describe('ApiClient', () => {
                     http.patch(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
                 );
 
-                await expect(client.patch({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+                await expect(client.patch({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
             }
         );
     });
@@ -142,7 +142,7 @@ describe('ApiClient', () => {
                     )
                 );
 
-                await expect(client.delete({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+                await expect(client.delete({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
             }
         );
     });
@@ -155,7 +155,7 @@ describe('ApiClient', () => {
                 )
             );
 
-            await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt (CallId: abc-123)');
+            await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt (CallId: abc-123)');
         });
 
         test('utelater callId fra feilmeldingen når den er null', async () => {
@@ -165,7 +165,7 @@ describe('ApiClient', () => {
                 )
             );
 
-            await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+            await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
         });
 
         test('utelater callId fra feilmeldingen når den mangler i responsen', async () => {
@@ -173,7 +173,7 @@ describe('ApiClient', () => {
                 http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs('FEILET', 'Noe gikk galt')))
             );
 
-            await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+            await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
         });
     });
 

--- a/src/frontend/api/client/apiClient.ts
+++ b/src/frontend/api/client/apiClient.ts
@@ -85,13 +85,16 @@ export class ApiClient {
     }
 
     private resolveToPromise<T>(ressurs: Ressurs<T>): Promise<T> {
+        if (!Object.values(RessursStatus).includes(ressurs.status)) {
+            return Promise.reject(new Error(`Ukjent status: ${ressurs.status}`));
+        }
         switch (ressurs.status) {
             case RessursStatus.SUKSESS:
                 return Promise.resolve(ressurs.data);
             case RessursStatus.FEILET:
             case RessursStatus.FUNKSJONELL_FEIL:
             case RessursStatus.IKKE_TILGANG:
-                const frontendFeilmelding = ressurs.frontendFeilmelding ?? ressurs.melding;
+                const frontendFeilmelding = ressurs.frontendFeilmelding?.trim() ?? undefined;
                 const frontendFeilmeldingMedEllerUtenCallId = ressurs.callId
                     ? `${frontendFeilmelding} (CallId: ${ressurs.callId})`
                     : frontendFeilmelding;

--- a/src/frontend/api/client/apiClient.ts
+++ b/src/frontend/api/client/apiClient.ts
@@ -91,10 +91,11 @@ export class ApiClient {
             case RessursStatus.FEILET:
             case RessursStatus.FUNKSJONELL_FEIL:
             case RessursStatus.IKKE_TILGANG:
+                const frontendFeilmelding = ressurs.frontendFeilmelding ?? ressurs.melding;
                 const frontendFeilmeldingMedEllerUtenCallId = ressurs.callId
-                    ? `${ressurs.frontendFeilmelding} (CallId: ${ressurs.callId})`
-                    : ressurs.frontendFeilmelding;
-                return Promise.reject(frontendFeilmeldingMedEllerUtenCallId);
+                    ? `${frontendFeilmelding} (CallId: ${ressurs.callId})`
+                    : frontendFeilmelding;
+                return Promise.reject(new Error(frontendFeilmeldingMedEllerUtenCallId));
         }
     }
 }

--- a/src/frontend/api/hentVedtaksperioder.ts
+++ b/src/frontend/api/hentVedtaksperioder.ts
@@ -1,0 +1,8 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
+
+export async function hentVedtaksperioder(behandlingId: number): Promise<IVedtaksperiodeMedBegrunnelser[]> {
+    return apiClient.get<void, IVedtaksperiodeMedBegrunnelser[]>({
+        url: `/familie-ks-sak/api/vedtaksperioder/behandling/${behandlingId}/hent-vedtaksperioder`,
+    });
+}

--- a/src/frontend/api/oppdaterVedtaksperiodeMedBegrunnelser.ts
+++ b/src/frontend/api/oppdaterVedtaksperiodeMedBegrunnelser.ts
@@ -1,23 +1,17 @@
-import type { IBehandling } from '@typer/behandling';
+import { apiClient } from '@api/client/apiClient';
 import type { Begrunnelse } from '@typer/vedtak';
-
-import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
-
-import { RessursResolver } from '../utils/ressursResolver';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
 
 interface Payload {
     begrunnelser: Begrunnelse[];
 }
 
 export async function oppdaterVedtaksperiodeMedBegrunnelser(
-    request: FamilieRequest,
     vedtaksperiodeMedBegrunnelserId: number,
     payload: Payload
-) {
-    const ressurs = await request<Payload, IBehandling>({
-        method: 'PUT',
+): Promise<IVedtaksperiodeMedBegrunnelser[]> {
+    return apiClient.put<Payload, IVedtaksperiodeMedBegrunnelser[]>({
         url: `/familie-ks-sak/api/vedtaksperioder/begrunnelser/${vedtaksperiodeMedBegrunnelserId}`,
         data: payload,
     });
-    return RessursResolver.resolveToPromise(ressurs);
 }

--- a/src/frontend/api/oppdaterVedtaksperiodeMedFritekster.ts
+++ b/src/frontend/api/oppdaterVedtaksperiodeMedFritekster.ts
@@ -1,22 +1,16 @@
-import type { IBehandling } from '@typer/behandling';
-
-import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
-
-import { RessursResolver } from '../utils/ressursResolver';
+import { apiClient } from '@api/client/apiClient';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
 
 export interface Payload {
     fritekster: string[];
 }
 
 export async function oppdaterVedtaksperiodeMedFritekster(
-    request: FamilieRequest,
     vedtaksperiodeMedBegrunnelserId: number,
     payload: Payload
-) {
-    const ressurs = await request<Payload, IBehandling>({
-        method: 'PUT',
+): Promise<IVedtaksperiodeMedBegrunnelser[]> {
+    return apiClient.put<Payload, IVedtaksperiodeMedBegrunnelser[]>({
         url: `/familie-ks-sak/api/vedtaksperioder/fritekster/${vedtaksperiodeMedBegrunnelserId}`,
         data: payload,
     });
-    return RessursResolver.resolveToPromise(ressurs);
 }

--- a/src/frontend/hooks/useHentVedtaksperioder.ts
+++ b/src/frontend/hooks/useHentVedtaksperioder.ts
@@ -1,0 +1,15 @@
+import { hentVedtaksperioder } from '@api/hentVedtaksperioder';
+import { MetaKey } from '@hooks/meta/metaKey';
+import { useQuery } from '@tanstack/react-query';
+
+export const HentVedtaksperioderQueryKeyFactory = {
+    behandling: (behandlingId: number) => ['vedtaksperioder', behandlingId],
+};
+
+export function useHentVedtaksperioder(behandlingId: number) {
+    return useQuery({
+        queryKey: HentVedtaksperioderQueryKeyFactory.behandling(behandlingId),
+        queryFn: () => hentVedtaksperioder(behandlingId),
+        meta: { [MetaKey.VIS_SYSTEMET_LASTER]: true },
+    });
+}

--- a/src/frontend/hooks/useOppdaterVedtaksperiodeMedBegrunnelser.ts
+++ b/src/frontend/hooks/useOppdaterVedtaksperiodeMedBegrunnelser.ts
@@ -1,13 +1,7 @@
 import { oppdaterVedtaksperiodeMedBegrunnelser } from '@api/oppdaterVedtaksperiodeMedBegrunnelser';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
-import type { IBehandling } from '@typer/behandling';
 import type { Begrunnelse } from '@typer/vedtak';
-
-import { useHttp } from '@navikt/familie-http';
-
-interface Parameters {
-    begrunnelser: Begrunnelse[];
-}
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
 
 export const OppdaterVedtaksperiodeMedBegrunnelserMutationKeyFactory = {
     vedtaksperiodeMedBegrunnelser: (vedtaksperiodeMedBegrunnelserId: number) => [
@@ -16,15 +10,17 @@ export const OppdaterVedtaksperiodeMedBegrunnelserMutationKeyFactory = {
     ],
 };
 
-type Options = Omit<UseMutationOptions<IBehandling, DefaultError, Parameters>, 'mutationFn'>;
+type Options = Omit<UseMutationOptions<IVedtaksperiodeMedBegrunnelser[], DefaultError, Parameters>, 'mutationFn'>;
+
+interface Parameters {
+    begrunnelser: Begrunnelse[];
+}
 
 export function useOppdaterVedtaksperiodeMedBegrunnelser(vedtaksperiodeMedBegrunnelserId: number, options?: Options) {
-    const { request } = useHttp();
     return useMutation({
         mutationFn: (parameters: Parameters) => {
             const { begrunnelser } = parameters;
-            const payload = { begrunnelser };
-            return oppdaterVedtaksperiodeMedBegrunnelser(request, vedtaksperiodeMedBegrunnelserId, payload);
+            return oppdaterVedtaksperiodeMedBegrunnelser(vedtaksperiodeMedBegrunnelserId, { begrunnelser });
         },
         mutationKey: OppdaterVedtaksperiodeMedBegrunnelserMutationKeyFactory.vedtaksperiodeMedBegrunnelser(
             vedtaksperiodeMedBegrunnelserId

--- a/src/frontend/hooks/useOppdaterVedtaksperiodeMedFritekster.ts
+++ b/src/frontend/hooks/useOppdaterVedtaksperiodeMedFritekster.ts
@@ -1,8 +1,6 @@
 import { oppdaterVedtaksperiodeMedFritekster } from '@api/oppdaterVedtaksperiodeMedFritekster';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
-import type { IBehandling } from '@typer/behandling';
-
-import { useHttp } from '@navikt/familie-http';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
 
 export const OppdaterVedtaksperiodeMedFriteksterMutationKeyFactory = {
     vedtaksperiodeMedFritekster: (vedtaksperiodeMedBegrunnelserId: number) => [
@@ -11,19 +9,17 @@ export const OppdaterVedtaksperiodeMedFriteksterMutationKeyFactory = {
     ],
 };
 
-type Options = Omit<UseMutationOptions<IBehandling, DefaultError, Parameters>, 'mutationFn'>;
+type Options = Omit<UseMutationOptions<IVedtaksperiodeMedBegrunnelser[], DefaultError, Parameters>, 'mutationFn'>;
 
 interface Parameters {
     fritekster: string[];
 }
 
 export function useOppdaterVedtaksperiodeMedFritekster(vedtaksperiodeMedBegrunnelserId: number, options?: Options) {
-    const { request } = useHttp();
     return useMutation({
         mutationFn: (parameters: Parameters) => {
             const { fritekster } = parameters;
-            const payload = { fritekster };
-            return oppdaterVedtaksperiodeMedFritekster(request, vedtaksperiodeMedBegrunnelserId, payload);
+            return oppdaterVedtaksperiodeMedFritekster(vedtaksperiodeMedBegrunnelserId, { fritekster });
         },
         mutationKey: OppdaterVedtaksperiodeMedFriteksterMutationKeyFactory.vedtaksperiodeMedFritekster(
             vedtaksperiodeMedBegrunnelserId

--- a/src/frontend/sider/Fagsak/Behandling/BehandlingRoutes.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingRoutes.tsx
@@ -9,6 +9,7 @@ import { FeilutbetaltValutaTabellProvider } from '@sider/Fagsak/Behandling/sider
 import { RefusjonEøsTabellProvider } from '@sider/Fagsak/Behandling/sider/Vedtak/RefusjonEøs/RefusjonEøsTabellContext';
 import { SammensattKontrollsakProvider } from '@sider/Fagsak/Behandling/sider/Vedtak/SammensattKontrollsak/SammensattKontrollsakContext';
 import { Vedtak } from '@sider/Fagsak/Behandling/sider/Vedtak/Vedtak';
+import { VedtaksperioderProvider } from '@sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperioderContext';
 import { Vilkårsvurdering } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/Vilkårsvurdering';
 import { VilkårsvurderingProvider } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/VilkårsvurderingContext';
 import { type RouteObject } from 'react-router';
@@ -52,7 +53,9 @@ export const behandlingRoutes: RouteObject[] = [
             <FeilutbetaltValutaTabellProvider>
                 <RefusjonEøsTabellProvider>
                     <SammensattKontrollsakProvider>
-                        <Vedtak />
+                        <VedtaksperioderProvider>
+                            <Vedtak />
+                        </VedtaksperioderProvider>
                     </SammensattKontrollsakProvider>
                 </RefusjonEøsTabellProvider>
             </FeilutbetaltValutaTabellProvider>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtak.tsx
@@ -12,6 +12,7 @@ import {
     BehandlingÅrsak,
     type IBehandling,
 } from '@typer/behandling';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
 import { useNavigate } from 'react-router';
 
 import { byggSuksessRessurs } from '@navikt/familie-typer';
@@ -20,11 +21,12 @@ import { useFeilutbetaltValutaTabellContext } from './FeilutbetaltValuta/Feilutb
 import OppsummeringVedtakInnhold from './OppsummeringVedtakInnhold';
 import { useRefusjonEøsTabellContext } from './RefusjonEøs/RefusjonEøsTabellContext';
 import { useSammensattKontrollsakContext } from './SammensattKontrollsak/SammensattKontrollsakContext';
+import { useVedtaksperioderContext } from './Vedtaksperioder/VedtaksperioderContext';
 import Skjemasteg from '../../../../../komponenter/Skjemasteg/Skjemasteg';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-function kanForeslåVedtak(behandling: IBehandling) {
-    const minstEnPeriodeHarBegrunnelseEllerFritekst = (behandling.vedtak?.vedtaksperioderMedBegrunnelser ?? []).some(
+function kanForeslåVedtak(behandling: IBehandling, vedtaksperioder: IVedtaksperiodeMedBegrunnelser[]) {
+    const minstEnPeriodeHarBegrunnelseEllerFritekst = vedtaksperioder.some(
         vedtaksperioderMedBegrunnelse =>
             vedtaksperioderMedBegrunnelse.begrunnelser.length !== 0 ||
             vedtaksperioderMedBegrunnelse.eøsBegrunnelser.length !== 0 ||
@@ -44,6 +46,7 @@ export function Vedtak() {
     const { erLeggTilFeilutbetaltValutaFormÅpen } = useFeilutbetaltValutaTabellContext();
     const { erLeggTilRefusjonEøsFormÅpen } = useRefusjonEøsTabellContext();
     const { erSammensattKontrollsak } = useSammensattKontrollsakContext();
+    const { vedtaksperioder } = useVedtaksperioderContext();
 
     const saksbehandler = useSaksbehandler();
     const fagsakId = useFagsakId();
@@ -78,7 +81,7 @@ export function Vedtak() {
             settFeilmelding(
                 'Det er lagt til en ny periode med refusjon EØS. Fyll ut periode og refusjonsbeløp, eller fjern perioden.'
             );
-        } else if (!kanForeslåVedtak(behandling) && !erSammensattKontrollsak) {
+        } else if (!kanForeslåVedtak(behandling, vedtaksperioder) && !erSammensattKontrollsak) {
             settFeilmelding('Vedtaksbrevet mangler begrunnelse. Du må legge til minst én begrunnelse.');
         } else {
             settFeilmelding(undefined);

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
@@ -1,34 +1,29 @@
+import { useBehandlingId } from '@hooks/useBehandlingId';
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { HentGenererteBrevbegrunnelserQueryKeyFactory } from '@hooks/useHentGenererteBrevbegrunnelser';
+import { HentVedtaksperioderQueryKeyFactory } from '@hooks/useHentVedtaksperioder';
 import { useOppdaterVedtaksperiodeMedBegrunnelser } from '@hooks/useOppdaterVedtaksperiodeMedBegrunnelser';
 import { useOppdaterVedtaksperiodeMedFriteksterIsPending } from '@hooks/useOppdaterVedtaksperiodeMedFriteksterIsPending';
-import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
 import { useQueryClient } from '@tanstack/react-query';
 import type { OptionType } from '@typer/common';
 import { type Begrunnelse, type BegrunnelseType, begrunnelseTyper, Standardbegrunnelse } from '@typer/vedtak';
 import { finnBegrunnelseType, hentBakgrunnsfarge, hentBorderfarge } from '@utils/vedtakUtils';
 
 import { BodyShort, Box, Label } from '@navikt/ds-react';
-import {
-    type ActionMeta,
-    FamilieReactSelect,
-    type FormatOptionLabelMeta,
-    type GroupBase,
-    type StylesConfig,
-} from '@navikt/familie-form-elements';
-import { byggSuksessRessurs } from '@navikt/familie-typer';
+import type { ActionMeta, FormatOptionLabelMeta, GroupBase, StylesConfig } from '@navikt/familie-form-elements';
+import { FamilieReactSelect } from '@navikt/familie-form-elements';
 
 import { useAlleBegrunnelserContext } from './AlleBegrunnelserContext';
 import Styles from './BegrunnelserMultiselect.module.css';
-import { grupperteBegrunnelser, mapBegrunnelserTilSelectOptions } from './utils';
+import { grupperBegrunnelser, mapBegrunnelserTilSelectOptions } from './utils';
 import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
 
 export function BegrunnelserMultiselect() {
-    const { settÅpenBehandling } = useBehandlingContext();
     const { vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
     const { alleBegrunnelser } = useAlleBegrunnelserContext();
 
     const queryClient = useQueryClient();
+    const behandlingId = useBehandlingId();
     const erLesevisning = useErLesevisning();
     const oppdaterVedtaksperiodeMedFriteksterIsPending = useOppdaterVedtaksperiodeMedFriteksterIsPending(
         vedtaksperiodeMedBegrunnelser.id
@@ -39,11 +34,14 @@ export function BegrunnelserMultiselect() {
         isPending: oppdaterVedtaksperiodeMedBegrunnelserIsPending,
         error: oppdaterVedtaksperiodeMedBegrunnelserError,
     } = useOppdaterVedtaksperiodeMedBegrunnelser(vedtaksperiodeMedBegrunnelser.id, {
-        onSuccess: async behandling => {
+        onSuccess: async vedtaksperioderMedBegrunnelser => {
             await queryClient.invalidateQueries({
                 queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(vedtaksperiodeMedBegrunnelser.id),
             });
-            settÅpenBehandling(byggSuksessRessurs(behandling));
+            queryClient.setQueryData(
+                HentVedtaksperioderQueryKeyFactory.behandling(behandlingId),
+                vedtaksperioderMedBegrunnelser
+            );
         },
     });
 
@@ -168,7 +166,7 @@ export function BegrunnelserMultiselect() {
                     </Box>
                 );
             }}
-            options={grupperteBegrunnelser(vedtaksperiodeMedBegrunnelser, alleBegrunnelser)}
+            options={grupperBegrunnelser(vedtaksperiodeMedBegrunnelser, alleBegrunnelser)}
         />
     );
 }

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
@@ -8,12 +8,14 @@ import { Heading, HelpText, HStack, VStack } from '@navikt/ds-react';
 import { filtrerOgSorterPerioderMedBegrunnelseBehov } from './utils';
 import { Vedtaksperiode } from './Vedtaksperiode';
 import { VedtaksperiodeProvider } from './VedtaksperiodeContext';
+import { useVedtaksperioderContext } from './VedtaksperioderContext';
 
 export function Vedtaksperioder() {
+    const { vedtaksperioder } = useVedtaksperioderContext();
     const behandling = useBehandling();
 
     const sorterteVedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
-        behandling.vedtak?.vedtaksperioderMedBegrunnelser ?? [],
+        vedtaksperioder,
         behandling.resultat,
         behandling.status,
         behandling.sisteVedtaksperiodeVisningDato

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperioderContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperioderContext.tsx
@@ -1,0 +1,61 @@
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
+
+import { useBehandlingId } from '@hooks/useBehandlingId';
+import { useHentVedtaksperioder } from '@hooks/useHentVedtaksperioder';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
+
+import { BodyShort, Box, ErrorMessage, Loader, LocalAlert, Stack } from '@navikt/ds-react';
+
+interface VedtaksperioderContext {
+    vedtaksperioder: IVedtaksperiodeMedBegrunnelser[];
+}
+
+const VedtaksperioderContext = createContext<VedtaksperioderContext | undefined>(undefined);
+
+export function VedtaksperioderProvider({ children }: PropsWithChildren) {
+    const behandlingId = useBehandlingId();
+
+    const { data, isPending, error } = useHentVedtaksperioder(behandlingId);
+
+    if (isPending) {
+        return (
+            <Box margin={'space-48'}>
+                <Stack direction={'row'} justify={'center'} align={'center'} gap={'space-8'}>
+                    <Loader size={'medium'} />
+                    <BodyShort weight={'semibold'}>Laster vedtaksperioder...</BodyShort>
+                </Stack>
+            </Box>
+        );
+    }
+
+    if (error) {
+        return (
+            <Box margin={'space-48'}>
+                <LocalAlert status={'error'}>
+                    <LocalAlert.Header>
+                        <LocalAlert.Title>En teknisk feil oppstod.</LocalAlert.Title>
+                    </LocalAlert.Header>
+                    <LocalAlert.Content>
+                        <Stack direction={'column'} gap={'space-16'}>
+                            Klarte ikke å hente inn vedtaksperiodene.
+                            <ErrorMessage>{error.message}</ErrorMessage>
+                        </Stack>
+                    </LocalAlert.Content>
+                </LocalAlert>
+            </Box>
+        );
+    }
+
+    return (
+        <VedtaksperioderContext.Provider value={{ vedtaksperioder: data }}>{children}</VedtaksperioderContext.Provider>
+    );
+}
+
+export function useVedtaksperioderContext() {
+    const context = useContext(VedtaksperioderContext);
+    if (context === undefined) {
+        throw new Error('useVedtaksperioderContext må brukes innenfor en VedtaksperioderProvider');
+    }
+    return context;
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/useFritekstbegrunnelserForm.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/useFritekstbegrunnelserForm.ts
@@ -1,16 +1,15 @@
 import { useEffect, useRef } from 'react';
 
+import { useBehandlingId } from '@hooks/useBehandlingId';
 import { useConfirmBrowserRefresh } from '@hooks/useConfirmBrowserRefresh';
 import { HentGenererteBrevbegrunnelserQueryKeyFactory } from '@hooks/useHentGenererteBrevbegrunnelser';
+import { HentVedtaksperioderQueryKeyFactory } from '@hooks/useHentVedtaksperioder';
 import { useOnFormSubmitSuccessful } from '@hooks/useOnFormSubmitSuccessful';
 import { useOppdaterVedtaksperiodeMedFritekster } from '@hooks/useOppdaterVedtaksperiodeMedFritekster';
-import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
 import { MAKS_LENGDE_FRITEKST } from '@sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/Fritekstbegrunnelser';
 import { useVedtaksperiodeContext } from '@sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext';
 import { useQueryClient } from '@tanstack/react-query';
 import { useFieldArray, useForm } from 'react-hook-form';
-
-import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 const NY_FRITEKSTBEGRUNNELSE = { value: '' };
 
@@ -28,9 +27,9 @@ export interface FormValues {
 
 export function useFritekstbegrunnelserForm() {
     const { vedtaksperiodeMedBegrunnelser, settErSkjemaendringer } = useVedtaksperiodeContext();
-    const { settÅpenBehandling } = useBehandlingContext();
 
     const queryClient = useQueryClient();
+    const behandlingId = useBehandlingId();
     const submittedFieldsRef = useRef<Set<string>>(new Set());
 
     const form = useForm<FormValues>({
@@ -65,13 +64,16 @@ export function useFritekstbegrunnelserForm() {
     const { mutateAsync: oppdaterVedtaksperiodeMedFritekster } = useOppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeMedBegrunnelser.id,
         {
-            onSuccess: async behandling => {
+            onSuccess: async vedtaksperioderMedBegrunnelser => {
                 await queryClient.invalidateQueries({
                     queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(
                         vedtaksperiodeMedBegrunnelser.id
                     ),
                 });
-                settÅpenBehandling(byggSuksessRessurs(behandling));
+                queryClient.setQueryData(
+                    HentVedtaksperioderQueryKeyFactory.behandling(behandlingId),
+                    vedtaksperioderMedBegrunnelser
+                );
             },
             onError: error => setError('root', { message: error.message ?? 'En ukjent feil oppstod.' }),
         }

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/utils.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtaksperioder/utils.ts
@@ -18,7 +18,7 @@ import { addMonths, differenceInMilliseconds, isAfter, isBefore, isSameMonth, st
 
 import type { GroupBase, OptionType } from '@navikt/familie-form-elements';
 
-export function grupperteBegrunnelser(
+export function grupperBegrunnelser(
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser,
     alleBegrunnelser: AlleBegrunnelser
 ) {

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -1,11 +1,9 @@
-import type { IVedtaksperiodeMedBegrunnelser } from './vedtaksperiode';
 import type { VilkårType } from './vilkår';
 import type { IsoDatoString } from '../utils/dato';
 
 export interface IVedtakForBehandling {
     aktiv: boolean;
     vedtaksdato: string;
-    vedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBegrunnelser[];
     id: number;
 }
 

--- a/src/frontend/typer/vedtaksperiode.test.ts
+++ b/src/frontend/typer/vedtaksperiode.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest';
+
+import type { IVedtaksperiodeMedBegrunnelser } from './vedtaksperiode';
+import { skalViseFritekstbegrunnelser, Vedtaksperiodetype } from './vedtaksperiode';
+
+function lagVedtaksperiodeMedBegrunnelser(
+    overstyringer: Partial<IVedtaksperiodeMedBegrunnelser> = {}
+): IVedtaksperiodeMedBegrunnelser {
+    return {
+        id: 1,
+        type: Vedtaksperiodetype.UTBETALING,
+        begrunnelser: [],
+        eøsBegrunnelser: [],
+        fritekster: [],
+        gyldigeBegrunnelser: [],
+        utbetalingsperiodeDetaljer: [],
+        støtterFritekst: false,
+        ...overstyringer,
+    };
+}
+
+describe('skalViseFritekstbegrunnelser', () => {
+    test('skal ikke vise fritekst for UTBETALING når ingen begrunnelser støtter fritekst og det ikke finnes fritekster', () => {
+        const vedtaksperiode = lagVedtaksperiodeMedBegrunnelser({
+            type: Vedtaksperiodetype.UTBETALING,
+            støtterFritekst: false,
+            fritekster: [],
+        });
+
+        expect(skalViseFritekstbegrunnelser(vedtaksperiode)).toBe(false);
+    });
+
+    test('skal vise fritekst for UTBETALING når minst én begrunnelse støtter fritekst', () => {
+        const vedtaksperiode = lagVedtaksperiodeMedBegrunnelser({
+            type: Vedtaksperiodetype.UTBETALING,
+            støtterFritekst: true,
+        });
+
+        expect(skalViseFritekstbegrunnelser(vedtaksperiode)).toBe(true);
+    });
+
+    test('skal vise fritekst for UTBETALING når det allerede finnes fritekster', () => {
+        const vedtaksperiode = lagVedtaksperiodeMedBegrunnelser({
+            type: Vedtaksperiodetype.UTBETALING,
+            støtterFritekst: false,
+            fritekster: ['En fritekst'],
+        });
+
+        expect(skalViseFritekstbegrunnelser(vedtaksperiode)).toBe(true);
+    });
+
+    test.each([Vedtaksperiodetype.OPPHØR, Vedtaksperiodetype.AVSLAG, Vedtaksperiodetype.FORTSATT_INNVILGET])(
+        'skal vise fritekst for periodetype %s selv om ingen begrunnelser støtter fritekst',
+        periodetype => {
+            const vedtaksperiode = lagVedtaksperiodeMedBegrunnelser({
+                type: periodetype,
+                støtterFritekst: false,
+                fritekster: [],
+            });
+
+            expect(skalViseFritekstbegrunnelser(vedtaksperiode)).toBe(true);
+        }
+    );
+});

--- a/src/frontend/typer/vedtaksperiode.ts
+++ b/src/frontend/typer/vedtaksperiode.ts
@@ -85,5 +85,13 @@ export const hentVedtaksperiodeTittel = (vedtaksperiodeMedBegrunnelser: IVedtaks
 };
 
 export function skalViseFritekstbegrunnelser(vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser) {
-    return vedtaksperiodeMedBegrunnelser.støtterFritekst || vedtaksperiodeMedBegrunnelser.fritekster.length > 0;
+    const ugyldigeVedtaksperiodetyper = [Vedtaksperiodetype.UTBETALING];
+
+    const harTillattVedtaksperiodetype = !ugyldigeVedtaksperiodetyper.includes(vedtaksperiodeMedBegrunnelser.type);
+
+    return (
+        harTillattVedtaksperiodetype ||
+        vedtaksperiodeMedBegrunnelser.støtterFritekst ||
+        vedtaksperiodeMedBegrunnelser.fritekster.length > 0
+    );
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
  Frontend skal hente og oppdatere vedtaksperioder på samme måte som ba-sak-frontend (vedtaksperioder via react-query, ikke via behandlingen), og saksbehandler skal kunne legge til fritekst og få en feilmelding ved ugyldig kombinasjon i stedet for at friteksten forsvinner.
  
  - **Ny datakilde for vedtaksperioder:** Ny `hentVedtaksperioder` + `useHentVedtaksperioder` (query-key-factory + `VIS_SYSTEMET_LASTER`-meta) mot det nye GET-endepunktet. Ny
  `VedtaksperioderProvider` montert på vedtak-ruten i `BehandlingRoutes`; `Vedtaksperioder` og `Vedtak` leser nå periodene fra query i stedet for fra `behandling.vedtak`.
  - **Mutasjoner:** `oppdaterVedtaksperiodeMedBegrunnelser`/`-Fritekster` returnerer nå `IVedtaksperiodeMedBegrunnelser[]`, og `onSuccess` oppdaterer query-cachen via
  `setQueryData` i stedet for `settÅpenBehandling`. Endringstidspunkt invaliderer vedtaksperiode-queryet etter regenerering.
  - **Fjernet `vedtaksperioderMedBegrunnelser` fra behandlingen:** Feltet er fjernet fra `IVedtakForBehandling` siden periodene nå hentes via eget endepunkt . Samsvarer med ba-sak.
  - **Tester:** Enhetstest for `skalViseFritekstbegrunnelser`, og `apiClient.test.ts` oppdatert til å forvente et kastet `Error`.

  ### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Apiclient endring, måtte gjøre endringer der for at error melding skal vises ordentlig.
<img width="776" height="547" alt="endring" src="https://github.com/user-attachments/assets/68274e65-0a14-49b6-9195-e1d6bc1f504f" />


