### PR TITLE
NAV-29213 Ta i bruk React Query i OpprettBehandling

### DIFF
--- a/src/frontend/api/opprettBehandling.ts
+++ b/src/frontend/api/opprettBehandling.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IBehandling, NyBehandling } from '@typer/behandling';
+
+export async function opprettBehandling(payload: NyBehandling) {
+    return apiClient.post<NyBehandling, IBehandling>({
+        data: payload,
+        url: '/familie-ks-sak/api/behandlinger',
+    });
+}

--- a/src/frontend/api/opprettKlagebehandling.ts
+++ b/src/frontend/api/opprettKlagebehandling.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IBehandling } from '@typer/behandling';
+import type { IsoDatoString } from '@utils/dato';
+
+export interface OpprettKlagebehandlingPayload {
+    klageMottattDato: IsoDatoString;
+}
+
+export async function opprettKlagebehandling(payload: OpprettKlagebehandlingPayload, fagsakId: number) {
+    return apiClient.post<OpprettKlagebehandlingPayload, IBehandling>({
+        data: payload,
+        url: `/familie-ks-sak/api/fagsaker/${fagsakId}/opprett-klagebehandling`,
+    });
+}

--- a/src/frontend/api/opprettTilbakekreving.ts
+++ b/src/frontend/api/opprettTilbakekreving.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IBehandling } from '@typer/behandling';
+
+export interface OpprettTilbakekrevingPayload {
+    fagsakId: number;
+}
+
+export async function opprettTilbakekreving(payload: OpprettTilbakekrevingPayload) {
+    return apiClient.post<OpprettTilbakekrevingPayload, IBehandling>({
+        data: payload,
+        url: `/familie-ks-sak/api/tilbakekreving/manuell`,
+    });
+}

