### PR TITLE
NAV-29798: Rydd forhaandsvis brev

### DIFF
--- a/src/frontend/api/hentEllerOpprettVedtaksbrevPdf.test.ts
+++ b/src/frontend/api/hentEllerOpprettVedtaksbrevPdf.test.ts
@@ -1,0 +1,50 @@
+import { apiClient } from '@api/client/apiClient';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { hentEllerOpprettVedtaksbrevPdf } from './hentEllerOpprettVedtaksbrevPdf';
+
+vi.mock('@api/client/apiClient', () => ({
+    apiClient: {
+        request: vi.fn(),
+    },
+}));
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+const base64Pdf = 'JVBERi0xLjQK'; // base64-encodet "%PDF-1.4"
+
+describe('hentEllerOpprettVedtaksbrevPdf', () => {
+    test.each([
+        ['GET', 'forhaandsvis-vedtaksbrev', '/familie-ks-sak/api/brev/forhaandsvis-vedtaksbrev/123'],
+        ['POST', 'forhaandsvis-og-lagre-vedtaksbrev', '/familie-ks-sak/api/brev/forhaandsvis-og-lagre-vedtaksbrev/123'],
+    ] as const)(
+        'kaller apiClient.request med httpMethod %s og riktig URL for urlSegment %s',
+        async (httpMethod, urlSegment, forventetUrl) => {
+            vi.mocked(apiClient.request).mockResolvedValue(base64Pdf);
+
+            const result = await hentEllerOpprettVedtaksbrevPdf(httpMethod, {
+                urlSegment,
+                behandlingId: 123,
+            });
+
+            expect(apiClient.request).toHaveBeenCalledWith({
+                method: httpMethod,
+                url: forventetUrl,
+            });
+            expect(result).toBe(base64Pdf);
+        }
+    );
+
+    test('kaster feil ved avvist promise', async () => {
+        vi.mocked(apiClient.request).mockRejectedValue(new Error('Noe gikk galt'));
+
+        await expect(
+            hentEllerOpprettVedtaksbrevPdf('POST', {
+                urlSegment: 'forhaandsvis-og-lagre-vedtaksbrev',
+                behandlingId: 123,
+            })
+        ).rejects.toThrow('Noe gikk galt');
+    });
+});

--- a/src/frontend/api/hentEllerOpprettVedtaksbrevPdf.ts
+++ b/src/frontend/api/hentEllerOpprettVedtaksbrevPdf.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '@api/client/apiClient';
+
+interface PathParams {
+    behandlingId: number;
+    urlSegment: 'forhaandsvis-og-lagre-vedtaksbrev' | 'forhaandsvis-vedtaksbrev';
+}
+
+export async function hentEllerOpprettVedtaksbrevPdf(httpMethod: 'GET' | 'POST', pathParams: PathParams) {
+    const { behandlingId, urlSegment } = pathParams;
+    return apiClient.request<void, string>({
+        method: httpMethod,
+        url: `/familie-ks-sak/api/brev/${urlSegment}/${behandlingId}`,
+    });
+}

