### PR TITLE
NAV-29193: Fikser bug i ekspanderingslogikk

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingRoutes.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingRoutes.tsx
@@ -7,10 +7,7 @@ import Simulering from '@sider/Fagsak/Behandling/sider/Simulering/Simulering';
 import { SimuleringProvider } from '@sider/Fagsak/Behandling/sider/Simulering/SimuleringContext';
 import { Vedtak } from '@sider/Fagsak/Behandling/sider/Vedtak/Vedtak';
 import { VedtakContainer } from '@sider/Fagsak/Behandling/sider/Vedtak/VedtakContainer';
-import { EkspanderbareVilkårResultatRaderProvider } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/EkspanderbareVilkårResultatRaderContext';
-import { EkspanderbareVilkårsvurderingPanelerProvider } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/EkspanderbareVilkårsvurderingPanelerContext';
-import { Vilkårsvurdering } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/Vilkårsvurdering';
-import { VilkårsvurderingProvider } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/VilkårsvurderingContext';
+import { VilkårsvurderingContainer } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/VilkårsvurderingContainer';
 import { type RouteObject } from 'react-router';
 
 export const behandlingRoutes: RouteObject[] = [
@@ -24,15 +21,7 @@ export const behandlingRoutes: RouteObject[] = [
     },
     {
         path: 'vilkaarsvurdering',
-        element: (
-            <VilkårsvurderingProvider>
-                <EkspanderbareVilkårsvurderingPanelerProvider>
-                    <EkspanderbareVilkårResultatRaderProvider>
-                        <Vilkårsvurdering />
-                    </EkspanderbareVilkårResultatRaderProvider>
-                </EkspanderbareVilkårsvurderingPanelerProvider>
-            </VilkårsvurderingProvider>
-        ),
+        element: <VilkårsvurderingContainer />,
     },
     {
         path: 'tilkjent-ytelse',

--- a/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
@@ -43,14 +43,14 @@ export function HentOgSettBehandlingProvider({ children }: PropsWithChildren) {
         }
     }, [behandlingIdParam, erBehandlingDelAvFagsak]);
 
