### PR TITLE
NAV-29334: Fikser rekkefølge på useEffect

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
@@ -1,21 +1,44 @@
+import { useEffect } from 'react';
+
 import { useBehandlingIdParam } from '@hooks/useBehandlingIdParam';
 import { NotFound } from '@komponenter/Error/NotFound';
 import { Behandlingslinje } from '@komponenter/Saklinje/Behandlingslinje';
 import { HenleggBehandlingModal } from '@komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandlingModal';
 import { HenleggBehandlingVeivalgModal } from '@komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandlingVeivalgModal';
+import type { SideId } from '@sider/Fagsak/Behandling/sider/sider';
+import { sider } from '@sider/Fagsak/Behandling/sider/sider';
+import { hentSideHref } from '@utils/miljø';
 import { Outlet } from 'react-router';
 
 import { Box, GlobalAlert, HStack, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import Styles from './BehandlingContainer.module.css';
-import { BehandlingProvider } from './context/BehandlingContext';
+import { BehandlingProvider, useBehandlingContext } from './context/BehandlingContext';
 import { useHentOgSettBehandlingContext } from './context/HentOgSettBehandlingContext';
 import { Høyremeny } from './Høyremeny/Høyremeny';
 import { TabContextProvider } from './Høyremeny/TabContextProvider';
 import { TotrinnskontrollModalContextProvider } from './Høyremeny/Totrinnskontroll/TotrinnskontrollModalContextProvider';
 import { KorrigerEtterbetalingModal } from './sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal';
 import { Venstremeny } from './Venstremeny/Venstremeny';
+
+/**
+ * Dette er gjort fordi useEffecten her må kjøre etter at useEffectene i BehandlingProvider er kjørt. Ellers visker
+ * den tilstand og viser masse "undefined" i GUI. Dette skjer spesielt hvis man er inne på vedtakssiden f.eks. og
+ * refresher siden. Burde skrive en bedre logikk.
+ */
+export function OutletContainer() {
+    const { leggTilBesøktSide } = useBehandlingContext();
+    const sidevisning = hentSideHref(location.pathname);
+
+    useEffect(() => {
+        if (sidevisning) {
+            leggTilBesøktSide(Object.entries(sider).find(([_, side]) => side.href === sidevisning)?.[0] as SideId);
+        }
+    }, [sidevisning]);
+
+    return <Outlet />;
+}
 
 export function BehandlingContainer() {
     const { behandlingRessurs } = useHentOgSettBehandlingContext();
@@ -40,7 +63,7 @@ export function BehandlingContainer() {
                                 <Venstremeny />
                             </Box>
                             <Box className={Styles.midtreKolonne}>
-                                <Outlet />
+                                <OutletContainer />
                             </Box>
                             <Box className={Styles.høyreKolonne}>
                                 <TotrinnskontrollModalContextProvider>

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -9,13 +9,14 @@ import { useLocation } from 'react-router';
 import { type Ressurs } from '@navikt/familie-typer';
 
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
-import { hentTrinnForBehandling, type ITrinn, KontrollertStatus, type SideId, sider } from '../sider/sider';
+import { hentTrinnForBehandling, type ITrinn, KontrollertStatus, type SideId } from '../sider/sider';
 
 interface Props extends PropsWithChildren {
     behandling: IBehandling;
 }
 
 interface BehandlingContextValue {
+    leggTilBesøktSide: (besøktSide: SideId) => void;
     settIkkeKontrollerteSiderTilManglerKontroll: () => void;
     trinnPåBehandling: { [sideId: string]: ITrinn };
     behandling: IBehandling;
@@ -33,8 +34,6 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
 
     const location = useLocation();
     const [trinnPåBehandling, settTrinnPåBehandling] = useState<{ [sideId: string]: ITrinn }>({});
-
-    const sidevisning = hentSideHref(location.pathname);
 
     useEffect(() => {
         const siderPåBehandling = hentTrinnForBehandling(behandling);
@@ -87,15 +86,10 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
         BehandlerRolle.BESLUTTER === saksbehandler.rolle &&
         saksbehandler.email !== behandling.endretAv;
 
-    useEffect(() => {
-        if (sidevisning) {
-            leggTilBesøktSide(Object.entries(sider).find(([_, side]) => side.href === sidevisning)?.[0] as SideId);
-        }
-    }, [sidevisning]);
-
     return (
         <BehandlingContext.Provider
             value={{
+                leggTilBesøktSide,
                 settIkkeKontrollerteSiderTilManglerKontroll,
                 trinnPåBehandling,
                 behandling,


### PR DESCRIPTION
### 📮 Favro
NAV-29334

### 💰 Hva skal gjøres, og hvorfor?
Dette er gjort fordi useEffecten her må kjøre etter at useEffectene i BehandlingProvider er kjørt. Ellers visker
den tilstand og viser masse "undefined" i GUI. Dette skjer spesielt hvis man er inne på vedtakssiden f.eks. og
refresher siden. Burde skrive en bedre logikk.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
Ingen visuelle endringer. 