### PR TITLE
NAV-29440: Kontrollerte sider for totrinnskontroll

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Behandling.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Behandling.tsx
@@ -1,46 +1,22 @@
-import { useEffect } from 'react';
-
 import { useBehandlingIdParam } from '@hooks/useBehandlingIdParam';
 import { NotFound } from '@komponenter/Error/NotFound';
 import { Behandlingslinje } from '@komponenter/Saklinje/Behandlingslinje';
 import { HenleggBehandlingModal } from '@komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandlingModal';
 import { HenleggBehandlingVeivalgModal } from '@komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandlingVeivalgModal';
-import type { SideId } from '@sider/Fagsak/Behandling/sider/sider';
-import { sider } from '@sider/Fagsak/Behandling/sider/sider';
-import { hentSideHref } from '@utils/miljø';
-import { Outlet, useLocation } from 'react-router';
+import { KontrollsiderProvider } from '@sider/Fagsak/Behandling/KontrollsiderContext';
+import { Outlet } from 'react-router';
 
 import { Box, GlobalAlert, HStack, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import Styles from './Behandling.module.css';
-import { BehandlingProvider, useBehandlingContext } from './context/BehandlingContext';
+import { BehandlingProvider } from './context/BehandlingContext';
 import { useHentOgSettBehandlingContext } from './context/HentOgSettBehandlingContext';
 import { Høyremeny } from './Høyremeny/Høyremeny';
 import { TabContextProvider } from './Høyremeny/TabContextProvider';
 import { TotrinnskontrollModalContextProvider } from './Høyremeny/Totrinnskontroll/TotrinnskontrollModalContextProvider';
 import { KorrigerEtterbetalingModal } from './sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal';
 import { Venstremeny } from './Venstremeny/Venstremeny';
-
-/**
- * Dette er gjort fordi useEffecten her må kjøre etter at useEffectene i BehandlingProvider er kjørt. Ellers visker
- * den tilstand og viser masse "undefined" i GUI. Dette skjer spesielt hvis man er inne på vedtakssiden f.eks. og
- * refresher siden. Burde skrive en bedre logikk.
- */
-export function OutletContainer() {
-    const { leggTilBesøktSide } = useBehandlingContext();
-    const location = useLocation();
-
-    const sidevisning = hentSideHref(location.pathname);
-
-    useEffect(() => {
-        if (sidevisning) {
-            leggTilBesøktSide(Object.entries(sider).find(([_, side]) => side.href === sidevisning)?.[0] as SideId);
-        }
-    }, [sidevisning]);
-
-    return <Outlet />;
-}
 
 export function Behandling() {
     const { behandlingRessurs } = useHentOgSettBehandlingContext();
@@ -53,29 +29,32 @@ export function Behandling() {
 
     switch (behandlingRessurs.status) {
         case RessursStatus.SUKSESS:
+            const behandling = behandlingRessurs.data;
             return (
-                <BehandlingProvider behandling={behandlingRessurs.data}>
-                    <HenleggBehandlingModal />
-                    <HenleggBehandlingVeivalgModal />
-                    <KorrigerEtterbetalingModal />
-                    <VStack className={Styles.skrollbarStack}>
-                        <Behandlingslinje />
-                        <HStack className={Styles.skrollbarStack}>
-                            <Box className={Styles.venstreKolonne}>
-                                <Venstremeny />
-                            </Box>
-                            <Box className={Styles.midtreKolonne}>
-                                <OutletContainer />
-                            </Box>
-                            <Box className={Styles.høyreKolonne}>
-                                <TotrinnskontrollModalContextProvider>
-                                    <TabContextProvider>
-                                        <Høyremeny />
-                                    </TabContextProvider>
-                                </TotrinnskontrollModalContextProvider>
-                            </Box>
-                        </HStack>
-                    </VStack>
+                <BehandlingProvider key={behandling.behandlingId} behandling={behandling}>
+                    <KontrollsiderProvider>
+                        <HenleggBehandlingModal />
+                        <HenleggBehandlingVeivalgModal />
+                        <KorrigerEtterbetalingModal />
+                        <VStack className={Styles.skrollbarStack}>
+                            <Behandlingslinje />
+                            <HStack className={Styles.skrollbarStack}>
+                                <Box className={Styles.venstreKolonne}>
+                                    <Venstremeny />
+                                </Box>
+                                <Box className={Styles.midtreKolonne}>
+                                    <Outlet />
+                                </Box>
+                                <Box className={Styles.høyreKolonne}>
+                                    <TotrinnskontrollModalContextProvider>
+                                        <TabContextProvider>
+                                            <Høyremeny />
+                                        </TabContextProvider>
+                                    </TotrinnskontrollModalContextProvider>
+                                </Box>
+                            </HStack>
+                        </VStack>
+                    </KontrollsiderProvider>
                 </BehandlingProvider>
             );
         case RessursStatus.IKKE_TILGANG:

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { HentVedtaksperioderQueryKeyFactory } from '@hooks/useHentVedtaksperioder';
+import { useKontrollsiderContext } from '@sider/Fagsak/Behandling/KontrollsiderContext';
 import { useQueryClient } from '@tanstack/react-query';
 import type { IBehandling } from '@typer/behandling';
 import { BehandlingStatus } from '@typer/behandling';
@@ -23,7 +24,6 @@ import { useTotrinnskontrollModalContext } from './TotrinnskontrollModalContextP
 import { Totrinnskontrollskjema } from './Totrinnskontrollskjema';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 import { KontrollertStatus } from '../../sider/sider';
-import type { Trinn } from '../../sider/sider';
 import { Tab, useTabContext } from '../TabContextProvider';
 
 const Container = styled.div`
@@ -32,8 +32,8 @@ const Container = styled.div`
 `;
 
 export function Totrinnskontroll() {
-    const { behandling, trinnPåBehandling, settIkkeKontrollerteSiderTilManglerKontroll, settÅpenBehandling } =
-        useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
+    const { kontrollsider, settIkkeKontrollerteSiderTilManglerKontroll } = useKontrollsiderContext();
     const { settTab } = useTabContext();
     const { åpneModal } = useTotrinnskontrollModalContext();
 
@@ -42,34 +42,31 @@ export function Totrinnskontroll() {
 
     const [innsendtVedtak, settInnsendtVedtak] = useState<Ressurs<IBehandling>>(byggTomRessurs());
 
-    const [forrigeState, settForrigeState] = useState(trinnPåBehandling);
+    const [forrigeKontrollsider, settForrigeKontrollsider] = useState(kontrollsider);
 
     const nullstillFeilmelding = () => {
-        const erFørsteSjekk = Object.entries(forrigeState).some(([sideId, trinn]) => {
-            const oppdatertTrinn: Trinn = Object.entries(trinnPåBehandling)
-                .filter(([oppdatertSideId, _]) => sideId === oppdatertSideId)
-                .map(([_, aTrinn]) => aTrinn)[0];
+        const harMinstEnSideBlittKontrollert = forrigeKontrollsider.some(forrigeSide => {
+            const nåværendeSide = kontrollsider.find(side => side.id === forrigeSide.id);
             return (
-                (trinn.kontrollert === KontrollertStatus.IKKE_KONTROLLERT ||
-                    trinn.kontrollert === KontrollertStatus.MANGLER_KONTROLL) &&
-                oppdatertTrinn.kontrollert === KontrollertStatus.KONTROLLERT
+                forrigeSide.kontrollertStatus !== KontrollertStatus.KONTROLLERT &&
+                nåværendeSide?.kontrollertStatus === KontrollertStatus.KONTROLLERT
             );
         });
-        if (erFørsteSjekk) {
+        if (harMinstEnSideBlittKontrollert) {
             settInnsendtVedtak(byggTomRessurs());
         }
-        settForrigeState(trinnPåBehandling);
+        settForrigeKontrollsider(kontrollsider);
     };
 
     useEffect(() => {
         nullstillFeilmelding();
-    }, [trinnPåBehandling]);
+    }, [kontrollsider]);
 
     const sendInnVedtak = (beslutning: TotrinnskontrollBeslutning, begrunnelse: string, egetVedtak: boolean) => {
-        if (
-            !egetVedtak &&
-            Object.values(trinnPåBehandling).some(trinn => trinn.kontrollert !== KontrollertStatus.KONTROLLERT)
-        ) {
+        const harSideSomIkkeErKontrollert = kontrollsider.some(
+            side => side.kontrollertStatus !== KontrollertStatus.KONTROLLERT
+        );
+        if (!egetVedtak && harSideSomIkkeErKontrollert) {
             settIkkeKontrollerteSiderTilManglerKontroll();
             settInnsendtVedtak(byggFunksjonellFeilRessurs('Du må kontrollere alle steg i løsningen.'));
             return;
@@ -87,9 +84,7 @@ export function Totrinnskontroll() {
                 data: {
                     beslutning,
                     begrunnelse,
-                    kontrollerteSider: Object.entries(trinnPåBehandling).map(([_, side]) => {
-                        return side.navn;
-                    }),
+                    kontrollerteSider: kontrollsider.map(side => side.navn),
                 },
                 url: `/familie-ks-sak/api/behandlinger/${behandling.behandlingId}/steg/beslutt-vedtak`,
             })

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -1,20 +1,21 @@
 import { useState } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { useKontrollsiderContext } from '@sider/Fagsak/Behandling/KontrollsiderContext';
+import type { IBehandling } from '@typer/behandling';
+import { TotrinnskontrollBeslutning } from '@typer/totrinnskontroll';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import styled from 'styled-components';
 
 import { BodyShort, Button, Detail, Fieldset, Heading, HStack, Radio, RadioGroup, Textarea } from '@navikt/ds-react';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useSaksbehandler } from '../../../../../hooks/useSaksbehandler';
 import ØyeGrå from '../../../../../ikoner/ØyeGrå';
 import ØyeGrønn from '../../../../../ikoner/ØyeGrønn';
 import ØyeRød from '../../../../../ikoner/ØyeRød';
-import type { IBehandling } from '../../../../../typer/behandling';
-import { TotrinnskontrollBeslutning } from '../../../../../typer/totrinnskontroll';
-import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
-import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 import { KontrollertStatus } from '../../sider/sider';
 
 interface Props {
@@ -27,8 +28,10 @@ const StyledButton = styled(Button)`
 `;
 
 export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props) {
-    const { behandling, trinnPåBehandling } = useBehandlingContext();
     const saksbehandler = useSaksbehandler();
+    const behandling = useBehandling();
+
+    const { kontrollsider } = useKontrollsiderContext();
 
     const [beslutning, settBeslutning] = useState<TotrinnskontrollBeslutning>(TotrinnskontrollBeslutning.IKKE_VURDERT);
     const [begrunnelse, settBegrunnelse] = useState<string>('');
@@ -70,10 +73,13 @@ export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props)
             ) : (
                 <div>
                     <BodyShort weight={'semibold'}>Kontrollerte trinn</BodyShort>
-
-                    {Object.entries(trinnPåBehandling).map(([_, trinn], index) => {
+                    {kontrollsider.map((side, index) => {
                         return (
-                            <TrinnStatus kontrollertStatus={trinn.kontrollert} navn={`${index + 1}. ${trinn.navn}`} />
+                            <TrinnStatus
+                                key={side.id}
+                                kontrollertStatus={side.kontrollertStatus}
+                                navn={`${index + 1}. ${side.navn}`}
+                            />
                         );
                     })}
                 </div>

--- a/src/frontend/sider/Fagsak/Behandling/KontrollsiderContext.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/KontrollsiderContext.test.tsx
@@ -1,0 +1,360 @@
+import type { PropsWithChildren } from 'react';
+
+import { KontrollertStatus, SideId, type Kontrollside } from '@sider/Fagsak/Behandling/sider/sider';
+import { renderHook, act } from '@testing-library/react';
+import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
+import { lagSaksbehandler } from '@testutils/testdata/saksbehandlerTestdata';
+import {
+    BehandlerRolle,
+    BehandlingStatus,
+    BehandlingSteg,
+    BehandlingStegStatus,
+    BehandlingÅrsak,
+} from '@typer/behandling';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+import { KontrollsiderProvider, useKontrollsiderContext } from './KontrollsiderContext';
+
+const { useLocationMock, useBehandlingMock, useSaksbehandlerMock } = vi.hoisted(() => ({
+    useLocationMock: vi.fn(),
+    useBehandlingMock: vi.fn(),
+    useSaksbehandlerMock: vi.fn(),
+}));
+
+vi.mock('@hooks/useBehandling', () => ({ useBehandling: useBehandlingMock }));
+vi.mock('@hooks/useSaksbehandler', () => ({ useSaksbehandler: useSaksbehandlerMock }));
+vi.mock('react-router', () => ({ useLocation: useLocationMock }));
+
+function lagPathname(href: string) {
+    return `/fagsak/123/321/${href}`;
+}
+
+function statusForSide(sider: Kontrollside[], id: SideId) {
+    return sider.find(side => side.id === id)?.kontrollertStatus;
+}
+
+function renderHookWithProvider() {
+    return renderHook(() => useKontrollsiderContext(), {
+        wrapper: ({ children }: PropsWithChildren) => <KontrollsiderProvider>{children}</KontrollsiderProvider>,
+    });
+}
+
+const defaultLocation = { pathname: lagPathname('vilkaarsvurdering') };
+
+const defaultBehandling = lagBehandling({
+    status: BehandlingStatus.FATTER_VEDTAK,
+    endretAv: 'saksbehandler@nav.no',
+    årsak: BehandlingÅrsak.SØKNAD,
+});
+
+const defaultSaksbehandler = lagSaksbehandler({
+    rolle: BehandlerRolle.BESLUTTER,
+    email: 'beslutter@nav.no',
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    useLocationMock.mockReturnValue(defaultLocation);
+    useBehandlingMock.mockReturnValue(defaultBehandling);
+    useSaksbehandlerMock.mockReturnValue(defaultSaksbehandler);
+});
+
+describe('KontrollsiderProvider', () => {
+    describe('Initialisering av kontrollsider', () => {
+        test('inneholder sidene som vises for behandlingen', () => {
+            const { result } = renderHookWithProvider();
+
+            expect(result.current.kontrollsider.map(side => side.id)).toEqual([
+                SideId.REGISTRERE_SØKNAD,
+                SideId.VILKÅRSVURDERING,
+                SideId.BEHANDLINGRESULTAT,
+                SideId.SIMULERING,
+                SideId.VEDTAK,
+            ]);
+        });
+
+        test('markerer den åpne siden som kontrollert ved mount', () => {
+            const { result } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+        });
+
+        test('lar øvrige sider være ikke kontrollert ved mount', () => {
+            const { result } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.BEHANDLINGRESULTAT)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.IKKE_KONTROLLERT);
+        });
+    });
+
+    describe('Tilgang til å kontrollere sider', () => {
+        test('markerer ikke åpen side når saksbehandler ikke er beslutter', () => {
+            useSaksbehandlerMock.mockReturnValue(lagSaksbehandler({ rolle: BehandlerRolle.SAKSBEHANDLER }));
+
+            const { result } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+        });
+
+        test('markerer ikke åpen side når behandlingen ikke er til fatte vedtak', () => {
+            useBehandlingMock.mockReturnValue(lagBehandling({ status: BehandlingStatus.UTREDES }));
+
+            const { result } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+        });
+
+        test('markerer ikke åpen side når beslutter selv endret behandlingen', () => {
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({ status: BehandlingStatus.FATTER_VEDTAK, endretAv: 'beslutter@nav.no' })
+            );
+
+            const { result } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+        });
+
+        test('markerer ikke besøkte sider når man ikke kan beslutte vedtak', () => {
+            useSaksbehandlerMock.mockReturnValue(lagSaksbehandler({ rolle: BehandlerRolle.SAKSBEHANDLER }));
+
+            const { result, rerender } = renderHookWithProvider();
+            useLocationMock.mockReturnValue({ pathname: lagPathname('vedtak') });
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.IKKE_KONTROLLERT);
+        });
+    });
+
+    describe('Markering av besøkte sider som kontrollert', () => {
+        test('markerer en side som kontrollert når man navigerer til den', () => {
+            const { result, rerender } = renderHookWithProvider();
+            useLocationMock.mockReturnValue({ pathname: lagPathname('vedtak') });
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.KONTROLLERT);
+        });
+
+        test('beholder tidligere besøkte sider som kontrollert ved videre navigering', () => {
+            const { result, rerender } = renderHookWithProvider();
+            useLocationMock.mockReturnValue({ pathname: lagPathname('tilkjent-ytelse') });
+            rerender();
+            useLocationMock.mockReturnValue({ pathname: lagPathname('vedtak') });
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+            expect(statusForSide(result.current.kontrollsider, SideId.BEHANDLINGRESULTAT)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.KONTROLLERT);
+        });
+
+        test('markerer ingen side når gjeldende href ikke matcher noen side', () => {
+            const { result, rerender } = renderHookWithProvider();
+            useLocationMock.mockReturnValue({ pathname: lagPathname('finnes-ikke') });
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.BEHANDLINGRESULTAT)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.IKKE_KONTROLLERT);
+        });
+    });
+
+    describe('Markering av sider som mangler kontroll', () => {
+        test('setter ikke-kontrollerte sider til mangler kontroll', () => {
+            const { result } = renderHookWithProvider();
+
+            act(() => result.current.settIkkeKontrollerteSiderTilManglerKontroll());
+
+            expect(statusForSide(result.current.kontrollsider, SideId.BEHANDLINGRESULTAT)).toBe(
+                KontrollertStatus.MANGLER_KONTROLL
+            );
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.MANGLER_KONTROLL);
+        });
+
+        test('lar kontrollerte sider være uendret', () => {
+            const { result } = renderHookWithProvider();
+
+            act(() => result.current.settIkkeKontrollerteSiderTilManglerKontroll());
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+        });
+
+        test('gjør ingenting når man ikke kan beslutte vedtak', () => {
+            useSaksbehandlerMock.mockReturnValue(lagSaksbehandler({ rolle: BehandlerRolle.SAKSBEHANDLER }));
+
+            const { result } = renderHookWithProvider();
+
+            act(() => result.current.settIkkeKontrollerteSiderTilManglerKontroll());
+
+            result.current.kontrollsider.forEach(side =>
+                expect(side.kontrollertStatus).toBe(KontrollertStatus.IKKE_KONTROLLERT)
+            );
+        });
+    });
+
+    describe('Synkronisering når sidelisten endres', () => {
+        test('legger til nye sider som ikke kontrollert', () => {
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({
+                    status: BehandlingStatus.FATTER_VEDTAK,
+                    årsak: BehandlingÅrsak.LOVENDRING_2024,
+                    stegTilstand: [],
+                })
+            );
+
+            const { result, rerender } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.SIMULERING)).toBeUndefined();
+
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({
+                    status: BehandlingStatus.FATTER_VEDTAK,
+                    årsak: BehandlingÅrsak.LOVENDRING_2024,
+                    stegTilstand: [
+                        {
+                            behandlingSteg: BehandlingSteg.SIMULERING,
+                            behandlingStegStatus: BehandlingStegStatus.UTFØRT,
+                        },
+                    ],
+                })
+            );
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.SIMULERING)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+        });
+
+        test('fjerner sider som ikke lenger vises', () => {
+            const { result, rerender } = renderHookWithProvider();
+
+            expect(result.current.kontrollsider.map(side => side.id)).toContain(SideId.SIMULERING);
+            expect(result.current.kontrollsider).toHaveLength(5);
+
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({
+                    status: BehandlingStatus.FATTER_VEDTAK,
+                    årsak: BehandlingÅrsak.LOVENDRING_2024,
+                    stegTilstand: [],
+                })
+            );
+            rerender();
+
+            expect(result.current.kontrollsider.map(side => side.id)).not.toContain(SideId.SIMULERING);
+        });
+
+        test('bevarer kontrollert-status for sider som fortsatt vises', () => {
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({
+                    status: BehandlingStatus.FATTER_VEDTAK,
+                    endretAv: 'saksbehandler@nav.no',
+                    årsak: BehandlingÅrsak.LOVENDRING_2024,
+                    stegTilstand: [],
+                })
+            );
+
+            const { result, rerender } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({
+                    status: BehandlingStatus.FATTER_VEDTAK,
+                    endretAv: 'saksbehandler@nav.no',
+                    årsak: BehandlingÅrsak.LOVENDRING_2024,
+                    stegTilstand: [
+                        {
+                            behandlingSteg: BehandlingSteg.SIMULERING,
+                            behandlingStegStatus: BehandlingStegStatus.UTFØRT,
+                        },
+                    ],
+                })
+            );
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+        });
+
+        test('fjerner sider når årsak endrer hvilke som vises', () => {
+            const { result, rerender } = renderHookWithProvider();
+
+            expect(result.current.kontrollsider.map(side => side.id)).toContain(SideId.REGISTRERE_SØKNAD);
+
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({ status: BehandlingStatus.FATTER_VEDTAK, årsak: BehandlingÅrsak.SATSENDRING })
+            );
+            rerender();
+
+            const ider = result.current.kontrollsider.map(side => side.id);
+            expect(ider).not.toContain(SideId.REGISTRERE_SØKNAD);
+            expect(ider).not.toContain(SideId.VEDTAK);
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+        });
+
+        test('markerer en nylig tillagt side som kontrollert dersom den er den åpne siden', () => {
+            useLocationMock.mockReturnValue({ pathname: lagPathname('simulering') });
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({
+                    status: BehandlingStatus.FATTER_VEDTAK,
+                    endretAv: 'saksbehandler@nav.no',
+                    årsak: BehandlingÅrsak.LOVENDRING_2024,
+                    stegTilstand: [],
+                })
+            );
+
+            const { result, rerender } = renderHookWithProvider();
+
+            expect(result.current.kontrollsider.find(side => side.id === SideId.SIMULERING)).toBeUndefined();
+
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({
+                    status: BehandlingStatus.FATTER_VEDTAK,
+                    endretAv: 'saksbehandler@nav.no',
+                    årsak: BehandlingÅrsak.LOVENDRING_2024,
+                    stegTilstand: [
+                        {
+                            behandlingSteg: BehandlingSteg.SIMULERING,
+                            behandlingStegStatus: BehandlingStegStatus.UTFØRT,
+                        },
+                    ],
+                })
+            );
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.SIMULERING)).toBe(KontrollertStatus.KONTROLLERT);
+        });
+    });
+
+    describe('Bruk av context utenfor provider', () => {
+        test('kaster feil når context brukes utenfor en provider', () => {
+            const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            expect(() => renderHook(() => useKontrollsiderContext())).toThrow(
+                'useKontrollsiderContext må brukes innenfor en KontrollsiderProvider.'
+            );
+
+            consoleError.mockRestore();
+        });
+    });
+});

--- a/src/frontend/sider/Fagsak/Behandling/KontrollsiderContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/KontrollsiderContext.tsx
@@ -1,0 +1,85 @@
+import { createContext, type PropsWithChildren, useCallback, useContext, useMemo, useState } from 'react';
+
+import { useBehandling } from '@hooks/useBehandling';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import type { SideId } from '@sider/Fagsak/Behandling/sider/sider';
+import { finnSiderForBehandling, KontrollertStatus, type Kontrollside } from '@sider/Fagsak/Behandling/sider/sider';
+import { BehandlerRolle, BehandlingStatus } from '@typer/behandling';
+import { hentSideHref } from '@utils/miljø';
+import { useLocation } from 'react-router';
+
+interface KontrollsiderContext {
+    kontrollsider: Kontrollside[];
+    settIkkeKontrollerteSiderTilManglerKontroll: () => void;
+}
+
+const Context = createContext<KontrollsiderContext | undefined>(undefined);
+
+export function KontrollsiderProvider({ children }: PropsWithChildren) {
+    const location = useLocation();
+    const saksbehandler = useSaksbehandler();
+    const behandling = useBehandling();
+
+    const [kontrollerteStatuser, setKontrollerteStatuser] = useState<Partial<Record<SideId, KontrollertStatus>>>({});
+
+    // Forhindrer ny liste ved hver render, viktig pga. equality-check.
+    const sider = useMemo(() => finnSiderForBehandling(behandling), [behandling]);
+
+    const erPåFatterVedtak = behandling.status === BehandlingStatus.FATTER_VEDTAK;
+    const erBeslutter = saksbehandler.rolle === BehandlerRolle.BESLUTTER;
+    const erIkkeSaksbehandlerPåBehandlingen = saksbehandler.email !== behandling.endretAv; // TODO : Er dette egentlig korrekt?
+    const kanBeslutteVedtak = erPåFatterVedtak && erBeslutter && erIkkeSaksbehandlerPåBehandlingen;
+
+    const sideHref = hentSideHref(location.pathname);
+    const åpenSideId = sider.find(side => side.href === sideHref)?.id;
+
+    const besøkteSideErIkkeKontrollert =
+        åpenSideId !== undefined && kontrollerteStatuser[åpenSideId] !== KontrollertStatus.KONTROLLERT;
+
+    if (kanBeslutteVedtak && besøkteSideErIkkeKontrollert) {
+        setKontrollerteStatuser(prev => ({
+            ...prev,
+            [åpenSideId]: KontrollertStatus.KONTROLLERT,
+        }));
+    }
+
+    const kontrollsider = useMemo(
+        () =>
+            sider.map(side => ({
+                ...side,
+                kontrollertStatus: kontrollerteStatuser[side.id] ?? KontrollertStatus.IKKE_KONTROLLERT,
+            })),
+        [sider, kontrollerteStatuser]
+    );
+
+    const settIkkeKontrollerteSiderTilManglerKontroll = useCallback(() => {
+        if (!kanBeslutteVedtak) {
+            return;
+        }
+        setKontrollerteStatuser(forrige => {
+            const nyeStatuser = { ...forrige };
+            sider.forEach(side => {
+                const status = nyeStatuser[side.id] ?? KontrollertStatus.IKKE_KONTROLLERT;
+                if (status === KontrollertStatus.IKKE_KONTROLLERT) {
+                    nyeStatuser[side.id] = KontrollertStatus.MANGLER_KONTROLL;
+                }
+            });
+            return nyeStatuser;
+        });
+    }, [kanBeslutteVedtak, sider]);
+
+    const value = useMemo(
+        () => ({ kontrollsider, settIkkeKontrollerteSiderTilManglerKontroll }),
+        [kontrollsider, settIkkeKontrollerteSiderTilManglerKontroll]
+    );
+
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+}
+
+export function useKontrollsiderContext() {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useKontrollsiderContext må brukes innenfor en KontrollsiderProvider.');
+    }
+    return context;
+}

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -1,112 +1,39 @@
-import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
+import { createContext, type PropsWithChildren, useContext } from 'react';
 
 import { useNavigerAutomatiskTilSideForBehandlingssteg } from '@hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
-import { useSaksbehandler } from '@hooks/useSaksbehandler';
-import { BehandlerRolle, BehandlingStatus, type IBehandling } from '@typer/behandling';
-import { hentSideHref } from '@utils/miljø';
-import { useLocation } from 'react-router';
+import { type IBehandling } from '@typer/behandling';
 
 import { type Ressurs } from '@navikt/familie-typer';
 
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
-import { hentTrinnForBehandling, type Trinn, KontrollertStatus, type SideId } from '../sider/sider';
 
 interface Props extends PropsWithChildren {
     behandling: IBehandling;
 }
 
 interface BehandlingContextValue {
-    leggTilBesøktSide: (besøktSide: SideId) => void;
-    settIkkeKontrollerteSiderTilManglerKontroll: () => void;
-    trinnPåBehandling: { [sideId: string]: Trinn };
     behandling: IBehandling;
     settÅpenBehandling: (behandling: Ressurs<IBehandling>, oppdaterMinimalFagsak?: boolean) => void;
 }
 
 const BehandlingContext = createContext<BehandlingContextValue | undefined>(undefined);
 
-export const BehandlingProvider = ({ behandling, children }: Props) => {
+export function BehandlingProvider({ behandling, children }: Props) {
     const { settBehandlingRessurs } = useHentOgSettBehandlingContext();
-
-    const saksbehandler = useSaksbehandler();
 
     useNavigerAutomatiskTilSideForBehandlingssteg({ behandling });
 
-    const location = useLocation();
-    const [trinnPåBehandling, settTrinnPåBehandling] = useState<{ [sideId: string]: Trinn }>({});
-
-    useEffect(() => {
-        const siderPåBehandling = hentTrinnForBehandling(behandling);
-
-        const sideHref = hentSideHref(location.pathname);
-        settTrinnPåBehandling(
-            Object.entries(siderPåBehandling).reduce((acc, [sideId, side]) => {
-                return {
-                    ...acc,
-                    [sideId]: {
-                        ...side,
-                        kontrollert:
-                            sideHref === side.href ? KontrollertStatus.KONTROLLERT : KontrollertStatus.IKKE_KONTROLLERT,
-                    },
-                };
-            }, {})
-        );
-    }, [behandling]);
-
-    const leggTilBesøktSide = (besøktSide: SideId) => {
-        if (kanBeslutteVedtak) {
-            settTrinnPåBehandling({
-                ...trinnPåBehandling,
-                [besøktSide]: {
-                    ...trinnPåBehandling[besøktSide],
-                    kontrollert: KontrollertStatus.KONTROLLERT,
-                },
-            });
-        }
-    };
-
-    const settIkkeKontrollerteSiderTilManglerKontroll = () => {
-        settTrinnPåBehandling(
-            Object.entries(trinnPåBehandling).reduce((acc, [sideId, trinn]) => {
-                if (trinn.kontrollert === KontrollertStatus.IKKE_KONTROLLERT) {
-                    return {
-                        ...acc,
-                        [sideId]: {
-                            ...trinn,
-                            kontrollert: KontrollertStatus.MANGLER_KONTROLL,
-                        },
-                    };
-                } else return acc;
-            }, trinnPåBehandling)
-        );
-    };
-
-    const kanBeslutteVedtak =
-        behandling.status === BehandlingStatus.FATTER_VEDTAK &&
-        BehandlerRolle.BESLUTTER === saksbehandler.rolle &&
-        saksbehandler.email !== behandling.endretAv;
-
     return (
-        <BehandlingContext.Provider
-            value={{
-                leggTilBesøktSide,
-                settIkkeKontrollerteSiderTilManglerKontroll,
-                trinnPåBehandling,
-                behandling,
-                settÅpenBehandling: settBehandlingRessurs,
-            }}
-        >
+        <BehandlingContext.Provider value={{ behandling, settÅpenBehandling: settBehandlingRessurs }}>
             {children}
         </BehandlingContext.Provider>
     );
-};
+}
 
-export const useBehandlingContext = () => {
+export function useBehandlingContext() {
     const context = useContext(BehandlingContext);
-
     if (context === undefined) {
-        throw new Error('useBehandlingContext må brukes innenfor en BehandlingProvider');
+        throw new Error('useBehandlingContext må brukes innenfor en BehandlingProvider.');
     }
-
     return context;
-};
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/sider.test.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/sider.test.ts
@@ -1,30 +1,88 @@
 import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
-import { BehandlingSteg, BehandlingÅrsak } from '@typer/behandling';
+import { BehandlingSteg, BehandlingStegStatus, BehandlingÅrsak } from '@typer/behandling';
 
 import {
     erViPåUdefinertFagsakSide,
     erViPåUlovligSteg,
     finnSideForBehandlingssteg,
-    hentTrinnForBehandling,
+    finnSiderForBehandling,
     SideId,
     sider,
 } from './sider';
 
-describe('sider.ts', () => {
-    describe('siderForBehandling', () => {
-        test('REGISTRERE_SØKNAD returneres ved årsak SØKNAD', () => {
-            const behandling = lagBehandling({ årsak: BehandlingÅrsak.SØKNAD });
-            expect(Object.keys(hentTrinnForBehandling(behandling))).toContain(SideId.REGISTRERE_SØKNAD);
+describe('Sider', () => {
+    describe('finnSiderForBehandling', () => {
+        test('viser alle sider for en ordinær søknadsbehandling', () => {
+            const behandling = lagBehandling();
+
+            const sideIder = finnSiderForBehandling(behandling).map(side => side.id);
+
+            expect(sideIder).toEqual([
+                SideId.REGISTRERE_SØKNAD,
+                SideId.VILKÅRSVURDERING,
+                SideId.BEHANDLINGRESULTAT,
+                SideId.SIMULERING,
+                SideId.VEDTAK,
+            ]);
         });
-        test('VEDTAK returneres ikke ved årsak SATSENDRING', () => {
+
+        test('skjuler registrer søknad og vedtak ved satsendring', () => {
             const behandling = lagBehandling({ årsak: BehandlingÅrsak.SATSENDRING });
-            expect(Object.keys(hentTrinnForBehandling(behandling))).not.toContain(SideId.VEDTAK);
+
+            const sideIder = finnSiderForBehandling(behandling).map(side => side.id);
+
+            expect(sideIder).toEqual([SideId.VILKÅRSVURDERING, SideId.BEHANDLINGRESULTAT, SideId.SIMULERING]);
         });
-        test('Standard revurdering uten søknad viser alle sider bortsett fra REGISTRERE_SØKNAD', () => {
-            const behandling = lagBehandling({ årsak: BehandlingÅrsak.NYE_OPPLYSNINGER });
-            expect(Object.keys(hentTrinnForBehandling(behandling))).toEqual(
-                Object.values(SideId).filter(side => side !== SideId.REGISTRERE_SØKNAD)
-            );
+
+        test('skjuler simulering og vedtak ved lovendring 2024 hvor behandling mangler stegene for simulering og vedtak', () => {
+            const behandling = lagBehandling({
+                årsak: BehandlingÅrsak.LOVENDRING_2024,
+                stegTilstand: [
+                    {
+                        behandlingSteg: BehandlingSteg.REGISTRERE_SØKNAD,
+                        behandlingStegStatus: BehandlingStegStatus.IKKE_UTFØRT,
+                    },
+                ],
+            });
+
+            const sideIder = finnSiderForBehandling(behandling).map(side => side.id);
+
+            expect(sideIder).toEqual([SideId.VILKÅRSVURDERING, SideId.BEHANDLINGRESULTAT]);
+        });
+
+        test('viser simulering og vedtak ved lovendring 2024 når behandlingen har stegene for simulering og vedtak', () => {
+            const behandling = lagBehandling({
+                årsak: BehandlingÅrsak.LOVENDRING_2024,
+                stegTilstand: [
+                    { behandlingSteg: BehandlingSteg.SIMULERING, behandlingStegStatus: BehandlingStegStatus.UTFØRT },
+                    { behandlingSteg: BehandlingSteg.VEDTAK, behandlingStegStatus: BehandlingStegStatus.UTFØRT },
+                ],
+            });
+
+            const sideIder = finnSiderForBehandling(behandling).map(side => side.id);
+
+            expect(sideIder).toEqual([
+                SideId.VILKÅRSVURDERING,
+                SideId.BEHANDLINGRESULTAT,
+                SideId.SIMULERING,
+                SideId.VEDTAK,
+            ]);
+        });
+
+        test('viser simulering, men skjuler vedtak, ved lovendring 2024 når kun simuleringssteget finnes', () => {
+            const behandling = lagBehandling({
+                årsak: BehandlingÅrsak.LOVENDRING_2024,
+                stegTilstand: [
+                    {
+                        behandlingSteg: BehandlingSteg.SIMULERING,
+                        behandlingStegStatus: BehandlingStegStatus.UTFØRT,
+                    },
+                ],
+            });
+
+            const sideIder = finnSiderForBehandling(behandling).map(side => side.id);
+
+            expect(sideIder).toEqual([SideId.VILKÅRSVURDERING, SideId.BEHANDLINGRESULTAT, SideId.SIMULERING]);
         });
     });
 

--- a/src/frontend/sider/Fagsak/Behandling/sider/sider.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/sider.ts
@@ -19,8 +19,10 @@ export interface Underside {
     hash: string;
 }
 
-export interface Trinn extends Side {
-    kontrollert: KontrollertStatus;
+export interface Kontrollside {
+    id: SideId;
+    navn: string;
+    kontrollertStatus: KontrollertStatus;
 }
 
 export enum KontrollertStatus {
@@ -120,24 +122,6 @@ export function erSidenAktiv(side: Side, behandling: IBehandling): boolean {
 
 export function finnSiderForBehandling(behandling: IBehandling) {
     return Object.values(sider).filter(side => side.visSide?.(behandling) ?? true);
-}
-
-export function hentTrinnForBehandling(behandling: IBehandling): { [sideId: string]: Side } {
-    const visSide = (side: Side) => {
-        if (side.visSide) {
-            return side.visSide(behandling);
-        } else {
-            return true;
-        }
-    };
-    return Object.entries(sider)
-        .filter(([_, side]) => visSide(side))
-        .reduce((acc, [sideId, side]) => {
-            return {
-                ...acc,
-                [sideId]: side,
-            };
-        }, {});
 }
 
 export function finnSideForBehandlingssteg(behandling: IBehandling): Side | undefined {


### PR DESCRIPTION
### 📮 Favro
NAV-29440

### 💰 Hva skal gjøres, og hvorfor?
Introduserer et eget context for “kontrollerte sider” som brukes i totrinnskontroll, og flytter ansvar for markering av kontrollerte/manglende kontroll fra `BehandlingContext` til ny `KontrollsiderContext`.

**Endringer:**
- Ny `KontrollsiderProvider` som utleder/lagrer kontrollstatus per side basert på behandling, brukerrolle og nåværende URL.
- Oppdatert totrinnskontroll-komponentene til å bruke `kontrollsider` i stedet for tidligere `trinnPåBehandling`.
- Ryddet `BehandlingContext` for tidligere trinn-/kontroll-logikk, og lagt til tester for kontrollside-context.


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 