-    const settBehandlingRessurs = async (behandling: Ressurs<IBehandling>, oppdaterMinimalFagsak: boolean = true) => {
+    const settBehandlingRessurs = (behandling: Ressurs<IBehandling>, oppdaterMinimalFagsak: boolean = true) => {
         if (behandling.status === RessursStatus.SUKSESS) {
             queryClient.invalidateQueries({
                 queryKey: HentHistorikkinnslagQueryKeyFactory.historikkinnslag(behandling.data.behandlingId),
             });
         }
         if (oppdaterMinimalFagsak) {
-            await queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id) });
+            queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id) });
         }
         if (skalObfuskereData) {
             obfuskerBehandling(behandling);

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/EkspanderbareVilkårResultatRaderContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/EkspanderbareVilkårResultatRaderContext.tsx
@@ -2,12 +2,10 @@ import { createContext, type PropsWithChildren, useCallback, useContext, useMemo
 
 import { useBehandling } from '@hooks/useBehandling';
 import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IBehandling } from '@typer/behandling';
 import { Resultat } from '@typer/vilkår';
 
-function useInitielleEkspanderteIder(): Set<number> {
-    const behandling = useBehandling();
-    const erLesevisning = useErLesevisning();
-
+function finnInitielleEkspanderteIder(behandling: IBehandling, erLesevisning: boolean): Set<number> {
     const vilkårResultater = behandling.personResultater.flatMap(it => it.vilkårResultater);
 
     if (erLesevisning) {
@@ -32,11 +30,19 @@ interface EkspanderbareVilkårResultatRaderContext {
 const Context = createContext<EkspanderbareVilkårResultatRaderContext | undefined>(undefined);
 
 export function EkspanderbareVilkårResultatRaderProvider({ children }: PropsWithChildren) {
-    const initielleEkspanderteIdenter = useInitielleEkspanderteIder();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
-    const [ekspanderteIder, settEkspanderteIder] = useState(initielleEkspanderteIdenter);
+    const [ekspanderteIder, settEkspanderteIder] = useState(() =>
+        finnInitielleEkspanderteIder(behandling, erLesevisning)
+    );
 
-    const erRadEkspandert = useCallback((id: number) => ekspanderteIder.has(id), [ekspanderteIder]);
+    const erRadEkspandert = useCallback(
+        (id: number) => {
+            return ekspanderteIder.has(id);
+        },
+        [ekspanderteIder]
+    );
 
     const ekspanderRad = useCallback((id: number, isDirty: boolean = false) => {
         if (isDirty) {

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/EkspanderbareVilkårsvurderingPanelerContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/EkspanderbareVilkårsvurderingPanelerContext.tsx
@@ -2,12 +2,10 @@ import { createContext, type PropsWithChildren, useCallback, useContext, useMemo
 
 import { useBehandling } from '@hooks/useBehandling';
 import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IBehandling } from '@typer/behandling';
 import { Resultat } from '@typer/vilkår';
 
-function useInitielleEkspanderteIdenter(): Set<string> {
-    const behandling = useBehandling();
-    const erLesevisning = useErLesevisning();
-
+function finnInitielleEkspanderteIdenter(behandling: IBehandling, erLesevisning: boolean): Set<string> {
     if (erLesevisning) {
         return new Set(behandling.personResultater.map(pr => pr.personIdent));
     }
@@ -37,11 +35,19 @@ interface EkspanderbareVilkårsvurderingPanelerContext {
 const Context = createContext<EkspanderbareVilkårsvurderingPanelerContext | undefined>(undefined);
 
 export function EkspanderbareVilkårsvurderingPanelerProvider({ children }: PropsWithChildren) {
-    const initielleEkspanderteIdenter = useInitielleEkspanderteIdenter();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
-    const [ekspanderteIdenter, settEkspanderteIdenter] = useState<Set<string>>(initielleEkspanderteIdenter);
+    const [ekspanderteIdenter, settEkspanderteIdenter] = useState(() =>
+        finnInitielleEkspanderteIdenter(behandling, erLesevisning)
+    );
 
-    const erPanelEkspandert = useCallback((ident: string) => ekspanderteIdenter.has(ident), [ekspanderteIdenter]);
+    const erPanelEkspandert = useCallback(
+        (ident: string) => {
+            return ekspanderteIdenter.has(ident);
+        },
+        [ekspanderteIdenter]
+    );
 
     const ekspanderPanel = useCallback((ident: string) => {
         settEkspanderteIdenter(forrige => {

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -25,6 +25,7 @@ export function VilkårTabellRad({ toggleForm, lagretVilkårResultat, erVilkårE
 
     return (
         <Table.ExpandableRow
+            key={`${lagretVilkårResultat.id}-${erVilkårEkspandert ? 'ekspandert' : 'lukket'}`} // Pga. React.Activity ikke fungerer så bra med Aksel, se https://github.com/navikt/aksel/issues/5017
             open={erVilkårEkspandert}
             togglePlacement={'right'}
             onOpenChange={() => toggleForm(true)}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/VilkårsvurderingContainer.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vilkårsvurdering/VilkårsvurderingContainer.tsx
@@ -1,0 +1,16 @@
+import { EkspanderbareVilkårResultatRaderProvider } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/EkspanderbareVilkårResultatRaderContext';
+import { EkspanderbareVilkårsvurderingPanelerProvider } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/EkspanderbareVilkårsvurderingPanelerContext';
+import { Vilkårsvurdering } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/Vilkårsvurdering';
+import { VilkårsvurderingProvider } from '@sider/Fagsak/Behandling/sider/Vilkårsvurdering/VilkårsvurderingContext';
+
+export function VilkårsvurderingContainer() {
+    return (
+        <VilkårsvurderingProvider>
+            <EkspanderbareVilkårsvurderingPanelerProvider>
+                <EkspanderbareVilkårResultatRaderProvider>
+                    <Vilkårsvurdering />
+                </EkspanderbareVilkårResultatRaderProvider>
+            </EkspanderbareVilkårsvurderingPanelerProvider>
+        </VilkårsvurderingProvider>
+    );
+}


### PR DESCRIPTION
### 📮 Favro
NAV-29193

### 💰 Hva skal gjøres, og hvorfor?
Denne PR-en retter en bug i ekspanderings-/kollaps-logikken i vilkårsvurderingen, og rydder samtidig opp i hvordan kontekst-providers komposeres og initialiseres i UI-laget.

**Endringer:**
- Introduserer `VilkårsvurderingContainer` og bruker den i routing for å samle providers på ett sted.
- Legger til en `key` på `Table.ExpandableRow` for å få ønsket remount/oppførsel ved åpne/lukke (workaround mot Aksel/React.Activity-problematikk).
- Refaktorerer initiering av ekspanderte paneler/rader og justerer invalidation-logikk i behandling-context.
- Fjerner `await` i `settBehandlingRessurs` da den i praksisk ikke gjorde noe da ingen `await`ed metoden. Det sørger for at `settÅpenBehandling` som blir kalt før man navigere til vilkårsvurderingen blir ferdig før navigeringen er ferdig. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.


### 👀 Screen shots
Ingen visuelle endringer. 