### PR TITLE
Reduserer alarmer når sesjon går ut

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -36,6 +36,17 @@ backend(sessionConfig, prometheusTellere, appConfig).then(async ({ app, azureAut
     app.use(express.urlencoded({ limit: '200mb', extended: true }));
     app.use('/', await setupRouter(azureAuthClient, router));
 
+    // Error-handling middleware - må registreres etter alle andre routes
+    app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+        if (res.headersSent) {
+            return _next(err);
+        }
+        if (err.message?.includes('did not find expected authorization request details in session')) {
+            logInfo(`OIDC-sesjon mangler ved callback - brukeren omdirigeres til login. Detaljer: ${err.message}`);
+            res.redirect('/login');
+        }
+    });
+
     app.listen(port, '0.0.0.0', () => {
         logInfo(`Server startet på port ${port}. Build version: ${envVar('APP_VERSION')}.`);
     });


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Samme fiks som i [ba-sak-frontend ](https://github.com/navikt/familie-ba-sak-frontend/pull/4623), som ble merget inn før helga og ser ut til å fungere [bra](https://logs.az.nav.no/goto/f605b918353eab2ca74a30738ac35f37?security_tenant=navlogs),

Det kommer mange falske alarmer når sesjonen har utløpt siden teksten inneholder ordet Error:
Error: did not find expected authorization request details in session, req.session["oidc:login.microsoftonline.com"] is undefined

Skriver om loggmelding til å ikke bruke ordet Error.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
