### PR TITLE
NAV-26302: Erstatt styled-components med module.css og Aksel primitives

### DIFF
--- a/src/frontend/ikoner/KontoSirkel.module.css
+++ b/src/frontend/ikoner/KontoSirkel.module.css
@@ -1,0 +1,8 @@
+.svg {
+    enable-background: new 0 0 24 24;
+}
+
+.path {
+    stroke-linejoin: round;
+    stroke-miterlimit: 10;
+}

--- a/src/frontend/ikoner/KontoSirkel.tsx
+++ b/src/frontend/ikoner/KontoSirkel.tsx
@@ -1,4 +1,6 @@
-import styled from 'styled-components';
+import classNames from 'classnames';
+
+import styles from './KontoSirkel.module.css';
 
 interface IKontoSirkel {
     filled?: boolean;
@@ -9,7 +11,8 @@ interface IKontoSirkel {
 
 export const KontoSirkel = ({ className, filled = false, width = 48, height = 48 }: IKontoSirkel) => {
     return filled ? (
-        <StyledSvg
+        <svg
+            className={styles.svg}
             aria-labelledby={'kontosirkel'}
             version="1.1"
             id="Filled_Version"
@@ -22,7 +25,8 @@ export const KontoSirkel = ({ className, filled = false, width = 48, height = 48
             enableBackground="new 0 0 24 24"
             fill="#0067c5"
         >
-            <StyledPath
+            <path
+                className={styles.path}
                 d="M12,0C5.383,0,0,5.383,0,12c0,3.18,1.232,6.177,3.469,8.438l0,0.001C5.743,22.735,8.772,24,12,24
        c3.234,0,6.268-1.27,8.542-3.573C22.772,18.166,24,15.174,24,12C24,5.383,18.617,0,12,0z M20.095,19.428
        c-1.055-0.626-2.64-1.202-4.32-1.81c-0.418-0.151-0.846-0.307-1.275-0.465v-1.848c0.501-0.309,1.384-1.107,1.49-2.935
@@ -32,9 +36,10 @@ export const KontoSirkel = ({ className, filled = false, width = 48, height = 48
        c0.106,1.828,0.989,2.626,1.49,2.935v1.848c-0.385,0.144-0.78,0.287-1.176,0.431c-1.621,0.587-3.288,1.194-4.407,1.857
        C2.04,17.405,1,14.782,1,12C1,5.935,5.935,1,12,1c6.065,0,11,4.935,11,11C23,14.775,21.965,17.394,20.095,19.428z"
             />
-        </StyledSvg>
+        </svg>
     ) : (
-        <StyledSvg
+        <svg
+            className={classNames(className, styles.svg)}
             aria-labelledby={'kontosirkel'}
             version="1.1"
             id="Layer_1"
@@ -44,27 +49,18 @@ export const KontoSirkel = ({ className, filled = false, width = 48, height = 48
             width={width}
             height={height}
             viewBox="0 0 24 24"
-            className={className}
             fill="none"
             stroke="#0067c5"
         >
             <title id={'kontosirkel'}>Kontosirkel</title>
             <g>
-                <StyledPath
+                <path
+                    className={styles.path}
                     d="M10,15c0,0-1.5-0.5-1.5-3c-0.8,0-0.8-2,0-2c0-0.3-1.5-4,1-3.5c0.5-2,6-2,6.5,0c0.3,1.4-0.5,3.3-0.5,3.5
 		c0.8,0,0.8,2,0,2c0,2.5-1.5,3-1.5,3v2.5c2.5,0.9,4.9,1.7,6.2,2.6c2-2.1,3.3-4.9,3.3-8.1c0-6.4-5.1-11.5-11.5-11.5S0.5,5.6,0.5,12
 		c0,3.2,1.3,6,3.3,8.1c1.3-0.9,4-1.7,6.2-2.6C10,17.5,10,15,10,15z M3.8,20.1c2.1,2.1,5,3.4,8.2,3.4c3.2,0,6.1-1.3,8.2-3.4"
                 />
             </g>
-        </StyledSvg>
+        </svg>
     );
 };
-
-const StyledSvg = styled.svg`
-    enable-background: new 0 0 24 24;
-`;
-
-const StyledPath = styled.path`
-    stroke-linejoin: round;
-    stroke-miterlimit: 10;
-`;

--- a/src/frontend/ikoner/StatusIkon.module.css
+++ b/src/frontend/ikoner/StatusIkon.module.css
@@ -1,0 +1,20 @@
+.icon {
+    font-size: 1.5rem;
+    min-width: 1.5rem;
+}
+
+.ok {
+    color: var(--ax-text-success-subtle);
+}
+
+.feil {
+    color: var(--ax-text-danger-subtle);
+}
+
+.advarsel {
+    color: var(--ax-text-warning-subtle);
+}
+
+.info {
+    color: var(--ax-text-info-subtle);
+}

--- a/src/frontend/ikoner/StatusIkon.tsx
+++ b/src/frontend/ikoner/StatusIkon.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import classNames from 'classnames';
 
 import {
     CheckmarkCircleFillIcon,
@@ -6,6 +6,8 @@ import {
     InformationSquareFillIcon,
     XMarkOctagonFillIcon,
 } from '@navikt/aksel-icons';
+
+import styles from './StatusIkon.module.css';
 
 interface IProps {
     status: Status;
@@ -19,40 +21,18 @@ export enum Status {
     INFO,
 }
 
-const OkIkon = styled(CheckmarkCircleFillIcon)`
-    color: var(--ax-text-success-subtle);
-    font-size: 1.5rem;
-    min-width: 1.5rem;
-`;
-
-const FeilIkon = styled(XMarkOctagonFillIcon)`
-    color: var(--ax-text-danger-subtle);
-    font-size: 1.5rem;
-    min-width: 1.5rem;
-`;
-
-const AdvarselIkon = styled(ExclamationmarkTriangleFillIcon)`
-    color: var(--ax-text-warning-subtle);
-    font-size: 1.5rem;
-    min-width: 1.5rem;
-`;
-
-const InfoIkon = styled(InformationSquareFillIcon)`
-    color: var(--ax-text-info-subtle);
-    font-size: 1.5rem;
-    min-width: 1.5rem;
-`;
-
 const StatusIkon = ({ status, title }: IProps) => {
     switch (status) {
         case Status.OK:
-            return <OkIkon title={title} />;
+            return <CheckmarkCircleFillIcon className={classNames(styles.icon, styles.ok)} title={title} />;
         case Status.FEIL:
-            return <FeilIkon title={title} />;
+            return <XMarkOctagonFillIcon className={classNames(styles.icon, styles.feil)} title={title} />;
         case Status.ADVARSEL:
-            return <AdvarselIkon title={title} />;
+            return (
+                <ExclamationmarkTriangleFillIcon className={classNames(styles.icon, styles.advarsel)} title={title} />
+            );
         case Status.INFO:
-            return <InfoIkon title={title} />;
+            return <InformationSquareFillIcon className={classNames(styles.icon, styles.info)} title={title} />;
     }
 };
 export default StatusIkon;

--- a/src/frontend/komponenter/FamilieBaseKnapp.tsx
+++ b/src/frontend/komponenter/FamilieBaseKnapp.tsx
@@ -3,7 +3,7 @@ import type { ButtonHTMLAttributes } from 'react';
 import styles from './FamilieBaseKnapp.module.css';
 
 const FamilieBaseKnapp = ({ children }: ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button className={styles.familieBaseKnapp}>{children}</button>
+    <button className={styles.knapp}>{children}</button>
 );
 
 export default FamilieBaseKnapp;

--- a/src/frontend/sider/Barnehagelister/BarnehagebarnTabellNavigator.tsx
+++ b/src/frontend/sider/Barnehagelister/BarnehagebarnTabellNavigator.tsx
@@ -40,35 +40,33 @@ const BarnehagebarnTabellNavigator = (props: BarnehagebarnTabellNavigatorProps) 
                         <option value="100">Vis 100 per side</option>
                         <option value="200">Vis 200 per side</option>
                     </Select>
-                    {data.totalElements > 0 && data?.totalPages > 0 && (
-                        <HStack>
-                            {data.totalElements > 0 ? (
-                                <HStack gap="space-8" align="center">
-                                    |
-                                    <span>
-                                        <b>
-                                            Side {data.number + 1} av {data.totalPages}{' '}
-                                        </b>
-                                        ({data.pageable.offset + 1} - {data.pageable.offset + data.numberOfElements} av{' '}
-                                        {data.totalElements} totalt)
-                                    </span>
-                                    |
-                                </HStack>
-                            ) : (
-                                <div>Ingen resultater</div>
-                            )}
-                            {data?.totalPages > 0 && (
-                                <Pagination
-                                    size="medium"
-                                    page={data.number + 1}
-                                    count={data.totalPages}
-                                    onPageChange={(side: number) => updateOffset(side - 1)}
-                                    boundaryCount={1}
-                                    siblingCount={1}
-                                />
-                            )}
-                        </HStack>
-                    )}
+                    <HStack>
+                        {data.totalElements > 0 ? (
+                            <HStack gap="space-8" align="center">
+                                |
+                                <span>
+                                    <b>
+                                        Side {data.number + 1} av {data.totalPages}{' '}
+                                    </b>
+                                    ({data.pageable.offset + 1} - {data.pageable.offset + data.numberOfElements} av{' '}
+                                    {data.totalElements} totalt)
+                                </span>
+                                |
+                            </HStack>
+                        ) : (
+                            <div>Ingen resultater</div>
+                        )}
+                        {data?.totalPages > 0 && (
+                            <Pagination
+                                size="medium"
+                                page={data.number + 1}
+                                count={data.totalPages}
+                                onPageChange={(side: number) => updateOffset(side - 1)}
+                                boundaryCount={1}
+                                siblingCount={1}
+                            />
+                        )}
+                    </HStack>
                 </HStack>
             )}
         </HStack>

--- a/src/frontend/sider/Barnehagelister/BarnehagebarnTabellNavigator.tsx
+++ b/src/frontend/sider/Barnehagelister/BarnehagebarnTabellNavigator.tsx
@@ -1,17 +1,7 @@
-import styled from 'styled-components';
+import { useHentBarnehagebarn } from '@hooks/useHentBarnehagebarn';
+import type { BarnehagebarnRequestParams } from '@typer/barnehagebarn';
 
 import { HStack, Pagination, Select } from '@navikt/ds-react';
-
-import { useHentBarnehagebarn } from '../../hooks/useHentBarnehagebarn';
-import type { BarnehagebarnRequestParams } from '../../typer/barnehagebarn';
-
-const StyledHStack = styled(HStack)`
-    margin-bottom: 1rem;
-`;
-
-const StyledSelect = styled(Select)`
-    margin-right: auto;
-`;
 
 interface BarnehagebarnTabellNavigatorProps {
     barnehagebarnRequestParams: BarnehagebarnRequestParams;
@@ -30,10 +20,10 @@ const BarnehagebarnTabellNavigator = (props: BarnehagebarnTabellNavigatorProps) 
     }
 
     return (
-        <StyledHStack>
+        <HStack marginBlock={'space-0 space-16'}>
             {data.content.length >= 0 && (
-                <>
-                    <StyledSelect
+                <HStack justify={'space-between'} width={'100%'}>
+                    <Select
                         hideLabel
                         label="Antall per side"
                         size="medium"
@@ -49,35 +39,39 @@ const BarnehagebarnTabellNavigator = (props: BarnehagebarnTabellNavigatorProps) 
                         <option value="50">Vis 50 per side</option>
                         <option value="100">Vis 100 per side</option>
                         <option value="200">Vis 200 per side</option>
-                    </StyledSelect>
-                    {data.totalElements > 0 ? (
-                        <HStack gap="space-8" align="center">
-                            |
-                            <span>
-                                <b>
-                                    Side {data.number + 1} av {data.totalPages}{' '}
-                                </b>
-                                ({data.pageable.offset + 1} - {data.pageable.offset + data.numberOfElements} av{' '}
-                                {data.totalElements} totalt)
-                            </span>
-                            |
+                    </Select>
+                    {data.totalElements > 0 && data?.totalPages > 0 && (
+                        <HStack>
+                            {data.totalElements > 0 ? (
+                                <HStack gap="space-8" align="center">
+                                    |
+                                    <span>
+                                        <b>
+                                            Side {data.number + 1} av {data.totalPages}{' '}
+                                        </b>
+                                        ({data.pageable.offset + 1} - {data.pageable.offset + data.numberOfElements} av{' '}
+                                        {data.totalElements} totalt)
+                                    </span>
+                                    |
+                                </HStack>
+                            ) : (
+                                <div>Ingen resultater</div>
+                            )}
+                            {data?.totalPages > 0 && (
+                                <Pagination
+                                    size="medium"
+                                    page={data.number + 1}
+                                    count={data.totalPages}
+                                    onPageChange={(side: number) => updateOffset(side - 1)}
+                                    boundaryCount={1}
+                                    siblingCount={1}
+                                />
+                            )}
                         </HStack>
-                    ) : (
-                        <div>Ingen resultater</div>
                     )}
-                    {data?.totalPages > 0 && (
-                        <Pagination
-                            size="medium"
-                            page={data.number + 1}
-                            count={data.totalPages}
-                            onPageChange={(side: number) => updateOffset(side - 1)}
-                            boundaryCount={1}
-                            siblingCount={1}
-                        />
-                    )}
-                </>
+                </HStack>
             )}
-        </StyledHStack>
+        </HStack>
     );
 };
 

--- a/src/frontend/sider/Barnehagelister/BarnehagelisterFilterskjema.tsx
+++ b/src/frontend/sider/Barnehagelister/BarnehagelisterFilterskjema.tsx
@@ -1,18 +1,18 @@
+import type { BarnehagebarnFilter, BarnehagebarnRequestParams, Barnehagekommune } from '@typer/barnehagebarn';
 import { Controller, type SubmitHandler, useForm } from 'react-hook-form';
-import styled from 'styled-components';
 
 import { FileResetIcon, FunnelIcon } from '@navikt/aksel-icons';
-import { Button, Checkbox, Fieldset, HelpText, HStack, TextField, UNSAFE_Combobox, VStack } from '@navikt/ds-react';
-
-import type { BarnehagebarnFilter, BarnehagebarnRequestParams, Barnehagekommune } from '../../typer/barnehagebarn';
-
-const StyledFieldset = styled(Fieldset)`
-    margin: 0 1rem 2rem 0;
-`;
-
-const StyledCheckbox = styled(Checkbox)`
-    align-self: end;
-`;
+import {
+    Box,
+    Button,
+    Checkbox,
+    Fieldset,
+    HelpText,
+    HStack,
+    TextField,
+    UNSAFE_Combobox,
+    VStack,
+} from '@navikt/ds-react';
 
 interface BarnehagebarnFilterSkjemaProps {
     oppdaterFiltrering: (filter: BarnehagebarnFilter) => void;
@@ -39,78 +39,80 @@ const BarnehagelisterFilterskjema = (props: BarnehagebarnFilterSkjemaProps) => {
 
     return (
         <form onSubmit={handleSubmit(onSubmit)}>
-            <StyledFieldset
-                size="small"
-                aria-label="BarnehagelisterInnhold filterskjema"
-                legend="Filterskjema"
-                description="Filtrer barnehagebarn resultater"
-                hideLegend
-            >
-                <VStack gap="space-16">
-                    <HStack gap="space-16" align="end">
-                        <TextField
-                            label="Barns ident"
-                            title="Filtrer på barns ident"
-                            size="medium"
-                            maxLength={11}
-                            {...register('ident')}
-                        />
-                        <Controller
-                            control={control}
-                            name={'kommuneNavn'}
-                            render={({ field }) => (
-                                <UNSAFE_Combobox
-                                    label="Kommunenavn"
-                                    selectedOptions={field.value != undefined ? [field.value] : []}
-                                    options={barnehageKommuner()}
-                                    title="Filtrer på kommunenavn"
-                                    size="medium"
-                                    ref={field.ref}
-                                    name={field.name}
-                                    onBlur={field.onBlur}
-                                    onToggleSelected={(option, isSelected): void => {
-                                        setValue('ident', undefined);
-                                        if (isSelected) {
-                                            field.onChange(option);
-                                        } else {
-                                            field.onChange(null);
-                                        }
-                                    }}
-                                    shouldAutocomplete={true}
-                                />
-                            )}
-                        />
-                        <HStack gap="space-16" align="center">
-                            <StyledCheckbox
-                                id="kun-loepende-andel"
-                                title="Vis kun løpende andeler"
+            <Box marginBlock={'space-0 space-32'}>
+                <Fieldset
+                    size="small"
+                    aria-label="BarnehagelisterInnhold filterskjema"
+                    legend="Filterskjema"
+                    description="Filtrer barnehagebarn resultater"
+                    hideLegend
+                >
+                    <VStack gap="space-16">
+                        <HStack gap="space-16" align="end">
+                            <TextField
+                                label="Barns ident"
+                                title="Filtrer på barns ident"
                                 size="medium"
-                                {...register('kunLøpendeAndel')}
-                            >
-                                Kun løpende utbetalinger
-                            </StyledCheckbox>
-                            <HelpText title="Løpende utbetaling">
-                                Viser kun saker hvor barn har en løpende utbetaling
-                            </HelpText>
+                                maxLength={11}
+                                {...register('ident')}
+                            />
+                            <Controller
+                                control={control}
+                                name={'kommuneNavn'}
+                                render={({ field }) => (
+                                    <UNSAFE_Combobox
+                                        label="Kommunenavn"
+                                        selectedOptions={field.value != undefined ? [field.value] : []}
+                                        options={barnehageKommuner()}
+                                        title="Filtrer på kommunenavn"
+                                        size="medium"
+                                        ref={field.ref}
+                                        name={field.name}
+                                        onBlur={field.onBlur}
+                                        onToggleSelected={(option, isSelected): void => {
+                                            setValue('ident', undefined);
+                                            if (isSelected) {
+                                                field.onChange(option);
+                                            } else {
+                                                field.onChange(null);
+                                            }
+                                        }}
+                                        shouldAutocomplete={true}
+                                    />
+                                )}
+                            />
+                            <HStack gap="space-16" align="center">
+                                <Checkbox
+                                    id="kun-loepende-andel"
+                                    title="Vis kun løpende andeler"
+                                    size="medium"
+                                    {...register('kunLøpendeAndel')}
+                                >
+                                    Kun løpende utbetalinger
+                                </Checkbox>
+                                <HelpText title="Løpende utbetaling">
+                                    Viser kun saker hvor barn har en løpende utbetaling
+                                </HelpText>
+                            </HStack>
                         </HStack>
-                    </HStack>
-                    <HStack gap="space-16">
-                        <Button type="submit" variant="primary" size="medium" icon={<FunnelIcon aria-hidden />}>
-                            Filtrer
-                        </Button>
-                        <Button
-                            variant="secondary"
-                            size="medium"
-                            onClick={() => {
-                                reset();
-                            }}
-                            icon={<FileResetIcon aria-hidden />}
-                        >
-                            Fjern filtre
-                        </Button>
-                    </HStack>
-                </VStack>
-            </StyledFieldset>
+                        <HStack gap="space-16">
+                            <Button type="submit" variant="primary" size="medium" icon={<FunnelIcon aria-hidden />}>
+                                Filtrer
+                            </Button>
+                            <Button
+                                variant="secondary"
+                                size="medium"
+                                onClick={() => {
+                                    reset();
+                                }}
+                                icon={<FileResetIcon aria-hidden />}
+                            >
+                                Fjern filtre
+                            </Button>
+                        </HStack>
+                    </VStack>
+                </Fieldset>
+            </Box>
         </form>
     );
 };

--- a/src/frontend/sider/Barnehagelister/BarnehagelisterInnhold.tsx
+++ b/src/frontend/sider/Barnehagelister/BarnehagelisterInnhold.tsx
@@ -1,6 +1,4 @@
-import styled from 'styled-components';
-
-import { Heading } from '@navikt/ds-react';
+import { Box, Heading } from '@navikt/ds-react';
 
 import { BarnehagebarnTabell } from './BarnehagebarnTabell';
 import BarnehagebarnTabellNavigator from './BarnehagebarnTabellNavigator';
@@ -8,18 +6,11 @@ import BarnehagelisterFilterskjema from './BarnehagelisterFilterskjema';
 import { LasterNyttTabellInnholdSpinner } from './LasterNyttTabellInnholdSpinner';
 import { useBarnehagelister } from './useBarnehagelister';
 
-const Container = styled.div`
-    padding: 0.5rem;
-    width: 100vw;
-    overflow: auto;
-    height: calc(100vh - 116px - 1.1rem);
-`;
-
 const BarnehagelisterInnhold = () => {
     const barnehagelisterContext = useBarnehagelister();
 
     return (
-        <Container>
+        <Box padding={'space-8'} width={'100vw'} overflow={'auto'} height={'calc(100vh - 116px - 1.1rem)'}>
             <Heading size={'medium'} level={'2'}>
                 Barnehageliste KS sak
             </Heading>
@@ -29,7 +20,7 @@ const BarnehagelisterInnhold = () => {
                 barnehagebarnRequestParams={barnehagelisterContext.barnehagebarnRequestParams}
             />
             <BarnehagebarnTabell {...barnehagelisterContext} />
-        </Container>
+        </Box>
     );
 };
 

--- a/src/frontend/sider/ManuellJournalføring/AvsenderPanel.module.css
+++ b/src/frontend/sider/ManuellJournalføring/AvsenderPanel.module.css
@@ -1,0 +1,10 @@
+.innerContent {
+    &[data-open='true'] {
+        padding: var(--ax-space-16);
+        padding-top: var(--ax-space-8);
+
+        & > div {
+            margin: var(--ax-space-16) var(--ax-space-64);
+        }
+    }
+}

--- a/src/frontend/sider/ManuellJournalføring/AvsenderPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/AvsenderPanel.tsx
@@ -1,29 +1,15 @@
 import { useEffect, useState } from 'react';
 
+import { EmailIkon } from '@ikoner/EmailIkon';
+import { formaterIdent } from '@utils/formatter';
 import classNames from 'classnames';
-import styled from 'styled-components';
 
 import { BodyShort, Checkbox, ExpansionCard, TextField } from '@navikt/ds-react';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
+import styles from './AvsenderPanel.module.css';
 import { DeltagerInfo } from './DeltagerInfo';
 import { useManuellJournalføringContext } from './ManuellJournalføringContext';
-import { EmailIkon } from '../../ikoner/EmailIkon';
-import { formaterIdent } from '../../utils/formatter';
-
-const StyledExpansionContent = styled(ExpansionCard.Content)`
-    &[data-open='true'] {
-        padding: var(--ax-space-8) var(--ax-space-16) var(--ax-space-16);
-
-        & > div {
-            margin: var(--ax-space-16) var(--ax-space-64);
-        }
-    }
-`;
-
-const StyledExpansionCard = styled(ExpansionCard)`
-    margin-top: 1rem;
-`;
 
 export const AvsenderPanel = () => {
     const { skjema, erLesevisning, settAvsenderLikBruker, tilbakestillAvsender } = useManuellJournalføringContext();
@@ -45,7 +31,7 @@ export const AvsenderPanel = () => {
     ]);
 
     return (
-        <StyledExpansionCard
+        <ExpansionCard
             open={åpen}
             onToggle={() => {
                 settÅpen(!åpen);
@@ -61,7 +47,7 @@ export const AvsenderPanel = () => {
                     undertittel="Avsender"
                 />
             </ExpansionCard.Header>
-            <StyledExpansionContent>
+            <ExpansionCard.Content className={styles.innerContent}>
                 {erLesevisning() ? (
                     brukerErAvsender ? (
                         <BodyShort
@@ -105,7 +91,7 @@ export const AvsenderPanel = () => {
                     placeholder={'Fnr/dnr/orgnr'}
                     disabled={brukerErAvsender}
                 />
-            </StyledExpansionContent>
-        </StyledExpansionCard>
+            </ExpansionCard.Content>
+        </ExpansionCard>
     );
 };

--- a/src/frontend/sider/ManuellJournalføring/BrukerPanel.module.css
+++ b/src/frontend/sider/ManuellJournalføring/BrukerPanel.module.css
@@ -1,0 +1,10 @@
+.innerContent {
+    &[data-open='true'] {
+        padding: var(--ax-space-16);
+        padding-top: var(--ax-space-8);
+
+        & > div {
+            margin: var(--ax-space-16) var(--ax-space-64);
+        }
+    }
+}

--- a/src/frontend/sider/ManuellJournalføring/BrukerPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/BrukerPanel.tsx
@@ -1,42 +1,16 @@
 import { useEffect, useState } from 'react';
 
 import { useHentFagsakPaaPersonError } from '@hooks/useHentFagsakPaaPersonError';
-import styled from 'styled-components';
+import { KontoSirkel } from '@ikoner/KontoSirkel';
+import { formaterIdent } from '@utils/formatter';
+import { identValidator } from '@utils/validators';
 
-import { Button, ExpansionCard, LocalAlert, TextField, VStack } from '@navikt/ds-react';
+import { Box, Button, ExpansionCard, HStack, LocalAlert, TextField, VStack } from '@navikt/ds-react';
 import { useFelt, Valideringsstatus } from '@navikt/familie-skjema';
 
+import styles from './BrukerPanel.module.css';
 import { DeltagerInfo } from './DeltagerInfo';
 import { useManuellJournalføringContext } from './ManuellJournalføringContext';
-import { KontoSirkel } from '../../ikoner/KontoSirkel';
-import { formaterIdent } from '../../utils/formatter';
-import { identValidator } from '../../utils/validators';
-
-const FlexDiv = styled.div`
-    display: flex;
-    margin-bottom: 1.5rem;
-`;
-
-const StyledExpansionCard = styled(ExpansionCard)`
-    margin-top: 1rem;
-    width: 100%;
-`;
-
-const StyledButton = styled(Button)`
-    margin-left: 1rem;
-    margin-top: auto;
-    width: 10rem;
-`;
-
-const StyledExpansionContent = styled(ExpansionCard.Content)`
-    &[data-open='true'] {
-        padding: var(--ax-space-8) var(--ax-space-16) var(--ax-space-16);
-
-        & > div {
-            margin: var(--ax-space-16) var(--ax-space-64);
-        }
-    }
-`;
 
 export const BrukerPanel = () => {
     const { skjema, endreBruker, erLesevisning } = useManuellJournalføringContext();
@@ -61,7 +35,7 @@ export const BrukerPanel = () => {
     }, [skjema.visFeilmeldinger, skjema.felter.bruker.valideringsstatus]);
 
     return (
-        <StyledExpansionCard
+        <ExpansionCard
             open={åpen}
             onToggle={() => {
                 settÅpen(!åpen);
@@ -77,10 +51,10 @@ export const BrukerPanel = () => {
                     ident={formaterIdent(skjema.felter.bruker.verdi?.personIdent ?? '')}
                 />
             </ExpansionCard.Header>
-            <StyledExpansionContent>
+            <ExpansionCard.Content className={styles.innerContent}>
                 {!erLesevisning() && (
                     <VStack>
-                        <FlexDiv>
+                        <HStack marginBlock={'space-24'} wrap={false} gap={'space-16'}>
                             <TextField
                                 {...nyIdent.hentNavInputProps(!!feilMelding)}
                                 error={nyIdent.hentNavInputProps(!!feilMelding).feil || feilMelding}
@@ -88,27 +62,36 @@ export const BrukerPanel = () => {
                                 description={'Skriv inn brukers/søkers fødselsnummer eller D-nummer'}
                                 size="small"
                             />
-                            <StyledButton
-                                onClick={() => {
-                                    if (nyIdent.valideringsstatus === Valideringsstatus.OK) {
-                                        settSpinner(true);
-                                        endreBruker(nyIdent.verdi)
-                                            .then((feilmelding: string) => {
-                                                settFeilMelding(feilmelding);
-                                            })
-                                            .finally(() => {
-                                                settSpinner(false);
-                                            });
-                                    } else {
-                                        settFeilMelding('Person ident er ugyldig');
-                                    }
-                                }}
-                                children={'Endre bruker'}
-                                loading={spinner}
-                                size="small"
-                                variant="secondary"
-                            />
-                        </FlexDiv>
+                            <Box
+                                marginBlock={
+                                    nyIdent.hentNavInputProps(!!feilMelding).feil || feilMelding
+                                        ? 'auto space-28'
+                                        : 'auto space-0'
+                                }
+                                width={'10rem'}
+                            >
+                                <Button
+                                    onClick={() => {
+                                        if (nyIdent.valideringsstatus === Valideringsstatus.OK) {
+                                            settSpinner(true);
+                                            endreBruker(nyIdent.verdi)
+                                                .then((feilmelding: string) => {
+                                                    settFeilMelding(feilmelding);
+                                                })
+                                                .finally(() => {
+                                                    settSpinner(false);
+                                                });
+                                        } else {
+                                            settFeilMelding('Person ident er ugyldig');
+                                        }
+                                    }}
+                                    children={'Endre bruker'}
+                                    loading={spinner}
+                                    size="small"
+                                    variant="secondary"
+                                />
+                            </Box>
+                        </HStack>
                         {hentFagsakPaaPersonError && (
                             <LocalAlert status={'error'}>
                                 <LocalAlert.Header>
@@ -119,7 +102,7 @@ export const BrukerPanel = () => {
                         )}
                     </VStack>
                 )}
-            </StyledExpansionContent>
-        </StyledExpansionCard>
+            </ExpansionCard.Content>
+        </ExpansionCard>
     );
 };

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentInfoStripe.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentInfoStripe.tsx
@@ -1,40 +1,10 @@
-import styled from 'styled-components';
+import { DokumentIkon } from '@ikoner/DokumentIkon';
+import { EksternLenke } from '@ikoner/EksternLenke';
 
-import { BodyShort } from '@navikt/ds-react';
+import { BodyShort, Box, HStack } from '@navikt/ds-react';
 import type { IDokumentInfo } from '@navikt/familie-typer';
 
-import { DokumentIkon } from '../../../ikoner/DokumentIkon';
-import { EksternLenke } from '../../../ikoner/EksternLenke';
 import FamilieBaseKnapp from '../../../komponenter/FamilieBaseKnapp';
-
-const DokumentInfoStripeContainer = styled.div`
-    display: flex;
-    justify-content: left;
-    align-items: flex-start;
-    width: 100%;
-    height: 100%;
-`;
-
-const DokumentTittelContainer = styled.div`
-    display: flex;
-    justfify-content: left;
-    flex-direction: column;
-`;
-
-const DokumentTittelDiv = styled.div`
-    font-size: 1.2rem;
-    margin-bottom: 10px;
-`;
-
-const StyledDokumentIkonDiv = styled.div`
-    margin: 0 16px 0 0;
-    min-width: 48px;
-    min-height: 48px;
-`;
-
-const StyledÅpenDokument = styled(FamilieBaseKnapp)`
-    margin-left: 10px;
-`;
 
 interface IDokumentInfoStripeProps {
     valgt: boolean;
@@ -44,28 +14,28 @@ interface IDokumentInfoStripeProps {
 
 export const DokumentInfoStripe = ({ valgt, journalpostId, dokument }: IDokumentInfoStripeProps) => {
     return (
-        <DokumentInfoStripeContainer>
-            <StyledDokumentIkonDiv>
+        <HStack align={'start'} height={'100%'} width={'100%'} wrap={false}>
+            <Box minWidth={'48'} minHeight={'48'} marginBlock={'space-0'} marginInline={'space-0 space-16'}>
                 <DokumentIkon filled={valgt} width={48} height={48} />
-            </StyledDokumentIkonDiv>
-            <DokumentTittelContainer>
-                <DokumentTittelDiv>
+            </Box>
+            <HStack gap={'space-8'} align={'center'}>
+                <BodyShort size={'large'} weight={'semibold'}>
                     {dokument.tittel || 'Ukjent'}
-                    <StyledÅpenDokument
-                        onClick={() => {
-                            window.open(
-                                `/familie-ks-sak/api/journalpost/${journalpostId}/dokument/${dokument.dokumentInfoId}/pdf`,
-                                '_blank'
-                            );
-                        }}
-                    >
-                        <EksternLenke />
-                    </StyledÅpenDokument>
-                </DokumentTittelDiv>
+                </BodyShort>
+                <FamilieBaseKnapp
+                    onClick={() => {
+                        window.open(
+                            `/familie-ks-sak/api/journalpost/${journalpostId}/dokument/${dokument.dokumentInfoId}/pdf`,
+                            '_blank'
+                        );
+                    }}
+                >
+                    <EksternLenke />
+                </FamilieBaseKnapp>
                 {dokument.logiskeVedlegg.map((it, index) => (
                     <BodyShort key={index}>{it.tittel}</BodyShort>
                 ))}
-            </DokumentTittelContainer>
-        </DokumentInfoStripeContainer>
+            </HStack>
+        </HStack>
     );
 };

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentVelger.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentVelger.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import styled from 'styled-components';
-
-import { ExpansionCard } from '@navikt/ds-react';
+import { Box, ExpansionCard } from '@navikt/ds-react';
 import type { IDokumentInfo } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -14,11 +12,6 @@ interface IDokumentVelgerProps {
     dokument: IDokumentInfo;
     visFeilmeldinger: boolean;
 }
-
-const StyledExpansionCard = styled(ExpansionCard)`
-    margin-top: 1rem;
-    width: 100%;
-`;
 
 export const DokumentVelger = ({ dokument, visFeilmeldinger }: IDokumentVelgerProps) => {
     const { dataForManuellJournalføring, valgtDokumentId, velgOgHentDokumentData } = useManuellJournalføringContext();
@@ -37,24 +30,26 @@ export const DokumentVelger = ({ dokument, visFeilmeldinger }: IDokumentVelgerPr
     }, [visFeilmeldinger]);
 
     return (
-        <StyledExpansionCard
-            open={åpen}
-            onToggle={() => {
-                settÅpen(!åpen);
-                if (!valgt && journalpostId && dokument.dokumentInfoId) {
-                    velgOgHentDokumentData(dokument.dokumentInfoId);
-                }
-            }}
-            aria-label={dokument.tittel || 'Ukjent'}
-        >
-            <ExpansionCard.Header>
-                <ExpansionCard.Title>
-                    <DokumentInfoStripe valgt={valgt} journalpostId={journalpostId} dokument={dokument} />
-                </ExpansionCard.Title>
-            </ExpansionCard.Header>
-            <ExpansionCard.Content>
-                <EndreDokumentInfoPanel dokument={dokument} visFeilmeldinger={visFeilmeldinger} />
-            </ExpansionCard.Content>
-        </StyledExpansionCard>
+        <Box marginBlock={'space-16 space-0'} width={'100%'}>
+            <ExpansionCard
+                open={åpen}
+                onToggle={() => {
+                    settÅpen(!åpen);
+                    if (!valgt && journalpostId && dokument.dokumentInfoId) {
+                        velgOgHentDokumentData(dokument.dokumentInfoId);
+                    }
+                }}
+                aria-label={dokument.tittel || 'Ukjent'}
+            >
+                <ExpansionCard.Header>
+                    <ExpansionCard.Title>
+                        <DokumentInfoStripe valgt={valgt} journalpostId={journalpostId} dokument={dokument} />
+                    </ExpansionCard.Title>
+                </ExpansionCard.Header>
+                <ExpansionCard.Content>
+                    <EndreDokumentInfoPanel dokument={dokument} visFeilmeldinger={visFeilmeldinger} />
+                </ExpansionCard.Content>
+            </ExpansionCard>
+        </Box>
     );
 };

--- a/src/frontend/sider/ManuellJournalføring/JournalpostSkjema.tsx
+++ b/src/frontend/sider/ManuellJournalføring/JournalpostSkjema.tsx
@@ -1,8 +1,9 @@
+import type { OppgavetypeFilter } from '@typer/oppgave';
+import { oppgaveTypeFilter } from '@typer/oppgave';
 import { useNavigate } from 'react-router';
-import styled from 'styled-components';
 
 import { ChevronLeftIcon } from '@navikt/aksel-icons';
-import { Button, ErrorSummary, Heading, HStack, LocalAlert } from '@navikt/ds-react';
+import { Box, Button, ErrorSummary, Heading, HStack, LocalAlert, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { AvsenderPanel } from './AvsenderPanel';
@@ -11,17 +12,6 @@ import { Dokumenter } from './Dokument/Dokumenter';
 import Journalpost from './Journalpost';
 import { KnyttJournalpostTilBehandling } from './KnyttJournalpostTilBehandling';
 import { useManuellJournalføringContext } from './ManuellJournalføringContext';
-import type { OppgavetypeFilter } from '../../typer/oppgave';
-import { oppgaveTypeFilter } from '../../typer/oppgave';
-
-const Container = styled.div`
-    padding: 2rem;
-    overflow: auto;
-`;
-
-const StyledSectionDiv = styled.div`
-    margin-top: 2.5rem;
-`;
 
 export const JournalpostSkjema = () => {
     const {
@@ -37,7 +27,7 @@ export const JournalpostSkjema = () => {
     const navigate = useNavigate();
 
     return (
-        <Container>
+        <Box overflow={'auto'} padding={'space-32'}>
             {dataForManuellJournalføring.status === RessursStatus.SUKSESS && (
                 <Heading spacing size="medium" level="2">
                     {
@@ -47,39 +37,40 @@ export const JournalpostSkjema = () => {
                     }
                 </Heading>
             )}
-            <Journalpost />
-            <StyledSectionDiv>
-                <Heading size={'small'} level={'2'} children={'Dokumenter'} />
-                <Dokumenter />
-            </StyledSectionDiv>
-            <StyledSectionDiv>
-                <Heading size={'small'} level={'2'} children={'Bruker og avsender'} />
-                <BrukerPanel />
-                <br />
-                <AvsenderPanel />
-            </StyledSectionDiv>
-            <StyledSectionDiv>
-                {kanKnytteJournalpostTilBehandling() && <KnyttJournalpostTilBehandling />}
-                <br />
-                {(skjema.submitRessurs.status === RessursStatus.FEILET ||
-                    skjema.submitRessurs.status === RessursStatus.FUNKSJONELL_FEIL ||
-                    skjema.submitRessurs.status === RessursStatus.IKKE_TILGANG) && (
-                    <LocalAlert status="error">
-                        <LocalAlert.Header>
-                            <LocalAlert.Title>{skjema.submitRessurs.frontendFeilmelding}</LocalAlert.Title>
-                        </LocalAlert.Header>
-                    </LocalAlert>
-                )}
-                {skjema.visFeilmeldinger && hentFeilTilOppsummering().length > 0 && (
-                    <ErrorSummary heading={'For å gå videre må du rette opp følgende'}>
-                        {hentFeilTilOppsummering().map(item => (
-                            <ErrorSummary.Item href={`#${item.skjemaelementId}`} key={item.skjemaelementId}>
-                                {item.feilmelding}
-                            </ErrorSummary.Item>
-                        ))}
-                    </ErrorSummary>
-                )}
-            </StyledSectionDiv>
+            <VStack gap={'space-40'}>
+                <Journalpost />
+                <VStack>
+                    <Heading size={'small'} level={'2'} children={'Dokumenter'} />
+                    <Dokumenter />
+                </VStack>
+                <VStack gap={'space-16'}>
+                    <Heading size={'small'} level={'2'} children={'Bruker og avsender'} />
+                    <BrukerPanel />
+                    <AvsenderPanel />
+                </VStack>
+                <VStack gap={'space-28'}>
+                    {kanKnytteJournalpostTilBehandling() && <KnyttJournalpostTilBehandling />}
+
+                    {(skjema.submitRessurs.status === RessursStatus.FEILET ||
+                        skjema.submitRessurs.status === RessursStatus.FUNKSJONELL_FEIL ||
+                        skjema.submitRessurs.status === RessursStatus.IKKE_TILGANG) && (
+                        <LocalAlert status="error">
+                            <LocalAlert.Header>
+                                <LocalAlert.Title>{skjema.submitRessurs.frontendFeilmelding}</LocalAlert.Title>
+                            </LocalAlert.Header>
+                        </LocalAlert>
+                    )}
+                    {skjema.visFeilmeldinger && hentFeilTilOppsummering().length > 0 && (
+                        <ErrorSummary heading={'For å gå videre må du rette opp følgende'}>
+                            {hentFeilTilOppsummering().map(item => (
+                                <ErrorSummary.Item href={`#${item.skjemaelementId}`} key={item.skjemaelementId}>
+                                    {item.feilmelding}
+                                </ErrorSummary.Item>
+                            ))}
+                        </ErrorSummary>
+                    )}
+                </VStack>
+            </VStack>
             <HStack marginBlock={'space-16'} justify={'space-between'}>
                 <Button
                     size="small"
@@ -112,6 +103,6 @@ export const JournalpostSkjema = () => {
                     </Button>
                 )}
             </HStack>
-        </Container>
+        </Box>
     );
 };

--- a/src/frontend/sider/ManuellJournalføring/KnyttJournalpostTilBehandling.tsx
+++ b/src/frontend/sider/ManuellJournalføring/KnyttJournalpostTilBehandling.tsx
@@ -1,18 +1,13 @@
-import styled from 'styled-components';
+import { behandlingsstatuser, behandlingstyper } from '@typer/behandling';
+import { finnVisningstekstForJournalføringsbehandlingsårsak } from '@typer/journalføringsbehandling';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
+import { ressursHarFeilet } from '@utils/ressursUtils';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
-import { Box, Checkbox, Heading, InfoCard, LocalAlert, Table, VStack } from '@navikt/ds-react';
+import { BodyShort, Box, Checkbox, Heading, InfoCard, LocalAlert, Table, VStack } from '@navikt/ds-react';
 
 import { KnyttTilNyBehandling } from './KnyttTilNyBehandling';
 import { useManuellJournalføringContext } from './ManuellJournalføringContext';
-import { behandlingsstatuser, behandlingstyper } from '../../typer/behandling';
-import { finnVisningstekstForJournalføringsbehandlingsårsak } from '../../typer/journalføringsbehandling';
-import { Datoformat, isoStringTilFormatertString } from '../../utils/dato';
-import { ressursHarFeilet } from '../../utils/ressursUtils';
-
-const GenerellSakInfoStripeTittel = styled.div`
-    font-weight: bold;
-`;
 
 export const KnyttJournalpostTilBehandling = () => {
     const {
@@ -120,11 +115,11 @@ export const KnyttJournalpostTilBehandling = () => {
                 <Box marginBlock={'space-32 space-0'}>
                     <InfoCard data-color="info">
                         <InfoCard.Message icon={<InformationSquareIcon aria-hidden />}>
-                            <GenerellSakInfoStripeTittel>
+                            <BodyShort weight={'semibold'}>
                                 {sorterteJournalføringsbehandlinger.length > 0
                                     ? `Du velger å journalføre uten å knytte til behandling(er).`
                                     : `Du velger å journalføre uten å knytte til ny behandling.`}
-                            </GenerellSakInfoStripeTittel>
+                            </BodyShort>
                         </InfoCard.Message>
                     </InfoCard>
                 </Box>

--- a/src/frontend/sider/ManuellJournalføring/KnyttTilNyBehandling.tsx
+++ b/src/frontend/sider/ManuellJournalføring/KnyttTilNyBehandling.tsx
@@ -1,16 +1,10 @@
 import { BehandlingstemaSelect } from '@sider/ManuellJournalføring/BehandlingstemaSelect';
 import BehandlingstypeFelt from '@sider/ManuellJournalføring/BehandlingstypeFelt';
 import { BehandlingårsakFelt } from '@sider/ManuellJournalføring/BehandlingsårsakFelt';
-import styled from 'styled-components';
 
-import { Checkbox, Fieldset, Heading } from '@navikt/ds-react';
-import { Space32 } from '@navikt/ds-tokens/dist/tokens';
+import { Box, Checkbox, Fieldset, Heading } from '@navikt/ds-react';
 
 import { useManuellJournalføringContext } from './ManuellJournalføringContext';
-
-const StyledFieldset = styled(Fieldset)`
-    margin-top: ${Space32};
-`;
 
 /**
  * Legger inn lesevisning slik at på sikt
@@ -21,48 +15,50 @@ export const KnyttTilNyBehandling = () => {
     const { skjema, minimalFagsak, kanKnytteJournalpostTilBehandling } = useManuellJournalføringContext();
     const { knyttTilNyBehandling, behandlingstype, behandlingstema } = skjema.felter;
     return (
-        <StyledFieldset legend="Knytt til ny behandling" hideLegend>
-            <Heading size={'small'} level={'2'}>
-                Knytt til ny behandling
-            </Heading>
-            <Checkbox
-                id={knyttTilNyBehandling.id}
-                value={'Knytt til ny behandling'}
-                checked={knyttTilNyBehandling.verdi}
-                onChange={() => {
-                    knyttTilNyBehandling.validerOgSettFelt(!knyttTilNyBehandling.verdi);
-                }}
-                readOnly={!kanKnytteJournalpostTilBehandling()}
-            >
-                {'Knytt til ny behandling'}
-            </Checkbox>
-            {behandlingstype.erSynlig && (
-                <BehandlingstypeFelt
-                    behandlingstype={skjema.felter.behandlingstype}
-                    visFeilmeldinger={skjema.visFeilmeldinger}
-                    minimalFagsak={minimalFagsak}
-                    erLesevisning={!kanKnytteJournalpostTilBehandling()}
-                    manuellJournalfør
-                />
-            )}
-
-            {skjema.felter.behandlingsårsak.erSynlig && (
-                <BehandlingårsakFelt
-                    behandlingsårsak={skjema.felter.behandlingsårsak}
-                    visFeilmeldinger={skjema.visFeilmeldinger}
-                    erLesevisning={!kanKnytteJournalpostTilBehandling()}
-                />
-            )}
-
-            {behandlingstema.erSynlig && (
-                <BehandlingstemaSelect
-                    behandlingstema={behandlingstema}
+        <Box marginBlock={'space-32 space-0'}>
+            <Fieldset legend="Knytt til ny behandling" hideLegend>
+                <Heading size={'small'} level={'2'}>
+                    Knytt til ny behandling
+                </Heading>
+                <Checkbox
+                    id={knyttTilNyBehandling.id}
+                    value={'Knytt til ny behandling'}
+                    checked={knyttTilNyBehandling.verdi}
+                    onChange={() => {
+                        knyttTilNyBehandling.validerOgSettFelt(!knyttTilNyBehandling.verdi);
+                    }}
                     readOnly={!kanKnytteJournalpostTilBehandling()}
-                    visFeilmeldinger={skjema.visFeilmeldinger}
-                    name="Behandlingstema"
-                    label="Velg behandlingstema"
-                />
-            )}
-        </StyledFieldset>
+                >
+                    {'Knytt til ny behandling'}
+                </Checkbox>
+                {behandlingstype.erSynlig && (
+                    <BehandlingstypeFelt
+                        behandlingstype={skjema.felter.behandlingstype}
+                        visFeilmeldinger={skjema.visFeilmeldinger}
+                        minimalFagsak={minimalFagsak}
+                        erLesevisning={!kanKnytteJournalpostTilBehandling()}
+                        manuellJournalfør
+                    />
+                )}
+
+                {skjema.felter.behandlingsårsak.erSynlig && (
+                    <BehandlingårsakFelt
+                        behandlingsårsak={skjema.felter.behandlingsårsak}
+                        visFeilmeldinger={skjema.visFeilmeldinger}
+                        erLesevisning={!kanKnytteJournalpostTilBehandling()}
+                    />
+                )}
+
+                {behandlingstema.erSynlig && (
+                    <BehandlingstemaSelect
+                        behandlingstema={behandlingstema}
+                        readOnly={!kanKnytteJournalpostTilBehandling()}
+                        visFeilmeldinger={skjema.visFeilmeldinger}
+                        name="Behandlingstema"
+                        label="Velg behandlingstema"
+                    />
+                )}
+            </Fieldset>
+        </Box>
     );
 };

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.module.css
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.module.css
@@ -1,0 +1,10 @@
+.toKolonner {
+    display: grid;
+    grid-template-columns: 40rem 1fr;
+    grid-template-rows: 1fr;
+    height: calc(100vh - 6rem);
+}
+
+.withAlert {
+    height: calc(100vh - 11.25rem);
+}

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.tsx
@@ -1,20 +1,13 @@
-import styled from 'styled-components';
+import { Personlinje } from '@komponenter/Personlinje/Personlinje';
+import classNames from 'classnames';
 
 import { GlobalAlert } from '@navikt/ds-react';
 import { Journalstatus, RessursStatus } from '@navikt/familie-typer';
 
 import { DokumentPanel } from './Dokument/DokumentPanel';
 import { JournalpostSkjema } from './JournalpostSkjema';
+import styles from './ManuellJournalføring.module.css';
 import { ManuellJournalføringProvider, useManuellJournalføringContext } from './ManuellJournalføringContext';
-import { Personlinje } from '../../komponenter/Personlinje/Personlinje';
-import { fagsakHeaderHøydeRem } from '../../typer/styling';
-
-const ToKolonnerDiv = styled.div<{ $viserAlert?: boolean }>`
-    display: grid;
-    grid-template-columns: 40rem 1fr;
-    grid-template-rows: 1fr;
-    height: calc(100vh - ${props => (props.$viserAlert ? fagsakHeaderHøydeRem + 5.25 : fagsakHeaderHøydeRem)}rem);
-`;
 
 const ManuellJournalføringContent = () => {
     const { dataForManuellJournalføring } = useManuellJournalføringContext();
@@ -41,10 +34,10 @@ const ManuellJournalføringContent = () => {
                         </>
                     )}
 
-                    <ToKolonnerDiv $viserAlert={viserAlert}>
+                    <div className={classNames(styles.toKolonner, { [styles.withAlert]: viserAlert })}>
                         <JournalpostSkjema />
                         <DokumentPanel />
-                    </ToKolonnerDiv>
+                    </div>
                 </>
             );
         case RessursStatus.FEILET:

--- a/src/frontend/utils/vilkår.module.css
+++ b/src/frontend/utils/vilkår.module.css
@@ -1,0 +1,4 @@
+.icon {
+    font-size: 1.5rem;
+    min-width: 1.5rem;
+}

--- a/src/frontend/utils/vilkår.tsx
+++ b/src/frontend/utils/vilkår.tsx
@@ -1,28 +1,18 @@
 import type { ReactNode } from 'react';
 
-import styled from 'styled-components';
+import { Regelverk } from '@typer/vilkår';
 
 import { FlagCrossIcon, StarsEuIcon } from '@navikt/aksel-icons';
 
-import { Regelverk } from '../typer/vilkår';
-
-const NorskFlaggIkon = styled(FlagCrossIcon)`
-    font-size: 1.5rem;
-    min-width: 1.5rem;
-`;
-
-const EuIkon = styled(StarsEuIcon)`
-    font-size: 1.5rem;
-    min-width: 1.5rem;
-`;
+import styles from './vilkår.module.css';
 
 export const alleRegelverk: Record<Regelverk, { tekst: string; symbol: ReactNode }> = {
     [Regelverk.NASJONALE_REGLER]: {
         tekst: 'Nasjonale regler',
-        symbol: <NorskFlaggIkon />,
+        symbol: <FlagCrossIcon className={styles.icon} />,
     },
     [Regelverk.EØS_FORORDNINGEN]: {
         tekst: 'EØS-forordningen',
-        symbol: <EuIkon />,
+        symbol: <StarsEuIcon className={styles.icon} />,
     },
 };


### PR DESCRIPTION
### 📮 Favro: NAV-26302
[Tilsvarende PR i Ba-sak-frontend](https://github.com/navikt/familie-ba-sak-frontend/pull/4647)

### 👀 Screen shots
Gammel venstre og ny høyre. Kopiert kode fra ba-sak-frontend pr er ikke tatt med skjermbilder av.

Barnehagelister
<img width="1667" height="685" alt="image" src="https://github.com/user-attachments/assets/c53392db-620d-4f93-b13f-33a6a0328e13" />

Manuell journalføring
<img width="1275" height="767" alt="image" src="https://github.com/user-attachments/assets/93ac4368-a80f-40f5-98ef-9f6ddebd2ae5" />
