### PR TITLE
NAV-26302: Bytte ut styled-components med module.css og aksel primitives

### DIFF
--- a/src/frontend/sider/Fagsak/Dokumenter/JournalpostDokument.module.css
+++ b/src/frontend/sider/Fagsak/Dokumenter/JournalpostDokument.module.css
@@ -1,0 +1,14 @@
+.text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.vedleggListe {
+    list-style-type: none;
+    margin: 0;
+
+    &:first-child {
+        padding-inline-start: 0;
+    }
+}

--- a/src/frontend/sider/Fagsak/Dokumenter/JournalpostDokument.tsx
+++ b/src/frontend/sider/Fagsak/Dokumenter/JournalpostDokument.tsx
@@ -1,20 +1,11 @@
 import type { FamilieAxiosRequestConfig } from '@hooks/useDokument';
 import type { ITilgangsstyrtJournalpost } from '@typer/journalpost';
-import styled from 'styled-components';
 
 import { ExternalLinkIcon, PadlockLockedIcon } from '@navikt/aksel-icons';
-import { BodyShort, HStack, Link } from '@navikt/ds-react';
+import { BodyShort, HStack, Link, VStack } from '@navikt/ds-react';
 import type { IDokumentInfo } from '@navikt/familie-typer';
 
-import { EllipsisBodyShort, Vedleggsliste } from './JournalpostListe';
-
-const ListeElement = styled.li`
-    margin-bottom: 1rem;
-
-    &:last-child {
-        margin-bottom: 0;
-    }
-`;
+import styles from './JournalpostDokument.module.css';
 
 interface IProps {
     dokument: IDokumentInfo;
@@ -39,15 +30,15 @@ export const JournalpostDokument = ({ dokument, hentForhåndsvisning, tilgangsst
     const dokumentTittel = dokument.tittel || 'Uten tittel';
 
     return (
-        <ListeElement>
+        <li>
             <HStack gap="space-4">
                 {journalpostTilgang.harTilgang ? (
                     <>
-                        <EllipsisBodyShort size="small" title={dokumentTittel}>
+                        <BodyShort className={styles.text} size="small" title={dokumentTittel}>
                             <Link href="#" onClick={() => hentPdfDokument(dokument.dokumentInfoId)}>
                                 {dokumentTittel}
                             </Link>
-                        </EllipsisBodyShort>
+                        </BodyShort>
 
                         <Link
                             href={`/familie-ks-sak/api/journalpost/${journalpost.journalpostId}/dokument/${dokument.dokumentInfoId}/pdf`}
@@ -69,16 +60,18 @@ export const JournalpostDokument = ({ dokument, hentForhåndsvisning, tilgangsst
             </HStack>
 
             {dokument.logiskeVedlegg && dokument.logiskeVedlegg.length > 0 && (
-                <Vedleggsliste>
-                    {dokument.logiskeVedlegg.map(vedlegg => (
-                        <ListeElement key={vedlegg.logiskVedleggId}>
-                            <EllipsisBodyShort size="small" title={vedlegg.tittel}>
-                                {vedlegg.tittel}
-                            </EllipsisBodyShort>
-                        </ListeElement>
-                    ))}
-                </Vedleggsliste>
+                <ul className={styles.vedleggListe}>
+                    <VStack gap={'space-16'}>
+                        {dokument.logiskeVedlegg.map(vedlegg => (
+                            <li key={vedlegg.logiskVedleggId}>
+                                <BodyShort className={styles.text} size="small" title={vedlegg.tittel}>
+                                    {vedlegg.tittel}
+                                </BodyShort>
+                            </li>
+                        ))}
+                    </VStack>
+                </ul>
             )}
-        </ListeElement>
+        </li>
     );
 };

--- a/src/frontend/sider/Fagsak/Dokumenter/JournalpostListe.module.css
+++ b/src/frontend/sider/Fagsak/Dokumenter/JournalpostListe.module.css
@@ -1,0 +1,59 @@
+.table {
+    table-layout: fixed;
+}
+
+.headerRow {
+    th {
+        white-space: nowrap;
+
+        &:nth-of-type(1) {
+            width: 3.5rem;
+        }
+
+        &:nth-of-type(2) {
+            width: 10rem;
+        }
+
+        &:nth-of-type(3) {
+            width: 25%;
+        }
+
+        &:nth-of-type(4) {
+            width: 15%;
+        }
+
+        &:nth-of-type(5) {
+            width: 20%;
+        }
+
+        &:nth-of-type(6) {
+            width: 22%;
+        }
+
+        &:nth-of-type(7) {
+            width: 8%;
+        }
+    }
+}
+
+.dataCell {
+    vertical-align: top;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.vedleggListe {
+    list-style-type: none;
+    margin: 0;
+
+    &:first-child {
+        padding-inline-start: 0;
+    }
+}

--- a/src/frontend/sider/Fagsak/Dokumenter/JournalpostListe.tsx
+++ b/src/frontend/sider/Fagsak/Dokumenter/JournalpostListe.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 
-import styled from 'styled-components';
+import type { ITilgangsstyrtJournalpost } from '@typer/journalpost';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
 
 import { ArrowDownIcon, ArrowLeftIcon, ArrowRightIcon } from '@navikt/aksel-icons';
-import { BodyShort, GlobalAlert, Heading, Table } from '@navikt/ds-react';
+import { BodyShort, Box, GlobalAlert, Heading, HStack, Table, VStack } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import type { IJournalpost, Ressurs } from '@navikt/familie-typer';
 import {
@@ -24,85 +25,8 @@ import {
 } from './journalpostUtils';
 import useDokument from '../../../hooks/useDokument';
 import PdfVisningModal from '../../../komponenter/PdfVisningModal/PdfVisningModal';
-import type { ITilgangsstyrtJournalpost } from '../../../typer/journalpost';
-import { Datoformat, isoStringTilFormatertString } from '../../../utils/dato';
 import { useBrukerContext } from '../BrukerContext';
-
-const Container = styled.div`
-    padding: 2rem;
-    overflow: auto;
-`;
-
-const InnUtWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    font-weight: bold;
-`;
-
-const IkonWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    margin-right: 0.5rem;
-`;
-
-const StyledTable = styled(Table)`
-    table-layout: fixed;
-`;
-
-const StyledDataCell = styled(Table.DataCell)`
-    vertical-align: top;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
-
-const StyledHeaderCell = styled(Table.HeaderCell)`
-    white-space: nowrap;
-
-    &:nth-of-type(1) {
-        width: 3.5rem;
-    }
-
-    &:nth-of-type(3) {
-        width: 25%;
-    }
-
-    &:nth-of-type(4) {
-        width: 15%;
-    }
-
-    &:nth-of-type(5) {
-        width: 20%;
-    }
-
-    &:nth-of-type(6) {
-        width: 22%;
-    }
-
-    &:nth-of-type(7) {
-        width: 8%;
-    }
-`;
-
-const StyledColumnHeader = styled(Table.ColumnHeader)`
-    white-space: nowrap;
-    width: 10rem;
-`;
-
-export const Vedleggsliste = styled.ul`
-    list-style-type: none;
-    margin: 0;
-
-    &:first-child {
-        padding-inline-start: 0;
-    }
-`;
-
-export const EllipsisBodyShort = styled(BodyShort)`
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
+import styles from './JournalpostListe.module.css';
 
 const hentIkonForJournalpostType = (journalposttype: Journalposttype) => {
     switch (journalposttype) {
@@ -168,13 +92,13 @@ export function JournalpostListe() {
         journalposterRessurs.status === RessursStatus.IKKE_TILGANG
     ) {
         return (
-            <Container>
+            <Box padding={'space-32'} overflow={'auto'}>
                 <GlobalAlert status={'error'}>
                     <GlobalAlert.Header>
                         <GlobalAlert.Title>Klarte ikke å hente inn journalposter for fagsak.</GlobalAlert.Title>
                     </GlobalAlert.Header>
                 </GlobalAlert>
-            </Container>
+            </Box>
         );
     }
 
@@ -188,71 +112,75 @@ export function JournalpostListe() {
         });
         const sorterteJournalPoster = hentSorterteJournalposter(journalposterMedOverstyrtDato, sortering);
         return (
-            <Container>
+            <Box padding={'space-32'} overflow={'auto'}>
                 <Heading level="2" size="large" spacing>
                     Dokumentoversikt
                 </Heading>
 
-                <StyledTable
+                <Table
+                    className={styles.table}
                     size="small"
                     zebraStripes
                     sort={hentSortState(sortering, 'datoRegistrertSendt')}
                     onSortChange={settNesteSorteringsrekkefølge}
                 >
                     <Table.Header>
-                        <Table.Row>
-                            <StyledHeaderCell>Inn/ut</StyledHeaderCell>
-                            <StyledColumnHeader sortKey="datoRegistrertSendt" sortable>
+                        <Table.Row className={styles.headerRow}>
+                            <Table.HeaderCell>Inn/ut</Table.HeaderCell>
+                            <Table.ColumnHeader sortKey="datoRegistrertSendt" sortable>
                                 Registrert/sendt
-                            </StyledColumnHeader>
+                            </Table.ColumnHeader>
 
-                            <StyledHeaderCell>Dokumenter</StyledHeaderCell>
-                            <StyledHeaderCell>Fagsystem | Saksid</StyledHeaderCell>
-                            <StyledHeaderCell>Avsender/Mottaker</StyledHeaderCell>
-                            <StyledHeaderCell>Journalpost</StyledHeaderCell>
-                            <StyledHeaderCell>Status</StyledHeaderCell>
+                            <Table.HeaderCell>Dokumenter</Table.HeaderCell>
+                            <Table.HeaderCell>Fagsystem | Saksid</Table.HeaderCell>
+                            <Table.HeaderCell>Avsender/Mottaker</Table.HeaderCell>
+                            <Table.HeaderCell>Journalpost</Table.HeaderCell>
+                            <Table.HeaderCell>Status</Table.HeaderCell>
                         </Table.Row>
                     </Table.Header>
                     <Table.Body>
                         {sorterteJournalPoster.map(tilgangsstyrtJournalpost => (
                             <Table.Row key={tilgangsstyrtJournalpost.journalpost.journalpostId}>
-                                <StyledDataCell>
-                                    <InnUtWrapper>
-                                        <IkonWrapper>
-                                            {hentIkonForJournalpostType(
-                                                tilgangsstyrtJournalpost.journalpost.journalposttype
-                                            )}{' '}
-                                        </IkonWrapper>
-                                        {tilgangsstyrtJournalpost.journalpost.journalposttype}
-                                    </InnUtWrapper>
-                                </StyledDataCell>
-                                <StyledDataCell>
+                                <Table.DataCell className={styles.dataCell}>
+                                    <HStack align={'center'} gap={'space-8'} justify={'center'} wrap={false}>
+                                        {hentIkonForJournalpostType(
+                                            tilgangsstyrtJournalpost.journalpost.journalposttype
+                                        )}
+                                        <BodyShort weight={'semibold'}>
+                                            {tilgangsstyrtJournalpost.journalpost.journalposttype}
+                                        </BodyShort>
+                                    </HStack>
+                                </Table.DataCell>
+                                <Table.DataCell className={styles.dataCell}>
                                     {isoStringTilFormatertString({
                                         isoString: tilgangsstyrtJournalpost.journalpost.datoMottatt,
                                         tilFormat: Datoformat.DATO_TID,
                                         defaultString: '-',
                                     })}
-                                </StyledDataCell>
+                                </Table.DataCell>
 
-                                <StyledDataCell>
+                                <Table.DataCell className={styles.dataCell}>
                                     {(tilgangsstyrtJournalpost.journalpost.dokumenter?.length ?? 0) > 0 ? (
-                                        <Vedleggsliste>
-                                            {tilgangsstyrtJournalpost.journalpost.dokumenter?.map(dokument => (
-                                                <JournalpostDokument
-                                                    dokument={dokument}
-                                                    key={dokument.dokumentInfoId}
-                                                    hentForhåndsvisning={hentForhåndsvisning}
-                                                    tilgangsstyrtJournalpost={tilgangsstyrtJournalpost}
-                                                />
-                                            ))}
-                                        </Vedleggsliste>
+                                        <ul className={styles.vedleggListe}>
+                                            <VStack gap={'space-16'}>
+                                                {tilgangsstyrtJournalpost.journalpost.dokumenter?.map(dokument => (
+                                                    <JournalpostDokument
+                                                        dokument={dokument}
+                                                        key={dokument.dokumentInfoId}
+                                                        hentForhåndsvisning={hentForhåndsvisning}
+                                                        tilgangsstyrtJournalpost={tilgangsstyrtJournalpost}
+                                                    />
+                                                ))}
+                                            </VStack>
+                                        </ul>
                                     ) : (
                                         <BodyShort>Ingen dokumenter</BodyShort>
                                     )}
-                                </StyledDataCell>
+                                </Table.DataCell>
 
-                                <StyledDataCell>
-                                    <EllipsisBodyShort
+                                <Table.DataCell className={styles.dataCell}>
+                                    <BodyShort
+                                        className={styles.text}
                                         size="small"
                                         title={formaterFagsak(
                                             tilgangsstyrtJournalpost.journalpost.sak?.fagsaksystem,
@@ -263,37 +191,43 @@ export function JournalpostListe() {
                                             tilgangsstyrtJournalpost.journalpost.sak?.fagsaksystem,
                                             tilgangsstyrtJournalpost.journalpost.sak?.fagsakId
                                         )}
-                                    </EllipsisBodyShort>
-                                </StyledDataCell>
-                                <StyledDataCell>
-                                    <EllipsisBodyShort
+                                    </BodyShort>
+                                </Table.DataCell>
+                                <Table.DataCell className={styles.dataCell}>
+                                    <BodyShort
+                                        className={styles.text}
                                         size="small"
                                         title={tilgangsstyrtJournalpost.journalpost.avsenderMottaker?.navn}
                                     >
                                         {tilgangsstyrtJournalpost.journalpost.avsenderMottaker?.navn}
-                                    </EllipsisBodyShort>
-                                </StyledDataCell>
-                                <StyledDataCell>
-                                    <EllipsisBodyShort size="small" title={tilgangsstyrtJournalpost.journalpost.tittel}>
+                                    </BodyShort>
+                                </Table.DataCell>
+                                <Table.DataCell className={styles.dataCell}>
+                                    <BodyShort
+                                        className={styles.text}
+                                        size="small"
+                                        title={tilgangsstyrtJournalpost.journalpost.tittel}
+                                    >
                                         {tilgangsstyrtJournalpost.journalpost.tittel}
-                                    </EllipsisBodyShort>
-                                </StyledDataCell>
-                                <StyledDataCell>
-                                    <EllipsisBodyShort
+                                    </BodyShort>
+                                </Table.DataCell>
+                                <Table.DataCell className={styles.dataCell}>
+                                    <BodyShort
+                                        className={styles.text}
                                         size="small"
                                         title={journalpoststatus[tilgangsstyrtJournalpost.journalpost.journalstatus]}
                                     >
                                         {journalpoststatus[tilgangsstyrtJournalpost.journalpost.journalstatus]}
-                                    </EllipsisBodyShort>
-                                </StyledDataCell>
+                                    </BodyShort>
+                                </Table.DataCell>
                             </Table.Row>
                         ))}
                     </Table.Body>
-                </StyledTable>
+                </Table>
                 {visDokumentModal && (
                     <PdfVisningModal onRequestClose={() => settVisDokumentModal(false)} pdfdata={hentetDokument} />
                 )}
-            </Container>
+            </Box>
         );
     } else {
         return null;

--- a/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnCheckbox.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnCheckbox.tsx
@@ -1,41 +1,9 @@
-import styled from 'styled-components';
+import type { IBarnMedOpplysninger } from '@typer/søknad';
+import { lagBarnLabel } from '@utils/formatter';
 
 import { TrashIcon } from '@navikt/aksel-icons';
-import { Box, Button, Checkbox } from '@navikt/ds-react';
+import { BodyShort, Box, Button, Checkbox, HStack } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
-
-import type { IBarnMedOpplysninger } from '../../../../typer/søknad';
-import { lagBarnLabel } from '../../../../utils/formatter';
-
-const CheckboxOgSlettknapp = styled.div`
-    display: flex;
-    align-items: flex-start;
-
-    .knapp {
-        height: 2rem;
-    }
-`;
-
-const StyledCheckbox = styled(Checkbox)`
-    > label {
-        width: 100%;
-    }
-`;
-
-const LabelContent = styled.div`
-    display: flex;
-    white-space: nowrap;
-`;
-
-const LabelTekst = styled.p`
-    margin: 0;
-    text-overflow: ellipsis;
-    overflow: hidden;
-`;
-
-const FjernBarnKnapp = styled(Button)`
-    margin-left: 1rem;
-`;
 
 interface IProps {
     barn: IBarnMedOpplysninger;
@@ -46,17 +14,17 @@ const BarnCheckbox = ({ barn, barnIBrevFelt }: IProps) => {
     const navnOgIdentTekst = lagBarnLabel(barn);
 
     return (
-        <div>
-            <CheckboxOgSlettknapp>
-                <Box marginInline={'space-16 space-0'}>
-                    <StyledCheckbox value={barn.ident}>
-                        <LabelContent>
-                            <LabelTekst title={navnOgIdentTekst}>{navnOgIdentTekst}</LabelTekst>
-                        </LabelContent>
-                    </StyledCheckbox>
-                </Box>
-                {barn.manueltRegistrert && (
-                    <FjernBarnKnapp
+        <HStack wrap={false} gap={'space-16'}>
+            <Box marginInline={'space-16 space-0'}>
+                <Checkbox value={barn.ident}>
+                    <BodyShort truncate title={navnOgIdentTekst}>
+                        {navnOgIdentTekst}
+                    </BodyShort>
+                </Checkbox>
+            </Box>
+            {barn.manueltRegistrert && (
+                <Box asChild height={'space-32'}>
+                    <Button
                         variant={'tertiary'}
                         id={`fjern__${barn.ident}`}
                         size={'small'}
@@ -73,10 +41,10 @@ const BarnCheckbox = ({ barn, barnIBrevFelt }: IProps) => {
                         icon={<TrashIcon />}
                     >
                         {'Fjern barn'}
-                    </FjernBarnKnapp>
-                )}
-            </CheckboxOgSlettknapp>
-        </div>
+                    </Button>
+                </Box>
+            )}
+        </HStack>
     );
 };
 

--- a/src/frontend/sider/Fagsak/Dokumentutsending/Dokumentutsending.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/Dokumentutsending.tsx
@@ -1,21 +1,12 @@
 import { Fagsaklinje } from '@komponenter/Saklinje/Fagsaklinje';
-import { fagsakHeaderHøydeRem } from '@typer/styling';
 import { useNavigate } from 'react-router';
-import styled from 'styled-components';
 
-import { Button, Modal } from '@navikt/ds-react';
+import { Button, HGrid, Modal } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useDokumentutsendingContext } from './DokumentutsendingContext';
 import { DokumentutsendingSkjema } from './DokumentutsendingSkjema';
 import { useFagsakContext } from '../FagsakContext';
-
-const Container = styled.div`
-    display: grid;
-    grid-template-columns: 35rem 1fr;
-    grid-template-rows: 1fr;
-    height: calc(100vh - ${fagsakHeaderHøydeRem}rem);
-`;
 
 export function Dokumentutsending() {
     const { fagsak } = useFagsakContext();
@@ -26,7 +17,7 @@ export function Dokumentutsending() {
     return (
         <>
             <Fagsaklinje />
-            <Container>
+            <HGrid columns={'35rem 1fr'} height={'calc(100vh - 6rem)'}>
                 {visInnsendtBrevModal && (
                     <Modal
                         open
@@ -65,7 +56,7 @@ export function Dokumentutsending() {
                     width={'100%'}
                     height={'100%'}
                 />
-            </Container>
+            </HGrid>
         </>
     );
 }

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -1,51 +1,22 @@
 import type { ChangeEvent } from 'react';
 
-import styled from 'styled-components';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { BrevmottakereAlert } from '@komponenter/BrevmottakereAlert';
+import { LeggTilBarnModal } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
+import { LeggTilBarnModalContextProvider } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
+import type { IBarnMedOpplysninger } from '@typer/søknad';
 
 import { FileTextIcon, InformationSquareIcon } from '@navikt/aksel-icons';
-import { Box, Button, Fieldset, Heading, InfoCard, Label, Select } from '@navikt/ds-react';
+import { Box, Button, Fieldset, Heading, HStack, InfoCard, Label, Select } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import BarnIBrevSkjema from './BarnIBrev/BarnIBrevSkjema';
 import { dokumentÅrsak, DokumentÅrsak, useDokumentutsendingContext } from './DokumentutsendingContext';
 import { LeggTilBarnKnapp } from './LeggTilBarnKnapp';
-import { useSaksbehandler } from '../../../hooks/useSaksbehandler';
-import { BrevmottakereAlert } from '../../../komponenter/BrevmottakereAlert';
 import FritekstAvsnitt from '../../../komponenter/FritekstAvsnitt';
-import { LeggTilBarnModal } from '../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
-import { LeggTilBarnModalContextProvider } from '../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
 import MålformVelger from '../../../komponenter/MålformVelger';
-import type { IBarnMedOpplysninger } from '../../../typer/søknad';
 import { useBrukerContext } from '../BrukerContext';
 import { useManuelleBrevmottakerePåFagsakContext } from '../ManuelleBrevmottakerePåFagsakContext';
-
-const Container = styled.div`
-    padding: 2rem;
-    overflow: auto;
-`;
-
-const StyledFieldset = styled(Fieldset)`
-    max-width: 30rem;
-    margin-top: 2rem;
-`;
-
-const FeltMargin = styled.div`
-    margin-bottom: 2rem;
-`;
-
-const Handlinger = styled.div`
-    display: flex;
-    justify-content: space-between;
-    margin-top: 1.5rem;
-`;
-
-const SendBrevKnapp = styled(Button)`
-    margin-right: 1rem;
-`;
-
-const StyledBrevmottakereAlert = styled(BrevmottakereAlert)`
-    margin: 1rem 0;
-`;
 
 enum BarnIBrevÅrsak {
     BARN_SØKT_FOR,
@@ -110,83 +81,84 @@ export function DokumentutsendingSkjema() {
             harBrevmottaker={manuelleBrevmottakerePåFagsak.length > 0}
         >
             {!erLesevisning && <LeggTilBarnModal />}
-            <Container>
+            <Box padding={'space-32'} overflow={'auto'}>
                 <Heading size={'large'} level={'1'} children={'Send informasjonsbrev'} />
-
                 {manuelleBrevmottakerePåFagsak.length > 0 && (
-                    <StyledBrevmottakereAlert
-                        erPåBehandling={false}
-                        brevmottakere={manuelleBrevmottakerePåFagsak}
-                        bruker={bruker}
-                    />
+                    <Box marginBlock={'space-16'}>
+                        <BrevmottakereAlert
+                            erPåBehandling={false}
+                            brevmottakere={manuelleBrevmottakerePåFagsak}
+                            bruker={bruker}
+                        />
+                    </Box>
                 )}
-
-                <StyledFieldset
-                    error={hentSkjemaFeilmelding()}
-                    errorPropagation={false}
-                    legend="Send informasjonsbrev"
-                    hideLegend
-                >
-                    <Select
-                        {...skjema.felter.årsak.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        label={'Velg årsak'}
-                        value={skjema.felter.årsak.verdi || ''}
-                        onChange={(event: ChangeEvent<HTMLSelectElement>): void => {
-                            skjema.felter.årsak.onChange(event.target.value as DokumentÅrsak);
-                        }}
-                        size={'medium'}
+                <Box asChild maxWidth={'30rem'} marginBlock={'space-32 space-0'}>
+                    <Fieldset
+                        error={hentSkjemaFeilmelding()}
+                        errorPropagation={false}
+                        legend="Send informasjonsbrev"
+                        hideLegend
                     >
-                        <option value="">Velg</option>
-                        {Object.values(DokumentÅrsak).map(årsak => {
-                            return (
-                                <option key={årsak} aria-selected={skjema.felter.årsak.verdi === årsak} value={årsak}>
-                                    {dokumentÅrsak[årsak]}
-                                </option>
-                            );
-                        })}
-                    </Select>
-
-                    {skalViseFritekstAvsnitt && (
-                        <Box paddingBlock={'space-4 space-0'}>
-                            <FritekstAvsnitt />
-                        </Box>
-                    )}
-
-                    <FeltMargin>
-                        {barnIBrevÅrsak != undefined && (
-                            <>
-                                <BarnIBrevSkjema
-                                    barnIBrevFelt={skjema.felter.barnIBrev}
-                                    visFeilmeldinger={skjema.visFeilmeldinger}
-                                    settVisFeilmeldinger={settVisfeilmeldinger}
-                                    tittel={barnIBrevÅrsakTilTittel[barnIBrevÅrsak]}
-                                />
-                                {!erLesevisning && <LeggTilBarnKnapp />}
-                            </>
+                        <Select
+                            {...skjema.felter.årsak.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                            label={'Velg årsak'}
+                            value={skjema.felter.årsak.verdi || ''}
+                            onChange={(event: ChangeEvent<HTMLSelectElement>): void => {
+                                skjema.felter.årsak.onChange(event.target.value as DokumentÅrsak);
+                            }}
+                            size={'medium'}
+                        >
+                            <option value="">Velg</option>
+                            {Object.values(DokumentÅrsak).map(årsak => {
+                                return (
+                                    <option
+                                        key={årsak}
+                                        aria-selected={skjema.felter.årsak.verdi === årsak}
+                                        value={årsak}
+                                    >
+                                        {dokumentÅrsak[årsak]}
+                                    </option>
+                                );
+                            })}
+                        </Select>
+                        {skalViseFritekstAvsnitt && (
+                            <Box paddingBlock={'space-4 space-0'}>
+                                <FritekstAvsnitt />
+                            </Box>
                         )}
-                    </FeltMargin>
-
-                    <MålformVelger
-                        målformFelt={skjema.felter.målform}
-                        visFeilmeldinger={skjema.visFeilmeldinger}
-                        erLesevisning={false}
-                        Legend={<Label children={'Målform'} />}
-                    />
-
-                    {årsakVerdi && visForhåndsvisningBeskjed() && (
-                        <Box marginBlock={'space-16'}>
-                            <InfoCard data-color="info">
-                                <InfoCard.Message icon={<InformationSquareIcon aria-hidden />}>
-                                    Du har gjort endringer i brevet som ikke er forhåndsvist
-                                </InfoCard.Message>
-                            </InfoCard>
+                        <Box marginBlock={'space-8 space-32'}>
+                            {barnIBrevÅrsak != undefined && (
+                                <>
+                                    <BarnIBrevSkjema
+                                        barnIBrevFelt={skjema.felter.barnIBrev}
+                                        visFeilmeldinger={skjema.visFeilmeldinger}
+                                        settVisFeilmeldinger={settVisfeilmeldinger}
+                                        tittel={barnIBrevÅrsakTilTittel[barnIBrevÅrsak]}
+                                    />
+                                    {!erLesevisning && <LeggTilBarnKnapp />}
+                                </>
+                            )}
                         </Box>
-                    )}
-                </StyledFieldset>
-
-                <Handlinger>
-                    <div>
-                        <SendBrevKnapp
+                        <MålformVelger
+                            målformFelt={skjema.felter.målform}
+                            visFeilmeldinger={skjema.visFeilmeldinger}
+                            erLesevisning={false}
+                            Legend={<Label children={'Målform'} />}
+                        />
+                        {årsakVerdi && visForhåndsvisningBeskjed() && (
+                            <Box marginBlock={'space-16'}>
+                                <InfoCard data-color="info">
+                                    <InfoCard.Message icon={<InformationSquareIcon aria-hidden />}>
+                                        Du har gjort endringer i brevet som ikke er forhåndsvist
+                                    </InfoCard.Message>
+                                </InfoCard>
+                            </Box>
+                        )}
+                    </Fieldset>
+                </Box>
+                <HStack justify={'space-between'} marginBlock={'space-24 space-0'}>
+                    <HStack gap={'space-16'}>
+                        <Button
                             size="medium"
                             variant="primary"
                             loading={senderBrev()}
@@ -194,12 +166,12 @@ export function DokumentutsendingSkjema() {
                             onClick={sendBrevPåFagsak}
                         >
                             Send brev
-                        </SendBrevKnapp>
+                        </Button>
 
                         <Button size="medium" variant="tertiary" onClick={nullstillSkjema}>
                             Avbryt
                         </Button>
-                    </div>
+                    </HStack>
                     {skjema.felter.årsak.verdi && (
                         <Button
                             variant={'tertiary'}
@@ -213,8 +185,8 @@ export function DokumentutsendingSkjema() {
                             {'Forhåndsvis'}
                         </Button>
                     )}
-                </Handlinger>
-            </Container>
+                </HStack>
+            </Box>
         </LeggTilBarnModalContextProvider>
     );
 }

--- a/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.module.css
+++ b/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.module.css
@@ -1,0 +1,7 @@
+.header {
+    font-size: var(--ax-font-size-xlarge);
+}
+
+.body {
+    font-size: var(--ax-font-size-heading-medium);
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
@@ -1,23 +1,15 @@
+import { BehandlingStatus } from '@typer/behandling';
+import type { IBehandlingstema } from '@typer/behandlingstema';
+import { tilBehandlingstema } from '@typer/behandlingstema';
+import { hentAktivBehandlingPåMinimalFagsak, hentFagsakStatusVisning } from '@utils/fagsak';
 import { Link as ReactRouterLink } from 'react-router';
-import styled from 'styled-components';
 
 import { BodyShort, Box, HStack, Link, LinkCard, VStack } from '@navikt/ds-react';
-import { FontSizeHeadingMedium, FontSizeXlarge, Space16, Space64 } from '@navikt/ds-tokens/dist/tokens';
+import { Space64 } from '@navikt/ds-tokens/dist/tokens';
 
 import type { VisningBehandling } from './visningBehandling';
-import { BehandlingStatus } from '../../../typer/behandling';
-import type { IBehandlingstema } from '../../../typer/behandlingstema';
-import { tilBehandlingstema } from '../../../typer/behandlingstema';
-import { hentAktivBehandlingPåMinimalFagsak, hentFagsakStatusVisning } from '../../../utils/fagsak';
 import { useFagsakContext } from '../FagsakContext';
-
-const HeaderTekst = styled(BodyShort)`
-    font-size: ${FontSizeXlarge};
-`;
-
-const BodyTekst = styled(BodyShort)`
-    font-size: ${FontSizeHeadingMedium};
-`;
+import styles from './FagsakLenkepanel.module.css';
 
 function Innholdstabell() {
     const { fagsak } = useFagsakContext();
@@ -27,31 +19,26 @@ function Innholdstabell() {
     return (
         <HStack gap="space-80">
             <div>
-                <HeaderTekst for={'behandlingstema'} spacing>
+                <BodyShort className={styles.header} spacing>
                     Behandlingstema
-                </HeaderTekst>
-                <BodyTekst name={'behandlingstema'} weight="semibold">
+                </BodyShort>
+                <BodyShort className={styles.body} weight="semibold">
                     {behandlingstema ? behandlingstema.navn : '-'}
-                </BodyTekst>
+                </BodyShort>
             </div>
             <div>
-                <HeaderTekst for={'status'} spacing>
+                <BodyShort className={styles.header} spacing>
                     Status
-                </HeaderTekst>
-                <BodyTekst name={'status'} weight="semibold">
+                </BodyShort>
+                <BodyShort className={styles.body} weight="semibold">
                     {hentFagsakStatusVisning(fagsak)}
-                </BodyTekst>
+                </BodyShort>
             </div>
         </HStack>
     );
 }
 
 export const SaksoversiktPanelBredde = `calc(10 * ${Space64})`;
-
-const FagsakPanel = styled(Box)`
-    width: ${SaksoversiktPanelBredde};
-    margin-top: ${Space16};
-`;
 
 const genererLinkTekst = (behandling: VisningBehandling) => {
     return behandling.status === BehandlingStatus.AVSLUTTET ? 'Gå til gjeldende vedtak' : 'Gå til åpen behandling';
@@ -79,8 +66,15 @@ export function FagsakLenkepanel() {
             </LinkCard>
         </Box>
     ) : (
-        <FagsakPanel borderColor="neutral-strong" borderWidth="1" borderRadius="2" padding="space-32">
+        <Box
+            width={SaksoversiktPanelBredde}
+            marginBlock={'space-16 space-0'}
+            borderColor="neutral-strong"
+            borderWidth="1"
+            borderRadius="2"
+            padding="space-32"
+        >
             <Innholdstabell />
-        </FagsakPanel>
+        </Box>
     );
 }

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.module.css
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.module.css
@@ -1,0 +1,3 @@
+.ytelse {
+    border-style: dashed;
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
@@ -1,20 +1,10 @@
-import styled from 'styled-components';
+import type { IUtbetalingsperiodeDetalj } from '@typer/vedtaksperiode';
+import { formaterBeløp } from '@utils/formatter';
 
-import { BodyShort, HStack } from '@navikt/ds-react';
-import { Space16, Space32, Space8 } from '@navikt/ds-tokens/dist/tokens';
+import { BodyShort, Box, HStack } from '@navikt/ds-react';
 
 import { PersonInformasjonUtbetaling } from './PersonInformasjonUtbetaling';
-import type { IUtbetalingsperiodeDetalj } from '../../../typer/vedtaksperiode';
-import { formaterBeløp } from '../../../utils/formatter';
-
-const Ytelser = styled.section`
-    margin: ${Space8} 0 ${Space16} ${Space32};
-    border-bottom: 1px dashed;
-`;
-
-const Ytelselinje = styled(HStack)`
-    margin-bottom: ${Space16};
-`;
+import styles from './PersonUtbetaling.module.css';
 
 interface IPersonUtbetalingProps {
     utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
@@ -24,16 +14,29 @@ const PersonUtbetaling = ({ utbetalingsperiodeDetaljer }: IPersonUtbetalingProps
     return (
         <section>
             <PersonInformasjonUtbetaling person={utbetalingsperiodeDetaljer[0].person} />
-            <Ytelser>
-                {utbetalingsperiodeDetaljer.map(utbetalingsperiodeDetalj => {
-                    return (
-                        <Ytelselinje key={utbetalingsperiodeDetalj.person.personIdent} justify="space-between">
-                            <BodyShort>Kontantstøtte</BodyShort>
-                            <BodyShort>{formaterBeløp(utbetalingsperiodeDetalj.utbetaltPerMnd)}</BodyShort>
-                        </Ytelselinje>
-                    );
-                })}
-            </Ytelser>
+            <Box
+                marginInline={'space-32 space-0'}
+                marginBlock={'space-8 space-16'}
+                asChild
+                borderColor={'neutral'}
+                borderWidth={'0 0 1 0'}
+                className={styles.ytelse}
+            >
+                <section>
+                    {utbetalingsperiodeDetaljer.map(utbetalingsperiodeDetalj => {
+                        return (
+                            <HStack
+                                marginBlock={'space-0 space-16'}
+                                key={utbetalingsperiodeDetalj.person.personIdent}
+                                justify="space-between"
+                            >
+                                <BodyShort>Kontantstøtte</BodyShort>
+                                <BodyShort>{formaterBeløp(utbetalingsperiodeDetalj.utbetaltPerMnd)}</BodyShort>
+                            </HStack>
+                        );
+                    })}
+                </section>
+            </Box>
         </section>
     );
 };

--- a/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.tsx
@@ -1,24 +1,11 @@
-import styled from 'styled-components';
+import type { IUtbetalingsperiodeDetalj, Vedtaksperiode } from '@typer/vedtaksperiode';
+import { Vedtaksperiodetype } from '@typer/vedtaksperiode';
+import { formaterBeløp, sorterUtbetaling } from '@utils/formatter';
 
-import { BodyShort, HStack, VStack } from '@navikt/ds-react';
-import { BorderNeutralStrong, Space32, Space8 } from '@navikt/ds-tokens/dist/tokens';
+import { BodyShort, Box, HStack, VStack } from '@navikt/ds-react';
 
 import { SaksoversiktPanelBredde } from './FagsakLenkepanel';
 import PersonUtbetaling from './PersonUtbetaling';
-import type { IUtbetalingsperiodeDetalj, Vedtaksperiode } from '../../../typer/vedtaksperiode';
-import { Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
-import { formaterBeløp, sorterUtbetaling } from '../../../utils/formatter';
-
-const LøpendeUtbetalinger = styled(VStack)`
-    max-width: ${SaksoversiktPanelBredde};
-    margin-top: ${Space32};
-`;
-
-const Totallinje = styled(HStack)`
-    margin-left: ${Space32};
-    padding-bottom: ${Space8};
-    border-bottom: 1px solid ${BorderNeutralStrong};
-`;
 
 interface IUtbetalingerProps {
     vedtaksperiode?: Vedtaksperiode;
@@ -43,7 +30,7 @@ const Utbetalinger = ({ vedtaksperiode }: IUtbetalingerProps) => {
             }, {}) ?? {};
 
     return (
-        <LøpendeUtbetalinger gap="space-16">
+        <VStack maxWidth={SaksoversiktPanelBredde} marginBlock={'space-32 space-0'} gap="space-16">
             {Object.values(utbetalingsperiodeDetaljerGruppertPåPerson).map(
                 (utbetalingsperiodeDetaljerForPerson, index) => {
                     return (
@@ -54,13 +41,15 @@ const Utbetalinger = ({ vedtaksperiode }: IUtbetalingerProps) => {
                     );
                 }
             )}
-            <Totallinje justify="space-between">
-                <BodyShort>Totalt utbetalt/mnd</BodyShort>
-                <BodyShort weight="semibold">
-                    {vedtaksperiode ? formaterBeløp(vedtaksperiode.utbetaltPerMnd) : '-'}
-                </BodyShort>
-            </Totallinje>
-        </LøpendeUtbetalinger>
+            <Box asChild borderWidth={'0 0 1 0'} borderColor={'neutral-strong'}>
+                <HStack marginInline={'space-32 space-0'} paddingBlock={'space-0 space-8'} justify="space-between">
+                    <BodyShort>Totalt utbetalt/mnd</BodyShort>
+                    <BodyShort weight="semibold">
+                        {vedtaksperiode ? formaterBeløp(vedtaksperiode.utbetaltPerMnd) : '-'}
+                    </BodyShort>
+                </HStack>
+            </Box>
+        </VStack>
     );
 };
 

--- a/src/frontend/typer/styling.ts
+++ b/src/frontend/typer/styling.ts
@@ -1,3 +1,0 @@
-const headerHøydeRem = 3;
-const personlinjeHøydeRem = 3;
-export const fagsakHeaderHøydeRem = headerHøydeRem + personlinjeHøydeRem;


### PR DESCRIPTION
### 📮 Favro: NAV-26302
tilsvarende PR i ba-sak-frontend: https://github.com/navikt/familie-ba-sak-frontend/pull/4675

### 💰 Hva skal gjøres, og hvorfor?


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
Før venstre og ny høyre
Dokumentutsending
<img width="1239" height="866" alt="image" src="https://github.com/user-attachments/assets/dcf23bcd-2f6d-4a66-af86-7ad11045eea4" />

Saksoversikt
<img width="1665" height="683" alt="image" src="https://github.com/user-attachments/assets/21a50271-9f36-4a81-82c6-fc53551e461d" />


Dokumenter gammel over og ny under for å lettere se bredden
<img width="1679" height="813" alt="image" src="https://github.com/user-attachments/assets/655041f7-5dd5-491f-af84-c1bd869113c4" />
