### PR TITLE
Fiks feil etter RHF

### DIFF
--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -107,10 +107,10 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
                 const opprettBehandlingParameters = {
                     behandlingType: behandlingstype,
                     behandlingÅrsak: behandlingsårsak,
-                    kategori: behandlingskategori ?? null,
+                    kategori: behandlingskategori || null,
                     saksbehandlerIdent: saksbehandler.navIdent,
                     søkersIdent: fagsak.søkerFødselsnummer,
-                    søknadMottattDato: søknadMottattDato ?? undefined,
+                    søknadMottattDato: søknadMottattDato || undefined,
                 };
                 const behandling = await opprettBehandling(opprettBehandlingParameters);
                 queryClient.invalidateQueries({


### PR DESCRIPTION
### 📮 Favro: NAV-29852 

### 💰 Hva skal gjøres, og hvorfor?
Etter overgangen til React Hook Form (NAV-29213) har skjemafeltene tom streng
('') som standardverdi i stedet for undefined. For behandlinger der
kategorifeltet ikke vises – f.eks. revurdering med årsak barnehageliste – ble
derfor `kategori: ''` sendt til backend. `'' ?? null` gir tom streng, ikke null,
og backend klarer ikke å deserialisere '' til enumen BehandlingKategori:

  Ugyldig verdi for felt no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto["kategori"]

Bruker `||` i stedet for `??` slik at tom streng faller tilbake til
null/undefined. Samme rettelse gjøres for søknadMottattDato, som hadde
tilsvarende problem på flyter uten søknad.

Testet lokalt:

FØR:
{"behandlingType":"REVURDERING","behandlingÅrsak":"BARNEHAGELISTE","kategori":"","saksbehandlerIdent":"Z994328","søkersIdent":"x","søknadMottattDato":""}

ETTER:
{"behandlingType":"REVURDERING","behandlingÅrsak":"BARNEHAGELISTE","kategori":null,"saksbehandlerIdent":"Z994328","søkersIdent":"x"}