--- a/src/frontend/hooks/useOpprettBehandling.ts
+++ b/src/frontend/hooks/useOpprettBehandling.ts
@@ -1,0 +1,12 @@
+import { opprettBehandling } from '@api/opprettBehandling';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling, NyBehandling } from '@typer/behandling';
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, NyBehandling>, 'mutationFn'>;
+
+export function useOpprettBehandling(options?: Options) {
+    return useMutation<IBehandling, Error, NyBehandling>({
+        mutationFn: (payload: NyBehandling): Promise<IBehandling> => opprettBehandling(payload),
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useOpprettKlagebehandling.ts
+++ b/src/frontend/hooks/useOpprettKlagebehandling.ts
@@ -1,0 +1,17 @@
+import { opprettKlagebehandling, type OpprettKlagebehandlingPayload } from '@api/opprettKlagebehandling';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+interface OpprettKlagebehandlingParameters extends OpprettKlagebehandlingPayload {
+    fagsakId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettKlagebehandlingParameters>, 'mutationFn'>;
+
+export function useOpprettKlagebehandling(options?: Options) {
+    return useMutation<IBehandling, Error, OpprettKlagebehandlingParameters>({
+        mutationFn: ({ klageMottattDato, fagsakId }: OpprettKlagebehandlingParameters): Promise<IBehandling> =>
+            opprettKlagebehandling({ klageMottattDato }, fagsakId),
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useOpprettTilbakekreving.ts
+++ b/src/frontend/hooks/useOpprettTilbakekreving.ts
@@ -1,0 +1,13 @@
+import { opprettTilbakekreving, type OpprettTilbakekrevingPayload } from '@api/opprettTilbakekreving';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettTilbakekrevingPayload>, 'mutationFn'>;
+
+export function useOpprettTilbakekreving(options?: Options) {
+    return useMutation<IBehandling, Error, OpprettTilbakekrevingPayload>({
+        mutationFn: ({ fagsakId }: OpprettTilbakekrevingPayload): Promise<IBehandling> =>
+            opprettTilbakekreving({ fagsakId }),
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useOpprettTilbakekreving.ts
+++ b/src/frontend/hooks/useOpprettTilbakekreving.ts
@@ -2,11 +2,13 @@ import { opprettTilbakekreving, type OpprettTilbakekrevingPayload } from '@api/o
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
 import type { IBehandling } from '@typer/behandling';
 
-type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettTilbakekrevingPayload>, 'mutationFn'>;
+type OpprettTilbakekrevingParameters = OpprettTilbakekrevingPayload;
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettTilbakekrevingParameters>, 'mutationFn'>;
 
 export function useOpprettTilbakekreving(options?: Options) {
-    return useMutation<IBehandling, Error, OpprettTilbakekrevingPayload>({
-        mutationFn: ({ fagsakId }: OpprettTilbakekrevingPayload): Promise<IBehandling> =>
+    return useMutation<IBehandling, Error, OpprettTilbakekrevingParameters>({
+        mutationFn: ({ fagsakId }: OpprettTilbakekrevingParameters): Promise<IBehandling> =>
             opprettTilbakekreving({ fagsakId }),
         ...options,
     });

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
@@ -1,3 +1,4 @@
+import useOpprettBehandlingSkjema from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
 import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
 import { hentDagensDato } from '@utils/dato';
 import { hentFrontendFeilmelding } from '@utils/ressursUtils';
@@ -9,7 +10,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 import BehandlingstypeFelt from './BehandlingstypeFelt';
 import { BehandlingårsakFelt } from './BehandlingsårsakFelt';
 import { OpprettBehandlingBehandlingstemaSelect } from './OpprettBehandlingBehandlingstemaSelect';
-import useOpprettBehandling from './useOpprettBehandling';
 import Datovelger from '../../../Datovelger/Datovelger';
 
 interface Props {
@@ -20,7 +20,7 @@ interface Props {
 export function OpprettBehandlingModal({ lukkModal, onTilbakekrevingsbehandlingOpprettet }: Props) {
     const { fagsak } = useFagsakContext();
 
-    const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus } = useOpprettBehandling({
+    const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus } = useOpprettBehandlingSkjema({
         lukkModal,
         onOpprettTilbakekrevingSuccess: () => {
             lukkModal();

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
@@ -1,4 +1,4 @@
-import useOpprettBehandlingSkjema from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
+import { useOpprettBehandlingSkjema } from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
 import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
 import { hentDagensDato } from '@utils/dato';
 import { hentFrontendFeilmelding } from '@utils/ressursUtils';
@@ -22,10 +22,7 @@ export function OpprettBehandlingModal({ lukkModal, onTilbakekrevingsbehandlingO
 
     const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus } = useOpprettBehandlingSkjema({
         lukkModal,
-        onOpprettTilbakekrevingSuccess: () => {
-            lukkModal();
-            onTilbakekrevingsbehandlingOpprettet();
-        },
+        onTilbakekrevingsbehandlingOpprettet,
     });
 
     const lukkOpprettBehandlingModal = () => {

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -131,12 +131,12 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
 
     const { mutate: opprettKlagebehandling } = useOpprettKlagebehandling({
         onSuccess: async behandling => {
-            await queryClient.invalidateQueries({
-                queryKey: HentKlagebehandlingerQueryKeyFactory.klagebehandlinger(fagsakId),
-            });
             lukkModal();
             nullstillSkjema();
             settSubmitRessurs(byggSuksessRessurs(behandling));
+            await queryClient.invalidateQueries({
+                queryKey: HentKlagebehandlingerQueryKeyFactory.klagebehandlinger(fagsakId),
+            });
         },
         onError: error => {
             settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
@@ -145,13 +145,13 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
 
     const { mutate: opprettTilbakekreving } = useOpprettTilbakekreving({
         onSuccess: async behandling => {
-            await queryClient.invalidateQueries({
-                queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.tilbakekrevingsbehandlinger(fagsakId),
-            });
             lukkModal();
             nullstillSkjemaStatus();
             onTilbakekrevingsbehandlingOpprettet();
             settSubmitRessurs(byggSuksessRessurs(behandling));
+            await queryClient.invalidateQueries({
+                queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.tilbakekrevingsbehandlinger(fagsakId),
+            });
         },
         onError: error => {
             settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
@@ -160,13 +160,6 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
 
     const { mutate: opprettBehandling } = useOpprettBehandling({
         onSuccess: async behandling => {
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: HentKontantstøttebehandlingerQueryKeyFactory.kontantstøttebehandlinger(fagsakId),
-                }),
-                queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) }),
-            ]);
-
             lukkModal();
             nullstillSkjema();
             settSubmitRessurs(byggSuksessRessurs(behandling));
@@ -176,6 +169,13 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
             } else {
                 navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/vilkaarsvurdering`);
             }
+
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: HentKontantstøttebehandlingerQueryKeyFactory.kontantstøttebehandlinger(fagsakId),
+                }),
+                queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) }),
+            ]);
         },
         onError: error => {
             settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -1,25 +1,32 @@
 import { useEffect } from 'react';
 
-import { useFagsak } from '@hooks/useFagsak';
+import { useFagsakId } from '@hooks/useFagsakId';
 import { HentFagsakQueryKeyFactory } from '@hooks/useHentFagsak';
 import { HentKlagebehandlingerQueryKeyFactory } from '@hooks/useHentKlagebehandlinger';
 import { HentKontantstøttebehandlingerQueryKeyFactory } from '@hooks/useHentKontantstøttebehandlinger';
 import { HentTilbakekrevingsbehandlingerQueryKeyFactory } from '@hooks/useHentTilbakekrevingsbehandlinger';
+import { useOpprettBehandling } from '@hooks/useOpprettBehandling';
+import { useOpprettKlagebehandling } from '@hooks/useOpprettKlagebehandling';
+import { useOpprettTilbakekreving } from '@hooks/useOpprettTilbakekreving';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { useBrukerContext } from '@sider/Fagsak/BrukerContext';
 import { useQueryClient } from '@tanstack/react-query';
-import type { IBehandling, NyBehandling } from '@typer/behandling';
+import type { IBehandling } from '@typer/behandling';
 import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
 import type { IBehandlingstema } from '@typer/behandlingstema';
 import { Klagebehandlingstype } from '@typer/klage';
 import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
-import type { IsoDatoString } from '@utils/dato';
 import { dateTilIsoDatoString, dateTilIsoDatoStringEllerUndefined, validerGyldigDato } from '@utils/dato';
 import { useNavigate } from 'react-router';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
+import {
+    byggFunksjonellFeilRessurs,
+    byggHenterRessurs,
+    byggSuksessRessurs,
+    byggTomRessurs,
+} from '@navikt/familie-typer';
 
 interface IOpprettBehandlingSkjemaFelter {
     behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype | '';
@@ -29,16 +36,15 @@ interface IOpprettBehandlingSkjemaFelter {
     klageMottattDato: Date | undefined;
 }
 
-const useOpprettBehandlingSkjema = ({
-    lukkModal,
-    onOpprettTilbakekrevingSuccess,
-}: {
+interface Props {
     lukkModal: () => void;
-    onOpprettTilbakekrevingSuccess: () => void;
-}) => {
+    onTilbakekrevingsbehandlingOpprettet: () => void;
+}
+
+export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandlingOpprettet }: Props) {
     const { bruker } = useBrukerContext();
 
-    const fagsak = useFagsak();
+    const fagsakId = useFagsakId();
     const saksbehandler = useSaksbehandler();
     const queryClient = useQueryClient();
     const navigate = useNavigate();
@@ -101,7 +107,7 @@ const useOpprettBehandlingSkjema = ({
         skalFeltetVises: avhengigheter => avhengigheter.behandlingstype.verdi === Klagebehandlingstype.KLAGE,
     });
 
-    const { skjema, nullstillSkjema, kanSendeSkjema, onSubmit, settSubmitRessurs } = useSkjema<
+    const { skjema, nullstillSkjema, kanSendeSkjema, settSubmitRessurs } = useSkjema<
         IOpprettBehandlingSkjemaFelter,
         IBehandling
     >({
@@ -123,90 +129,80 @@ const useOpprettBehandlingSkjema = ({
         }
     }, [behandlingstype.verdi]);
 
-    const opprettKlagebehandling = () => {
-        onSubmit<{ klageMottattDato: IsoDatoString }>(
-            {
-                method: 'POST',
-                url: `/familie-ks-sak/api/fagsaker/${fagsak.id}/opprett-klagebehandling`,
-                data: { klageMottattDato: dateTilIsoDatoString(klageMottattDato.verdi) },
-            },
-            response => {
-                if (response.status === RessursStatus.SUKSESS) {
-                    lukkModal();
-                    nullstillSkjema();
-                    queryClient.invalidateQueries({
-                        queryKey: HentKlagebehandlingerQueryKeyFactory.klagebehandlinger(fagsak.id),
-                    });
-                }
-            }
-        );
-    };
+    const { mutate: opprettKlagebehandling } = useOpprettKlagebehandling({
+        onSuccess: async behandling => {
+            await queryClient.invalidateQueries({
+                queryKey: HentKlagebehandlingerQueryKeyFactory.klagebehandlinger(fagsakId),
+            });
+            lukkModal();
+            nullstillSkjema();
+            settSubmitRessurs(byggSuksessRessurs(behandling));
+        },
+        onError: error => {
+            settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
+        },
+    });
 
-    const opprettTilbakekreving = () => {
-        onSubmit(
-            {
-                method: 'POST',
-                url: `/familie-ks-sak/api/tilbakekreving/manuell`,
-                data: { fagsakId: fagsak.id },
-            },
-            response => {
-                if (response.status === RessursStatus.SUKSESS) {
-                    nullstillSkjemaStatus();
-                    onOpprettTilbakekrevingSuccess();
-                    queryClient.invalidateQueries({
-                        queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.tilbakekrevingsbehandlinger(fagsak.id),
-                    });
-                }
-            }
-        );
-    };
+    const { mutate: opprettTilbakekreving } = useOpprettTilbakekreving({
+        onSuccess: async behandling => {
+            await queryClient.invalidateQueries({
+                queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.tilbakekrevingsbehandlinger(fagsakId),
+            });
+            lukkModal();
+            nullstillSkjemaStatus();
+            onTilbakekrevingsbehandlingOpprettet();
+            settSubmitRessurs(byggSuksessRessurs(behandling));
+        },
+        onError: error => {
+            settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
+        },
+    });
 
-    const opprettKontantstøttebehandling = (søkersIdent: string) => {
-        onSubmit<NyBehandling>(
-            {
-                data: {
+    const { mutate: opprettBehandling } = useOpprettBehandling({
+        onSuccess: async behandling => {
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: HentKontantstøttebehandlingerQueryKeyFactory.kontantstøttebehandlinger(fagsakId),
+                }),
+                queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) }),
+            ]);
+
+            lukkModal();
+            nullstillSkjema();
+            settSubmitRessurs(byggSuksessRessurs(behandling));
+
+            if (behandling.årsak === BehandlingÅrsak.SØKNAD) {
+                navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/registrer-soknad`);
+            } else {
+                navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/vilkaarsvurdering`);
+            }
+        },
+        onError: error => {
+            settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
+        },
+    });
+
+    const onBekreft = (søkersIdent: string) => {
+        if (kanSendeSkjema()) {
+            settSubmitRessurs(byggHenterRessurs());
+
+            if (behandlingstype.verdi === Klagebehandlingstype.KLAGE) {
+                opprettKlagebehandling({
+                    klageMottattDato: dateTilIsoDatoString(klageMottattDato.verdi),
+                    fagsakId,
+                });
+            } else if (behandlingstype.verdi === Tilbakekrevingsbehandlingstype.TILBAKEKREVING) {
+                opprettTilbakekreving({ fagsakId });
+            } else {
+                const payload = {
                     kategori: skjema.felter.behandlingstema.verdi?.kategori ?? null,
                     søkersIdent: søkersIdent,
                     behandlingType: behandlingstype.verdi as Behandlingstype,
                     behandlingÅrsak: behandlingsårsak.verdi as BehandlingÅrsak,
                     saksbehandlerIdent: saksbehandler.navIdent,
                     søknadMottattDato: dateTilIsoDatoStringEllerUndefined(skjema.felter.søknadMottattDato.verdi),
-                },
-                method: 'POST',
-                url: '/familie-ks-sak/api/behandlinger',
-            },
-            async response => {
-                if (response.status === RessursStatus.SUKSESS) {
-                    lukkModal();
-                    nullstillSkjema();
-
-                    queryClient.invalidateQueries({
-                        queryKey: HentKontantstøttebehandlingerQueryKeyFactory.kontantstøttebehandlinger(fagsak.id),
-                    });
-
-                    await queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id) });
-
-                    const behandling = response.data;
-
-                    if (behandling.årsak === BehandlingÅrsak.SØKNAD) {
-                        navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/registrer-soknad`);
-                    } else {
-                        navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
-                    }
-                }
-            }
-        );
-    };
-
-    const onBekreft = (søkersIdent: string) => {
-        if (kanSendeSkjema()) {
-            settSubmitRessurs(byggHenterRessurs());
-            if (behandlingstype.verdi === Klagebehandlingstype.KLAGE) {
-                opprettKlagebehandling();
-            } else if (behandlingstype.verdi === Tilbakekrevingsbehandlingstype.TILBAKEKREVING) {
-                opprettTilbakekreving();
-            } else {
-                opprettKontantstøttebehandling(søkersIdent);
+                };
+                opprettBehandling(payload);
             }
         }
     };
@@ -222,6 +218,4 @@ const useOpprettBehandlingSkjema = ({
         nullstillSkjemaStatus,
         bruker,
     };
-};
-
-export default useOpprettBehandlingSkjema;
+}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -1,26 +1,25 @@
 import { useEffect } from 'react';
 
+import { useFagsak } from '@hooks/useFagsak';
+import { HentFagsakQueryKeyFactory } from '@hooks/useHentFagsak';
+import { HentKlagebehandlingerQueryKeyFactory } from '@hooks/useHentKlagebehandlinger';
+import { HentKontantstøttebehandlingerQueryKeyFactory } from '@hooks/useHentKontantstøttebehandlinger';
+import { HentTilbakekrevingsbehandlingerQueryKeyFactory } from '@hooks/useHentTilbakekrevingsbehandlinger';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { useBrukerContext } from '@sider/Fagsak/BrukerContext';
 import { useQueryClient } from '@tanstack/react-query';
+import type { IBehandling, NyBehandling } from '@typer/behandling';
+import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import type { IBehandlingstema } from '@typer/behandlingstema';
+import { Klagebehandlingstype } from '@typer/klage';
+import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
+import type { IsoDatoString } from '@utils/dato';
+import { dateTilIsoDatoString, dateTilIsoDatoStringEllerUndefined, validerGyldigDato } from '@utils/dato';
 import { useNavigate } from 'react-router';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
-
-import { useFagsak } from '../../../../hooks/useFagsak';
-import { HentFagsakQueryKeyFactory } from '../../../../hooks/useHentFagsak';
-import { HentKlagebehandlingerQueryKeyFactory } from '../../../../hooks/useHentKlagebehandlinger';
-import { HentKontantstøttebehandlingerQueryKeyFactory } from '../../../../hooks/useHentKontantstøttebehandlinger';
-import { HentTilbakekrevingsbehandlingerQueryKeyFactory } from '../../../../hooks/useHentTilbakekrevingsbehandlinger';
-import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
-import { useBrukerContext } from '../../../../sider/Fagsak/BrukerContext';
-import type { IBehandling, IRestNyBehandling } from '../../../../typer/behandling';
-import { Behandlingstype, BehandlingÅrsak } from '../../../../typer/behandling';
-import type { IBehandlingstema } from '../../../../typer/behandlingstema';
-import { Klagebehandlingstype } from '../../../../typer/klage';
-import { Tilbakekrevingsbehandlingstype } from '../../../../typer/tilbakekrevingsbehandling';
-import type { IsoDatoString } from '../../../../utils/dato';
-import { dateTilIsoDatoString, dateTilIsoDatoStringEllerUndefined, validerGyldigDato } from '../../../../utils/dato';
+import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
 interface IOpprettBehandlingSkjemaFelter {
     behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype | '';
@@ -30,7 +29,7 @@ interface IOpprettBehandlingSkjemaFelter {
     klageMottattDato: Date | undefined;
 }
 
-const useOpprettBehandling = ({
+const useOpprettBehandlingSkjema = ({
     lukkModal,
     onOpprettTilbakekrevingSuccess,
 }: {
@@ -163,7 +162,7 @@ const useOpprettBehandling = ({
     };
 
     const opprettKontantstøttebehandling = (søkersIdent: string) => {
-        onSubmit<IRestNyBehandling>(
+        onSubmit<NyBehandling>(
             {
                 data: {
                     kategori: skjema.felter.behandlingstema.verdi?.kategori ?? null,
@@ -201,6 +200,7 @@ const useOpprettBehandling = ({
 
     const onBekreft = (søkersIdent: string) => {
         if (kanSendeSkjema()) {
+            settSubmitRessurs(byggHenterRessurs());
             if (behandlingstype.verdi === Klagebehandlingstype.KLAGE) {
                 opprettKlagebehandling();
             } else if (behandlingstype.verdi === Tilbakekrevingsbehandlingstype.TILBAKEKREVING) {
@@ -224,4 +224,4 @@ const useOpprettBehandling = ({
     };
 };
 
-export default useOpprettBehandling;
+export default useOpprettBehandlingSkjema;

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -27,7 +27,7 @@ import type { IRestPersonResultat, IRestStegTilstand } from './vilkår';
 
 export const MIDLERTIDIG_BEHANDLENDE_ENHET_ID = '4863';
 
-export interface IRestNyBehandling {
+export interface NyBehandling {
     kategori: BehandlingKategori | null;
     søkersIdent: string;
     behandlingType: Behandlingstype;


### PR DESCRIPTION
### 📮 Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29213

### 💰 Hva skal gjøres, og hvorfor?
- Ta i bruk TanStack Query (React Query) i OpprettBehandling modalen og skjemaet. Første steg i omskrivingen til react-query og react-hook-form.
- Bruk @ -imports.
- Endre navn fra `useOpprettBehandling` til `useOpprettBehandlingSkjema` for tydeliggjøring.

OBS: Denne PR-en er så og si kun omskriving til react-query, ingen forenkling av kode. Det kommer flere PR-er, men tar litt om gangen 🤓

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_ ingen funksjonelle endringer


### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_ ingen visuelle endringer
