### PR TITLE
Fjern KORREKSJON_VEDTAKSBREV behandlingsårsak

### DIFF
--- a/src/frontend/hooks/useErLesevisning.test.ts
+++ b/src/frontend/hooks/useErLesevisning.test.ts
@@ -6,7 +6,7 @@ import { useErLesevisning } from './useErLesevisning';
 import { useSaksbehandler } from './useSaksbehandler';
 import { lagBehandling } from '../testutils/testdata/behandlingTestdata';
 import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
-import { BehandlingStatus, BehandlingSteg, BehandlingÅrsak, SettPåVentÅrsak } from '../typer/behandling';
+import { BehandlingStatus, BehandlingSteg, SettPåVentÅrsak } from '../typer/behandling';
 import { harTilgangTilEnhet } from '../typer/enhet';
 import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../utils/behandling';
 
@@ -105,15 +105,6 @@ describe('useErLesevisning', () => {
     it('returnerer false når saksbehandler mangler enhetstilgang men er superbruker', () => {
         mockHarTilgangTilEnhet.mockReturnValue(false);
         mockUseSaksbehandler.mockReturnValue(lagSaksbehandler({ harSuperbrukertilgang: true }));
-
-        const { result } = renderHook(() => useErLesevisning());
-
-        expect(result.current).toBe(false);
-    });
-
-    it('returnerer false når saksbehandler mangler enhetstilgang men årsak er KORREKSJON_VEDTAKSBREV', () => {
-        mockHarTilgangTilEnhet.mockReturnValue(false);
-        mockUseBehandling.mockReturnValue(lagBehandling({ årsak: BehandlingÅrsak.KORREKSJON_VEDTAKSBREV }));
 
         const { result } = renderHook(() => useErLesevisning());
 

--- a/src/frontend/hooks/useErLesevisning.ts
+++ b/src/frontend/hooks/useErLesevisning.ts
@@ -4,7 +4,7 @@ import { BehandlingStatus, BehandlingSteg, BehandlingÅrsak, hentStegNummer } fr
 import { harTilgangTilEnhet } from '../typer/enhet';
 import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../utils/behandling';
 
-const ÅRSAKER_ÅPEN_FOR_ALLE = new Set([BehandlingÅrsak.TEKNISK_ENDRING, BehandlingÅrsak.KORREKSJON_VEDTAKSBREV]);
+const ÅRSAKER_ÅPEN_FOR_ALLE = new Set([BehandlingÅrsak.TEKNISK_ENDRING]);
 
 interface Parameters {
     sjekkTilgangTilEnhet?: boolean;

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.tsx
@@ -8,7 +8,6 @@ const relevanteBehandlingsårsaker = [
     BehandlingÅrsak.NYE_OPPLYSNINGER,
     BehandlingÅrsak.KLAGE,
     BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
-    BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
 ];
 
 interface Props {

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/BehandlingsårsakFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/BehandlingsårsakFelt.tsx
@@ -3,7 +3,6 @@ import type { ChangeEvent } from 'react';
 import { Select } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
-import { useFeatureToggles } from '../../../../hooks/useFeatureToggles';
 import {
     behandlingÅrsak,
     BehandlingÅrsak,
@@ -21,8 +20,6 @@ interface IProps {
 }
 
 export const BehandlingårsakFelt = ({ behandlingsårsak, visFeilmeldinger, erLesevisning = false }: IProps) => {
-    const toggles = useFeatureToggles();
-
     return (
         <Select
             {...behandlingsårsak.hentNavBaseSkjemaProps(visFeilmeldinger)}
@@ -37,9 +34,7 @@ export const BehandlingårsakFelt = ({ behandlingsårsak, visFeilmeldinger, erLe
                 Velg
             </option>
             {Object.values(BehandlingÅrsak)
-                .filter(
-                    behandlingsårsak => !behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles).includes(behandlingsårsak)
-                )
+                .filter(behandlingsårsak => !behandlingÅrsakerSomIkkeSkalSettesManuelt().includes(behandlingsårsak))
                 .map(årsak => {
                     return (
                         <option key={årsak} aria-selected={behandlingsårsak.verdi === årsak} value={årsak}>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -83,8 +83,6 @@ const OppsummeringVedtakInnhold = ({
             return 'Behandlingen er avsluttet. Du kan se vedtaksbrevet ved å trykke på "Vis vedtaksbrev".';
         } else if (årsak === BehandlingÅrsak.DØDSFALL) {
             return 'Vedtak om opphør på grunn av dødsfall er automatisk generert.';
-        } else if (årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV) {
-            return 'Behandling bruker manuelt skrevet vedtaksbrev. Forhåndsvis for å se brevet.';
         } else return '';
     };
 
@@ -170,7 +168,6 @@ const OppsummeringVedtakInnhold = ({
                     brevmottakere={åpenBehandling.brevmottakere}
                 />
                 {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL ||
-                åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
                 åpenBehandling.status === BehandlingStatus.AVSLUTTET ? (
                     <Box marginBlock={'space-32 space-16'}>
                         <InfoCard data-color="info">

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/Vedtak.tsx
@@ -36,7 +36,6 @@ function kanForeslåVedtak(behandling: IBehandling, vedtaksperioder: IVedtaksper
     return (
         minstEnPeriodeHarBegrunnelseEllerFritekst ||
         behandling?.årsak === BehandlingÅrsak.TEKNISK_ENDRING ||
-        behandling?.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
         behandling?.årsak === BehandlingÅrsak.IVERKSETTE_KA_VEDTAK ||
         behandling?.årsak === BehandlingÅrsak.DØDSFALL
     );

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -6,7 +6,6 @@ import type { IPersonMedAndelerTilkjentYtelse } from './beregning';
 import type { INøkkelPar } from './common';
 import type { IRestFeilutbetaltValuta } from './eøs-feilutbetalt-valuta';
 import type { IRestKompetanse, IRestUtenlandskPeriodeBeløp, IRestValutakurs } from './eøsPerioder';
-import { FeatureToggle, type FeatureToggles } from './featureToggles';
 import type { KlageResultat, KlageStatus, KlageÅrsak } from './klage';
 import type { ManglendeSvalbardmerking } from './ManglendeSvalbardmerking';
 import type { IRestOvergangsordningAndel } from './overgangsordningAndel';
@@ -54,7 +53,6 @@ export enum BehandlingÅrsak {
     DØDSFALL = 'DØDSFALL',
     NYE_OPPLYSNINGER = 'NYE_OPPLYSNINGER',
     KLAGE = 'KLAGE',
-    KORREKSJON_VEDTAKSBREV = 'KORREKSJON_VEDTAKSBREV',
     SATSENDRING = 'SATSENDRING',
     BARNEHAGELISTE = 'BARNEHAGELISTE',
     TEKNISK_ENDRING = 'TEKNISK_ENDRING',
@@ -63,13 +61,10 @@ export enum BehandlingÅrsak {
     IVERKSETTE_KA_VEDTAK = 'IVERKSETTE_KA_VEDTAK',
 }
 
-export const behandlingÅrsakerSomIkkeSkalSettesManuelt = (toggles: FeatureToggles): BehandlingÅrsak[] =>
-    [
-        BehandlingÅrsak.KLAGE,
-        BehandlingÅrsak.LOVENDRING_2024,
-        BehandlingÅrsak.SATSENDRING,
-        toggles[FeatureToggle.kanManueltKorrigereMedVedtaksbrev] ? null : BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
-    ].filter(behandlingsårsak => behandlingsårsak !== null);
+export const behandlingÅrsakerSomIkkeSkalSettesManuelt = (): BehandlingÅrsak[] =>
+    [BehandlingÅrsak.KLAGE, BehandlingÅrsak.LOVENDRING_2024, BehandlingÅrsak.SATSENDRING].filter(
+        behandlingsårsak => behandlingsårsak !== null
+    );
 
 export const behandlingÅrsak: Record<BehandlingÅrsak | TilbakekrevingsbehandlingÅrsak | KlageÅrsak, string> = {
     SØKNAD: 'Søknad',
@@ -77,7 +72,6 @@ export const behandlingÅrsak: Record<BehandlingÅrsak | Tilbakekrevingsbehandli
     DØDSFALL: 'Dødsfall',
     NYE_OPPLYSNINGER: 'Nye opplysninger',
     KLAGE: 'Klage',
-    KORREKSJON_VEDTAKSBREV: 'Korrigere vedtak med egen brevmal',
     SATSENDRING: 'Satsendring',
     BARNEHAGELISTE: 'Barnehageliste',
     TEKNISK_ENDRING: 'Teknisk Endring',

--- a/src/frontend/typer/featureToggles.ts
+++ b/src/frontend/typer/featureToggles.ts
@@ -5,7 +5,6 @@ export interface FeatureToggles {
 export enum FeatureToggle {
     // Operasjonelle
     kanBehandleTekniskEndring = 'familie-ks-sak.behandling.teknisk-endring',
-    kanManueltKorrigereMedVedtaksbrev = 'familie-ks-sak.behandling.korreksjon-vedtaksbrev',
     tekniskVedlikeholdHenleggelse = 'familie-ks-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring',
     kanOppretteOgEndreSammensatteKontrollsaker = 'familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker',
     skalObfuskereData = 'familie-ks-sak.anonymiser-persondata',

--- a/src/frontend/typer/test/behandling.test.ts
+++ b/src/frontend/typer/test/behandling.test.ts
@@ -4,7 +4,6 @@ import {
     behandlingÅrsakerSomIkkeSkalSettesManuelt,
     erBehandlingHenlagt,
 } from '../behandling';
-import { type FeatureToggles } from '../featureToggles';
 
 describe('Behandlingstester', () => {
     test('Alle henleggelsesresultater skal trigge erHenlagt', () => {
@@ -19,12 +18,8 @@ describe('Behandlingstester', () => {
 });
 
 describe('behandlingÅrsakerSomIkkeSkalSettesManuelt inneholde alle behandlingsårsaker som ikke skal kunne velges manuelt', () => {
-    test('Alle relevante toggles er skrudd på', () => {
+    test('Inneholder forventede behandlingsårsaker', () => {
         // Arrange
-        const toggles: FeatureToggles = {
-            kanManueltKorrigereMedVedtaksbrev: true,
-        };
-
         const forventedeBehandlingsårsaker = new Set([
             BehandlingÅrsak.KLAGE,
             BehandlingÅrsak.LOVENDRING_2024,
@@ -32,33 +27,7 @@ describe('behandlingÅrsakerSomIkkeSkalSettesManuelt inneholde alle behandlings�
         ]);
 
         // Act
-        const behandlingsårsaker = behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles);
-
-        // Assert
-        const behandlingsårsakerSet = new Set(behandlingsårsaker);
-        const forventedeBehandlingsårsakerSet = new Set(forventedeBehandlingsårsaker);
-        expect(behandlingsårsakerSet.size == forventedeBehandlingsårsakerSet.size);
-        expect(
-            [...behandlingsårsakerSet].every(behandlingÅrsak =>
-                [...forventedeBehandlingsårsakerSet].includes(behandlingÅrsak)
-            )
-        );
-    });
-    test('Alle relevante toggles er skrudd av', () => {
-        // Arrange
-        const toggles: FeatureToggles = {
-            kanManueltKorrigereMedVedtaksbrev: false,
-        };
-
-        const forventedeBehandlingsårsaker = new Set([
-            BehandlingÅrsak.KLAGE,
-            BehandlingÅrsak.LOVENDRING_2024,
-            BehandlingÅrsak.SATSENDRING,
-            BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
-        ]);
-
-        // Act
-        const behandlingsårsaker = behandlingÅrsakerSomIkkeSkalSettesManuelt(toggles);
+        const behandlingsårsaker = behandlingÅrsakerSomIkkeSkalSettesManuelt();
 
         // Assert
         const behandlingsårsakerSet = new Set(behandlingsårsaker);


### PR DESCRIPTION
### 📮 Favro: Nav-29782

### 💰 Hva skal gjøres, og hvorfor?
Fjerner behandlingsårsaken `KORREKSJON_VEDTAKSBREV` og UI-logikk som var avhengig av den. 

- Fjerner `KORREKSJON_VEDTAKSBREV` fra `behandling`-typene og feature toggle `kanManueltKorrigereMedVedtaksbrev`.
- Fjerner betinget logikk i `useErLesevisning`, `Behandlingsårsak`-felt, `LeggTilBarnPåBehandling`, `OppsummeringVedtakInnhold` og `Vedtak`.
- Rydder/oppdaterer berørte tester.