--- a/src/frontend/hooks/useHentEllerOpprettVedtaksbrevPdf.test.ts
+++ b/src/frontend/hooks/useHentEllerOpprettVedtaksbrevPdf.test.ts
@@ -1,0 +1,152 @@
+import { hentEllerOpprettVedtaksbrevPdf } from '@api/hentEllerOpprettVedtaksbrevPdf';
+import { renderHook, waitFor } from '@testing-library/react';
+import { TestProviders } from '@testutils/testrender';
+import { opprettPdfBlob } from '@utils/blob';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useHentEllerOpprettVedtaksbrevPdf } from './useHentEllerOpprettVedtaksbrevPdf';
+
+vi.mock('@api/hentEllerOpprettVedtaksbrevPdf');
+vi.mock('@utils/blob');
+
+const bytes = 'JVBERi0xLjQK'; // base64-encodet "%PDF-1.4"
+const blob = new Blob([bytes], { type: 'application/pdf' });
+const objectUrl = 'blob:http://localhost/abc-123';
+
+beforeEach(() => {
+    // jsdom implementerer ikke createObjectURL, så den må stubbes
+    window.URL.createObjectURL = vi.fn().mockReturnValue(objectUrl);
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('useHentEllerOpprettVedtaksbrevPdf', () => {
+    test.each([
+        ['GET', 'forhaandsvis-vedtaksbrev'],
+        ['POST', 'forhaandsvis-og-lagre-vedtaksbrev'],
+    ] as const)(
+        'kaller hentEllerOpprettVedtaksbrevPdf med httpMethod %s, urlSegment %s og riktig behandlingId',
+        async (httpMethod, urlSegment) => {
+            // Arrange
+            vi.mocked(hentEllerOpprettVedtaksbrevPdf).mockResolvedValue(bytes);
+            vi.mocked(opprettPdfBlob).mockReturnValue(blob);
+
+            const { result } = renderHook(() => useHentEllerOpprettVedtaksbrevPdf(), {
+                wrapper: TestProviders,
+            });
+
+            // Act
+            result.current.mutate({ behandlingId: 123, urlSegment, httpMethod });
+
+            // Assert
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+            expect(hentEllerOpprettVedtaksbrevPdf).toHaveBeenCalledWith(httpMethod, {
+                urlSegment,
+                behandlingId: 123,
+            });
+        }
+    );
+
+    test('oppretter en pdf-blob av bytene og returnerer en object-URL', async () => {
+        // Arrange
+        vi.mocked(hentEllerOpprettVedtaksbrevPdf).mockResolvedValue(bytes);
+        vi.mocked(opprettPdfBlob).mockReturnValue(blob);
+
+        const { result } = renderHook(() => useHentEllerOpprettVedtaksbrevPdf(), {
+            wrapper: TestProviders,
+        });
+
+        // Act
+        result.current.mutate({
+            behandlingId: 123,
+            urlSegment: 'forhaandsvis-vedtaksbrev',
+            httpMethod: 'GET',
+        });
+
+        // Assert
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(opprettPdfBlob).toHaveBeenCalledWith(bytes);
+        expect(window.URL.createObjectURL).toHaveBeenCalledWith(blob);
+        expect(result.current.data).toBe(objectUrl);
+    });
+
+    test('kaller onSuccess-callback med object-URL ved vellykket mutasjon', async () => {
+        // Arrange
+        const onSuccess = vi.fn();
+        vi.mocked(hentEllerOpprettVedtaksbrevPdf).mockResolvedValue(bytes);
+        vi.mocked(opprettPdfBlob).mockReturnValue(blob);
+
+        const { result } = renderHook(() => useHentEllerOpprettVedtaksbrevPdf({ onSuccess }), {
+            wrapper: TestProviders,
+        });
+
+        // Act
+        result.current.mutate({
+            behandlingId: 123,
+            urlSegment: 'forhaandsvis-og-lagre-vedtaksbrev',
+            httpMethod: 'POST',
+        });
+
+        // Assert
+        await waitFor(() =>
+            expect(onSuccess).toHaveBeenCalledWith(
+                objectUrl,
+                {
+                    behandlingId: 123,
+                    urlSegment: 'forhaandsvis-og-lagre-vedtaksbrev',
+                    httpMethod: 'POST',
+                },
+                undefined,
+                expect.any(Object)
+            )
+        );
+    });
+
+    test('Skal håndtere feil fra api-kallet', async () => {
+        // Arrange
+        vi.mocked(hentEllerOpprettVedtaksbrevPdf).mockRejectedValue(new Error('Noe gikk galt'));
+
+        const { result } = renderHook(() => useHentEllerOpprettVedtaksbrevPdf(), {
+            wrapper: TestProviders,
+        });
+
+        // Act
+        result.current.mutate({
+            behandlingId: 123,
+            urlSegment: 'forhaandsvis-vedtaksbrev',
+            httpMethod: 'GET',
+        });
+
+        // Assert
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.error?.message).toBe('Noe gikk galt');
+        expect(opprettPdfBlob).not.toHaveBeenCalled();
+        expect(window.URL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    test('Skal håndtere feil ved oppretting av pdf-blob', async () => {
+        // Arrange
+        vi.mocked(hentEllerOpprettVedtaksbrevPdf).mockResolvedValue(bytes);
+        vi.mocked(opprettPdfBlob).mockImplementation(() => {
+            throw new Error('Ugyldig pdf');
+        });
+
+        const { result } = renderHook(() => useHentEllerOpprettVedtaksbrevPdf(), {
+            wrapper: TestProviders,
+        });
+
+        // Act
+        result.current.mutate({
+            behandlingId: 123,
+            urlSegment: 'forhaandsvis-vedtaksbrev',
+            httpMethod: 'GET',
+        });
+
+        // Assert
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.error?.message).toBe('Ugyldig pdf');
+        expect(window.URL.createObjectURL).not.toHaveBeenCalled();
+    });
+});

--- a/src/frontend/hooks/useHentEllerOpprettVedtaksbrevPdf.ts
+++ b/src/frontend/hooks/useHentEllerOpprettVedtaksbrevPdf.ts
@@ -1,0 +1,23 @@
+import { hentEllerOpprettVedtaksbrevPdf } from '@api/hentEllerOpprettVedtaksbrevPdf';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import { opprettPdfBlob } from '@utils/blob';
+
+interface Parameters {
+    behandlingId: number;
+    httpMethod: 'GET' | 'POST';
+    urlSegment: 'forhaandsvis-og-lagre-vedtaksbrev' | 'forhaandsvis-vedtaksbrev';
+}
+
+type Options = Omit<UseMutationOptions<string, DefaultError, Parameters>, 'mutationFn'>;
+
+export function useHentEllerOpprettVedtaksbrevPdf(options?: Options) {
+    return useMutation({
+        mutationFn: async (parameters: Parameters) => {
+            const { behandlingId, httpMethod, urlSegment } = parameters;
+            const bytes = await hentEllerOpprettVedtaksbrevPdf(httpMethod, { behandlingId, urlSegment });
+            const blob = opprettPdfBlob(bytes);
+            return window.URL.createObjectURL(blob);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/ForhåndsvisVedtaksbrev.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/ForhåndsvisVedtaksbrev.module.css
@@ -1,0 +1,17 @@
+.modal {
+    width: 80%;
+    height: 80%;
+    overflow: hidden;
+
+    section {
+        height: 100%;
+        width: 90%;
+        margin: 0 auto;
+    }
+}
+
+.iframe {
+    margin: 0 auto;
+    height: 100%;
+    width: 100%;
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/ForhåndsvisVedtaksbrev.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/ForhåndsvisVedtaksbrev.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+
+import { useBehandling } from '@hooks/useBehandling';
+import { useHentEllerOpprettVedtaksbrevPdf } from '@hooks/useHentEllerOpprettVedtaksbrevPdf';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { BehandlerRolle, BehandlingSteg, hentStegNummer } from '@typer/behandling';
+
+import { FileTextIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
+import { Button, ErrorMessage, Heading, HStack, Loader, Modal } from '@navikt/ds-react';
+
+import Styles from './ForhåndsvisVedtaksbrev.module.css';
+
+export function ForhåndsvisVedtaksbrev() {
+    const behandling = useBehandling();
+    const saksbehandler = useSaksbehandler();
+
+    const [visModal, settVisModal] = useState(false);
+
+    const {
+        data: vedtaksbrevPdf,
+        mutate: hentEllerOpprettVedtaksbrevPdf,
+        isPending: hentEllerOpprettVedtaksbrevPdfIsPending,
+        error: hentEllerOpprettVedtaksbrevPdfError,
+    } = useHentEllerOpprettVedtaksbrevPdf();
+
+    function onVisVedtaksbrevClicked() {
+        const { behandlingId, steg } = behandling;
+
+        const erMinstSaksbehandler = saksbehandler.rolle >= BehandlerRolle.SAKSBEHANDLER;
+        const erPåEllerFørBeslutteVedtak = hentStegNummer(steg) <= hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
+        const skalLagreBrev = erMinstSaksbehandler && erPåEllerFørBeslutteVedtak;
+
+        const httpMethod = skalLagreBrev ? 'POST' : 'GET';
+        const urlSegment = skalLagreBrev ? 'forhaandsvis-og-lagre-vedtaksbrev' : 'forhaandsvis-vedtaksbrev';
+
+        hentEllerOpprettVedtaksbrevPdf({ behandlingId, httpMethod, urlSegment });
+
+        settVisModal(true);
+    }
+
+    return (
+        <>
+            <Button
+                variant={'secondary'}
+                size={'medium'}
+                onClick={onVisVedtaksbrevClicked}
+                loading={hentEllerOpprettVedtaksbrevPdfIsPending}
+                icon={<FileTextIcon aria-hidden={true} />}
+            >
+                Vis vedtaksbrev
+            </Button>
+            <Modal
+                className={Styles.modal}
+                open={visModal}
+                onClose={() => settVisModal(false)}
+                header={{ heading: 'Forhåndsvis vedtaksbrev', closeButton: true }}
+                width={'100rem'}
+                portal={true}
+            >
+                {hentEllerOpprettVedtaksbrevPdfIsPending && (
+                    <HStack height={'100%'} justify={'center'} align={'center'} gap={'space-8'}>
+                        <Loader size={'small'} title={'Laster vedtaksbrev...'} />
+                        <Heading size={'small'} level={'2'}>
+                            Laster vedtaksbrev...
+                        </Heading>
+                    </HStack>
+                )}
+                {hentEllerOpprettVedtaksbrevPdfError && (
+                    <HStack height={'100%'} justify={'center'} align={'center'} gap={'space-8'}>
+                        <XMarkOctagonFillIcon color={'var(--ax-text-danger-subtle)'} fontSize={'1.2rem'} />
+                        <ErrorMessage>{hentEllerOpprettVedtaksbrevPdfError.message}</ErrorMessage>
+                    </HStack>
+                )}
+                {!hentEllerOpprettVedtaksbrevPdfIsPending && !hentEllerOpprettVedtaksbrevPdfError && (
+                    <iframe className={Styles.iframe} title={'Vedtaksbrev'} src={vedtaksbrevPdf} />
+                )}
+            </Modal>
+        </>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Vedtak/OppsummeringVedtakInnhold.tsx
@@ -2,21 +2,13 @@ import { useBehandling } from '@hooks/useBehandling';
 import { useBruker } from '@hooks/useBruker';
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useOpprettSammensattKontrollsakError } from '@hooks/useOpprettSammensattKontrollsakError';
-import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { useSlettSammensattKontrollsakError } from '@hooks/useSlettSammensattKontrollsakError';
 import { BrevmottakereAlert } from '@komponenter/BrevmottakereAlert';
-import {
-    BehandlerRolle,
-    BehandlingStatus,
-    BehandlingSteg,
-    Behandlingstype,
-    BehandlingÅrsak,
-    hentStegNummer,
-} from '@typer/behandling';
+import { ForhåndsvisVedtaksbrev } from '@sider/Fagsak/Behandling/sider/Vedtak/ForhåndsvisVedtaksbrev';
+import { BehandlingStatus, Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
 
-import { FileTextIcon, InformationSquareIcon } from '@navikt/aksel-icons';
-import { Box, Button, InfoCard, LocalAlert, VStack } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
+import { InformationSquareIcon } from '@navikt/aksel-icons';
+import { Box, InfoCard, LocalAlert, VStack } from '@navikt/ds-react';
 
 import { FeilutbetaltValutaTabell } from './FeilutbetaltValuta/FeilutbetaltValutaTabell';
 import { useFeilutbetaltValutaTabellContext } from './FeilutbetaltValuta/FeilutbetaltValutaTabellContext';
@@ -26,17 +18,11 @@ import { SammensattKontrollsak } from './SammensattKontrollsak/SammensattKontrol
 import { useSammensattKontrollsakContext } from './SammensattKontrollsak/SammensattKontrollsakContext';
 import { Vedtaksmeny } from './Vedtaksmeny/Vedtaksmeny';
 import { Vedtaksperioder } from './Vedtaksperioder/Vedtaksperioder';
-import useDokument from '../../../../../hooks/useDokument';
-import PdfVisningModal from '../../../../../komponenter/PdfVisningModal/PdfVisningModal';
 
 export function OppsummeringVedtakInnhold() {
-    const saksbehandler = useSaksbehandler();
     const erLesevisning = useErLesevisning();
     const bruker = useBruker();
     const behandling = useBehandling();
-
-    const { hentForhåndsvisning, nullstillDokument, visDokumentModal, hentetDokument, settVisDokumentModal } =
-        useDokument();
 
     const { sammensattKontrollsak } = useSammensattKontrollsakContext();
     const { erFeilutbetaltValutaTabellSynlig } = useFeilutbetaltValutaTabellContext();
@@ -47,24 +33,6 @@ export function OppsummeringVedtakInnhold() {
 
     const erBehandlingMedVedtaksbrevutsending =
         behandling.type !== Behandlingstype.TEKNISK_ENDRING && behandling.årsak !== BehandlingÅrsak.SATSENDRING;
-
-    const hentVedtaksbrev = () => {
-        const skalOgsåLagreBrevPåVedtak =
-            saksbehandler.rolle > BehandlerRolle.VEILEDER &&
-            hentStegNummer(behandling.steg) <= hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
-
-        if (skalOgsåLagreBrevPåVedtak) {
-            hentForhåndsvisning({
-                method: 'POST',
-                url: `/familie-ks-sak/api/brev/forhaandsvis-og-lagre-vedtaksbrev/${behandling.behandlingId}`,
-            });
-        } else {
-            hentForhåndsvisning({
-                method: 'GET',
-                url: `/familie-ks-sak/api/brev/forhaandsvis-vedtaksbrev/${behandling.behandlingId}`,
-            });
-        }
-    };
 
     const hentInfostripeTekst = (årsak: BehandlingÅrsak, status: BehandlingStatus): string => {
         if (status === BehandlingStatus.AVSLUTTET) {
@@ -120,15 +88,6 @@ export function OppsummeringVedtakInnhold() {
                 )}
                 <Vedtaksmeny erBehandlingMedVedtaksbrevutsending={erBehandlingMedVedtaksbrevutsending} />
             </VStack>
-            {visDokumentModal && (
-                <PdfVisningModal
-                    onRequestClose={() => {
-                        settVisDokumentModal(false);
-                        nullstillDokument();
-                    }}
-                    pdfdata={hentetDokument}
-                />
-            )}
             <div>
                 {behandling.korrigertEtterbetaling && (
                     <Box marginBlock={'space-0 space-24'}>
@@ -176,19 +135,7 @@ export function OppsummeringVedtakInnhold() {
                         )}
                     </>
                 )}
-                <Button
-                    id={'forhandsvis-vedtaksbrev'}
-                    variant={'secondary'}
-                    size={'medium'}
-                    onClick={() => {
-                        settVisDokumentModal(true);
-                        hentVedtaksbrev();
-                    }}
-                    loading={hentetDokument.status === RessursStatus.HENTER}
-                    icon={<FileTextIcon aria-hidden />}
-                >
-                    Vis vedtaksbrev
-                </Button>
+                <ForhåndsvisVedtaksbrev />
             </div>
         </>
     );


### PR DESCRIPTION
### 📮 Favro
NAV-29798

### 💰 Hva skal gjøres, og hvorfor?
Refaktorer visning av vedtaksbrev til å bruke react-query.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots

Laster vedtaksbrev:

<img width="1296" height="585" alt="image" src="https://github.com/user-attachments/assets/924fbb32-3ce1-4cc1-8c31-aea60a9e4fa3" />

Feil ved innlasting av vedtaksbrev:

<img width="1296" height="585" alt="image" src="https://github.com/user-attachments/assets/da3347d5-ed38-456e-93ca-0b6e73c9d527" />

Innlasted vedtaksbrev:

<img width="1296" height="585" alt="image" src="https://github.com/user-attachments/assets/3a94e97b-7cdd-4a5a-8abd-ae564a3acfe7" />

