### PR TITLE
NAV-29440: Rydder opp i sider.ts og venstremenyen

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
@@ -21,7 +21,7 @@ import type { ITotrinnskontrollData } from '../../../../../typer/totrinnskontrol
 import { TotrinnskontrollBeslutning } from '../../../../../typer/totrinnskontroll';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 import { KontrollertStatus } from '../../sider/sider';
-import type { ITrinn } from '../../sider/sider';
+import type { Trinn } from '../../sider/sider';
 import { Tab, useTabContext } from '../TabContextProvider';
 
 const Container = styled.div`
@@ -43,7 +43,7 @@ export function Totrinnskontroll() {
 
     const nullstillFeilmelding = () => {
         const erFørsteSjekk = Object.entries(forrigeState).some(([sideId, trinn]) => {
-            const oppdatertTrinn: ITrinn = Object.entries(trinnPåBehandling)
+            const oppdatertTrinn: Trinn = Object.entries(trinnPåBehandling)
                 .filter(([oppdatertSideId, _]) => sideId === oppdatertSideId)
                 .map(([_, aTrinn]) => aTrinn)[0];
             return (

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
@@ -55,7 +55,7 @@
 }
 
 .lenkeInaktiv {
-    color: var(--ax-text-neutral-subtle);
+    color: var(--ax-text-neutral-decoration);
     pointer-events: none;
 }
 

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
@@ -1,5 +1,8 @@
 import { Activity } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useFagsakId } from '@hooks/useFagsakId';
+import { formaterIdent } from '@utils/formatter';
 import classNames from 'classnames';
 import { NavLink } from 'react-router';
 
@@ -8,16 +11,15 @@ import { BodyShort, Box, Button, CopyButton, HStack, Stack, VStack } from '@navi
 
 import { useVenstremeny } from './useVenstremeny';
 import Styles from './Venstremeny.module.css';
-import { useFagsakId } from '../../../../hooks/useFagsakId';
-import { formaterIdent } from '../../../../utils/formatter';
-import { useBehandlingContext } from '../context/BehandlingContext';
-import { erSidenAktiv } from '../sider/sider';
+import { erSidenAktiv, finnSiderForBehandling } from '../sider/sider';
 
 export function Venstremeny() {
-    const { behandling, trinnPåBehandling } = useBehandlingContext();
-
     const fagsakId = useFagsakId();
+    const behandling = useBehandling();
+
     const [erÅpen, settErÅpen] = useVenstremeny();
+
+    const sider = finnSiderForBehandling(behandling);
 
     function stansNavigeringDersomSidenIkkeErAktiv(event: React.MouseEvent, sidenErAktiv: boolean) {
         if (!sidenErAktiv) {
@@ -45,12 +47,12 @@ export function Venstremeny() {
             />
             <Activity mode={erÅpen ? 'visible' : 'hidden'}>
                 <Box as={'nav'} width={'clamp(14rem, 15vw, 25rem)'}>
-                    {Object.entries(trinnPåBehandling).map(([sideId, side], index) => {
+                    {sider.map((side, index) => {
                         const tilPath = `/fagsak/${fagsakId}/${behandling.behandlingId}/${side.href}`;
                         const undersider = side.undersider ? side.undersider(behandling) : [];
                         const sidenErAktiv = erSidenAktiv(side, behandling);
                         return (
-                            <VStack key={sideId}>
+                            <VStack key={side.id}>
                                 <NavLink
                                     to={tilPath}
                                     className={({ isActive }) =>
@@ -69,7 +71,7 @@ export function Venstremeny() {
                                     const antallAksjonspunkter = underside.antallAksjonspunkter();
                                     return (
                                         <NavLink
-                                            key={`${sideId}_${underside.hash}`}
+                                            key={`${side.id}_${underside.hash}`}
                                             to={`${tilPath}#${underside.hash}`}
                                             className={({ isActive }) =>
                                                 classNames(Styles.undersidelenke, {

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -9,7 +9,7 @@ import { useLocation } from 'react-router';
 import { type Ressurs } from '@navikt/familie-typer';
 
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
-import { hentTrinnForBehandling, type ITrinn, KontrollertStatus, type SideId } from '../sider/sider';
+import { hentTrinnForBehandling, type Trinn, KontrollertStatus, type SideId } from '../sider/sider';
 
 interface Props extends PropsWithChildren {
     behandling: IBehandling;
@@ -18,7 +18,7 @@ interface Props extends PropsWithChildren {
 interface BehandlingContextValue {
     leggTilBesøktSide: (besøktSide: SideId) => void;
     settIkkeKontrollerteSiderTilManglerKontroll: () => void;
-    trinnPåBehandling: { [sideId: string]: ITrinn };
+    trinnPåBehandling: { [sideId: string]: Trinn };
     behandling: IBehandling;
     settÅpenBehandling: (behandling: Ressurs<IBehandling>, oppdaterMinimalFagsak?: boolean) => void;
 }
@@ -33,7 +33,7 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
     useNavigerAutomatiskTilSideForBehandlingssteg({ behandling });
 
     const location = useLocation();
-    const [trinnPåBehandling, settTrinnPåBehandling] = useState<{ [sideId: string]: ITrinn }>({});
+    const [trinnPåBehandling, settTrinnPåBehandling] = useState<{ [sideId: string]: Trinn }>({});
 
     useEffect(() => {
         const siderPåBehandling = hentTrinnForBehandling(behandling);

--- a/src/frontend/sider/Fagsak/Behandling/sider/sider.test.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/sider.test.ts
@@ -1,3 +1,6 @@
+import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
+import { BehandlingSteg, BehandlingÅrsak } from '@typer/behandling';
+
 import {
     erViPåUdefinertFagsakSide,
     erViPåUlovligSteg,
@@ -6,8 +9,6 @@ import {
     SideId,
     sider,
 } from './sider';
-import { lagBehandling } from '../../../../testutils/testdata/behandlingTestdata';
-import { BehandlingSteg, BehandlingÅrsak } from '../../../../typer/behandling';
 
 describe('sider.ts', () => {
     describe('siderForBehandling', () => {

--- a/src/frontend/sider/Fagsak/Behandling/sider/sider.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/sider.ts
@@ -1,24 +1,25 @@
-import { mapFraRestPersonResultatTilPersonResultat } from './Vilkårsvurdering/utils';
-import { BehandlingSteg, BehandlingÅrsak, hentStegNummer, type IBehandling } from '../../../../typer/behandling';
-import type { IPersonResultat, IVilkårResultat } from '../../../../typer/vilkår';
-import { Resultat } from '../../../../typer/vilkår';
+import { BehandlingSteg, BehandlingÅrsak, hentStegNummer, type IBehandling } from '@typer/behandling';
+import { Resultat } from '@typer/vilkår';
 
-export interface ISide {
+import { mapFraRestPersonResultatTilPersonResultat } from './Vilkårsvurdering/utils';
+
+export interface Side {
+    id: SideId;
     href: string;
     navn: string;
     steg: BehandlingSteg;
-    undersider?: (åpenBehandling: IBehandling) => IUnderside[];
-    visSide?: (åpenBehandling: IBehandling) => boolean;
+    undersider?: (behandling: IBehandling) => Underside[];
+    visSide?: (behandling: IBehandling) => boolean;
 }
 
-export interface IUnderside {
+export interface Underside {
     navn: string;
     ident: string;
     antallAksjonspunkter: () => number;
     hash: string;
 }
 
-export interface ITrinn extends ISide {
+export interface Trinn extends Side {
     kontrollert: KontrollertStatus;
 }
 
@@ -36,68 +37,75 @@ export enum SideId {
     VEDTAK = 'VEDTAK',
 }
 
-export const sider: Record<SideId, ISide> = {
+export const sider: Record<SideId, Side> = {
     REGISTRERE_SØKNAD: {
+        id: SideId.REGISTRERE_SØKNAD,
         href: 'registrer-soknad',
         navn: 'Registrer søknad',
         steg: BehandlingSteg.REGISTRERE_SØKNAD,
-        visSide: (åpenBehandling: IBehandling) => {
-            return åpenBehandling.årsak === BehandlingÅrsak.SØKNAD;
+        visSide: behandling => {
+            return behandling.årsak === BehandlingÅrsak.SØKNAD;
         },
     },
     VILKÅRSVURDERING: {
+        id: SideId.VILKÅRSVURDERING,
         href: 'vilkaarsvurdering',
         navn: 'Vilkårsvurdering',
         steg: BehandlingSteg.VILKÅRSVURDERING,
-        undersider: (åpenBehandling: IBehandling) => {
+        undersider: behandling => {
             const personResultater = mapFraRestPersonResultatTilPersonResultat(
-                åpenBehandling.personResultater,
-                åpenBehandling.personer
+                behandling.personResultater,
+                behandling.personer
             );
 
-            return personResultater.map((personResultat: IPersonResultat, index: number): IUnderside => {
+            return personResultater.map((personResultat, index): Underside => {
                 return {
                     navn: personResultat.person.navn,
                     ident: personResultat.person.personIdent,
                     hash: `${index}_${personResultat.person.fødselsdato}`,
-                    antallAksjonspunkter: () =>
-                        personResultat.vilkårResultater.filter((vilkårResultat: IVilkårResultat) => {
-                            return vilkårResultat.resultat === Resultat.IKKE_VURDERT;
-                        }).length,
+                    antallAksjonspunkter: () => {
+                        const vilkårSomErIkkeVurdert = personResultat.vilkårResultater.filter(
+                            vilkårResultat => vilkårResultat.resultat === Resultat.IKKE_VURDERT
+                        );
+                        return vilkårSomErIkkeVurdert.length;
+                    },
                 };
             });
         },
     },
     BEHANDLINGRESULTAT: {
+        id: SideId.BEHANDLINGRESULTAT,
         href: 'tilkjent-ytelse',
         navn: 'Behandlingsresultat',
         steg: BehandlingSteg.BEHANDLINGSRESULTAT,
     },
     SIMULERING: {
+        id: SideId.SIMULERING,
         href: 'simulering',
         navn: 'Simulering',
         steg: BehandlingSteg.SIMULERING,
-        visSide: (åpenBehandling: IBehandling) => {
+        visSide: behandling => {
             const erLovendringUtenSimuleringsteg =
-                åpenBehandling.årsak === BehandlingÅrsak.LOVENDRING_2024 &&
-                åpenBehandling.stegTilstand.every(steg => steg.behandlingSteg !== BehandlingSteg.SIMULERING);
+                behandling.årsak === BehandlingÅrsak.LOVENDRING_2024 &&
+                behandling.stegTilstand.every(steg => steg.behandlingSteg !== BehandlingSteg.SIMULERING);
             return !erLovendringUtenSimuleringsteg;
         },
     },
     VEDTAK: {
+        id: SideId.VEDTAK,
         href: 'vedtak',
         navn: 'Vedtak',
         steg: BehandlingSteg.VEDTAK,
-        visSide: (åpenBehandling: IBehandling) => {
+        visSide: behandling => {
             const erLovendringUtenVedtaksteg =
-                åpenBehandling.årsak === BehandlingÅrsak.LOVENDRING_2024 &&
-                åpenBehandling.stegTilstand.every(steg => steg.behandlingSteg !== BehandlingSteg.VEDTAK);
-            return åpenBehandling.årsak !== BehandlingÅrsak.SATSENDRING && !erLovendringUtenVedtaksteg;
+                behandling.årsak === BehandlingÅrsak.LOVENDRING_2024 &&
+                behandling.stegTilstand.every(steg => steg.behandlingSteg !== BehandlingSteg.VEDTAK);
+            return behandling.årsak !== BehandlingÅrsak.SATSENDRING && !erLovendringUtenVedtaksteg;
         },
     },
 };
 
-export const erSidenAktiv = (side: ISide, behandling: IBehandling): boolean => {
+export function erSidenAktiv(side: Side, behandling: IBehandling): boolean {
     const steg = behandling.steg;
 
     if (!side.steg && side.steg !== 0) {
@@ -108,12 +116,16 @@ export const erSidenAktiv = (side: ISide, behandling: IBehandling): boolean => {
         return false;
     }
     return hentStegNummer(side.steg) <= hentStegNummer(steg);
-};
+}
 
-export const hentTrinnForBehandling = (åpenBehandling: IBehandling): { [sideId: string]: ISide } => {
-    const visSide = (side: ISide) => {
+export function finnSiderForBehandling(behandling: IBehandling) {
+    return Object.values(sider).filter(side => side.visSide?.(behandling) ?? true);
+}
+
+export function hentTrinnForBehandling(behandling: IBehandling): { [sideId: string]: Side } {
+    const visSide = (side: Side) => {
         if (side.visSide) {
-            return side.visSide(åpenBehandling);
+            return side.visSide(behandling);
         } else {
             return true;
         }
@@ -126,9 +138,9 @@ export const hentTrinnForBehandling = (åpenBehandling: IBehandling): { [sideId:
                 [sideId]: side,
             };
         }, {});
-};
+}
 
-export const finnSideForBehandlingssteg = (behandling: IBehandling): ISide | undefined => {
+export function finnSideForBehandlingssteg(behandling: IBehandling): Side | undefined {
     const steg = behandling.steg;
 
     if (hentStegNummer(steg) >= hentStegNummer(BehandlingSteg.VEDTAK)) {
@@ -144,20 +156,22 @@ export const finnSideForBehandlingssteg = (behandling: IBehandling): ISide | und
     const sideForSteg = Object.entries(sider).find(([_, side]) => side.steg === steg);
 
     return sideForSteg ? sideForSteg[1] : undefined;
-};
+}
 
-export const erViPåUdefinertFagsakSide = (pathname: string) => {
+export function erViPåUdefinertFagsakSide(pathname: string) {
     return (
-        Object.values(sider).filter((side: ISide) => pathname.includes(side.href)).length === 0 &&
+        Object.values(sider).filter((side: Side) => pathname.includes(side.href)).length === 0 &&
         !pathname.includes('saksoversikt') &&
         !pathname.includes('ny-behandling')
     );
-};
+}
 
-export const erViPåUlovligSteg = (pathname: string, behandlingSide?: ISide) => {
-    if (!behandlingSide) return false;
+export function erViPåUlovligSteg(pathname: string, behandlingSide?: Side) {
+    if (!behandlingSide) {
+        return false;
+    }
 
-    const ønsketSteg: ISide | undefined = Object.values(sider).find((side: ISide) => pathname.includes(side.href));
+    const ønsketSteg = Object.values(sider).find((side: Side) => pathname.includes(side.href));
 
     if (ønsketSteg) {
         if (hentStegNummer(ønsketSteg?.steg) > hentStegNummer(behandlingSide.steg)) {
@@ -166,4 +180,4 @@ export const erViPåUlovligSteg = (pathname: string, behandlingSide?: ISide) => 
     }
 
     return false;
-};
+}


### PR DESCRIPTION
### 📮 Favro
NAV-29440

### 💰 Hva skal gjøres, og hvorfor?
Rydder opp i navigasjons-/side-definisjoner for behandling ved å modernisere typene i `sider.ts`, og forenkler venstremenyen ved å bruke felles side-filtrering (i stedet for å iterere via `trinnPåBehandling`).

**Endringer:**
- Omdøper typene (`Side`, `Underside`, `Trinn`) og legger til eksplisitt `id` på sider i `sider.ts`.
- Legger til `finnSiderForBehandling()` og oppdaterer venstremenyen til å bruke denne for å finne synlige sider.
- Oppdaterer imports/typer i kontekst og totrinnskontroll, samt justerer inaktiv lenke-farge i CSS.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Burde ikke være så stor logiske endringer.

### 👀 Screen shots
<img width="231" height="300" alt="image" src="https://github.com/user-attachments/assets/925f59de-fa3b-4fba-a9ac-293947d48b88" />