### PR TITLE
Overfør 'sed-er-sendt-til-land' logikk fra ba

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
@@ -7,6 +7,7 @@ import {
     mutationKey,
     useOpprettForhåndsvisbarBehandlingBrevPdf,
 } from '@hooks/useOpprettForhåndsvisbarBehandlingBrevPdf';
+import { EØS_LAND_REGIONKODER, RegionCombobox, type Regionkode } from '@komponenter/FlaggCombobox';
 import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
 import type { IBehandling } from '@typer/behandling';
 import type { IManueltBrevRequestPåBehandling } from '@typer/dokument';
@@ -30,6 +31,7 @@ import {
     UNSAFE_Combobox,
     VStack,
 } from '@navikt/ds-react';
+import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { FeltState } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -151,6 +153,27 @@ export const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                             );
                         })}
                     </Select>
+                    {skjema.felter.mottakerlandSed.erSynlig && (
+                        <RegionCombobox
+                            label={'SED er sendt til'}
+                            value={skjema.felter.mottakerlandSed.verdi as Regionkode[]}
+                            options={EØS_LAND_REGIONKODER}
+                            isMulti
+                            onChange={verdier => {
+                                if (verdier.length) {
+                                    skjema.felter.mottakerlandSed.validerOgSettFelt(verdier);
+                                } else {
+                                    skjema.felter.mottakerlandSed.nullstill();
+                                }
+                            }}
+                            error={
+                                skjema.visFeilmeldinger &&
+                                skjema.felter.mottakerlandSed.valideringsstatus === Valideringsstatus.FEIL
+                                    ? skjema.felter.mottakerlandSed.feilmelding?.toString()
+                                    : ''
+                            }
+                        />
+                    )}
                     {skjema.felter.dokumenter.erSynlig && (
                         <UNSAFE_Combobox
                             error={skjema.felter.dokumenter.hentNavInputProps(skjema.visFeilmeldinger).error}

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/useBrevModul.test.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/useBrevModul.test.ts
@@ -1,11 +1,17 @@
+import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
+import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import { BehandlingKategori } from '@typer/behandlingstema';
+import { Målform } from '@typer/søknad';
+import { mockBarn, mockSøker } from '@utils/test/person/person.mock';
+
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { Brevmal } from './typer';
-import { hentMuligeBrevmalerImplementering, mottakersMålformImplementering } from './useBrevModul';
-import { lagBehandling } from '../../../../../testutils/testdata/behandlingTestdata';
-import { Behandlingstype, BehandlingÅrsak } from '../../../../../typer/behandling';
-import { Målform } from '../../../../../typer/søknad';
-import { mockBarn, mockSøker } from '../../../../../utils/test/person/person.mock';
+import {
+    hentMuligeBrevmalerImplementering,
+    mottakersMålformImplementering,
+    skalMottakerlandSedVisesImplementering,
+} from './useBrevModul';
 
 describe('useBrevModul', () => {
     describe('hentMuligeBrevmalerImplementering', () => {
@@ -60,6 +66,30 @@ describe('useBrevModul', () => {
 
         test('Skal returnere NN når søkers målform er NN', () => {
             expect(mottakersMålformImplementering(personerNN, Valideringsstatus.OK, personIdent)).toEqual(Målform.NN);
+        });
+    });
+
+    describe('skalMottakerlandSedVisesImplementering', () => {
+        test('Skal vise feltet når brevmalen er SVARTIDSBREV og behandlingen er EØS', () => {
+            expect(skalMottakerlandSedVisesImplementering(Brevmal.SVARTIDSBREV, BehandlingKategori.EØS)).toBe(true);
+        });
+
+        test('Skal ikke vise feltet når brevmalen er SVARTIDSBREV og behandlingen er NASJONAL', () => {
+            expect(skalMottakerlandSedVisesImplementering(Brevmal.SVARTIDSBREV, BehandlingKategori.NASJONAL)).toBe(
+                false
+            );
+        });
+
+        test('Skal ikke vise feltet for andre brevmaler uavhengig av behandlingskategori', () => {
+            const andreBrevmaler = Object.values(Brevmal).filter(brevmal => brevmal !== Brevmal.SVARTIDSBREV);
+            andreBrevmaler.forEach(brevmal => {
+                expect(skalMottakerlandSedVisesImplementering(brevmal, BehandlingKategori.EØS)).toBe(false);
+                expect(skalMottakerlandSedVisesImplementering(brevmal, BehandlingKategori.NASJONAL)).toBe(false);
+            });
+        });
+
+        test('Skal ikke vise feltet når brevmal ikke er valgt', () => {
+            expect(skalMottakerlandSedVisesImplementering('', BehandlingKategori.EØS)).toBe(false);
         });
     });
 });

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/useBrevModul.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/useBrevModul.ts
@@ -79,6 +79,11 @@ export const mottakersMålformImplementering = (
         }
     })?.målform ?? Målform.NB;
 
+export const skalMottakerlandSedVisesImplementering = (
+    brevmalVerdi: Brevmal | '',
+    behandlingKategori: BehandlingKategori
+): boolean => brevmalVerdi === Brevmal.SVARTIDSBREV && behandlingKategori === BehandlingKategori.EØS;
+
 export const useBrevModul = () => {
     const behandling = useBehandling();
 
@@ -216,6 +221,15 @@ export const useBrevModul = () => {
         nullstillVedAvhengighetEndring: false,
     });
 
+    const mottakerlandSed = useFelt<string[]>({
+        verdi: [],
+        // På svartidsbrev er det valgfritt å oppgi land SED er sendt til.
+        valideringsfunksjon: (felt: FeltState<string[]>) => ok(felt),
+        skalFeltetVises: (avhengigheter: Avhengigheter) =>
+            skalMottakerlandSedVisesImplementering(avhengigheter?.brevmal.verdi, behandlingKategori),
+        avhengigheter: { brevmal },
+    });
+
     const { kanSendeSkjema, onSubmit, skjema, settVisfeilmeldinger } = useSkjema<
         {
             mottakerIdent: string;
@@ -225,6 +239,7 @@ export const useBrevModul = () => {
             fritekstAvsnitt: string | undefined;
             barnBrevetGjelder: IBarnMedOpplysninger[];
             antallUkerSvarfrist: number;
+            mottakerlandSed: string[];
         },
         IBehandling
     >({
@@ -236,6 +251,7 @@ export const useBrevModul = () => {
             fritekstAvsnitt,
             barnBrevetGjelder,
             antallUkerSvarfrist,
+            mottakerlandSed,
         },
         skjemanavn: 'brevmodul',
     });
@@ -262,6 +278,7 @@ export const useBrevModul = () => {
      */
     useEffect(() => {
         skjema.felter.dokumenter.nullstill();
+        skjema.felter.mottakerlandSed.nullstill();
         nullstillBarnBrevetGjelder();
     }, [behandling]);
 
@@ -334,6 +351,7 @@ export const useBrevModul = () => {
             behandlingKategori,
             antallUkerSvarfrist: skjema.felter.antallUkerSvarfrist.verdi,
             fritekstAvsnitt: skjema.felter.fritekstAvsnitt.verdi,
+            mottakerlandSed: skjema.felter.mottakerlandSed.verdi,
         };
     };
 

--- a/src/frontend/typer/dokument.ts
+++ b/src/frontend/typer/dokument.ts
@@ -12,6 +12,7 @@ export interface IManueltBrevRequestPåBehandling {
     behandlingKategori?: BehandlingKategori | undefined;
     antallUkerSvarfrist?: number;
     fritekstAvsnitt?: string;
+    mottakerlandSed?: string[];
 }
 
 export interface IManueltBrevRequestPåFagsak {
@@ -25,4 +26,5 @@ export interface IManueltBrevRequestPåFagsak {
     antallUkerSvarfrist?: undefined;
     manuelleBrevmottakere: SkjemaBrevmottaker[];
     fritekstAvsnitt?: string;
+    mottakerlandSed?: undefined;
 }


### PR DESCRIPTION
### 📮 Favro: Nav-29845

### 💰 Hva skal gjøres, og hvorfor?
Saksbehandler skal kunne opplyse søker om at vi innhenter opplysninger fra annet EØS-land allerede i søknadsprosessen. Viser derfor landvelgeren "SED er sendt til" i brevmenyen for svartidsbrev, tilsvarende navikt/familie-ba-sak-frontend#4660.
