### PR TITLE
Fjern teknisk opphør som behandlingstype

### DIFF
--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -273,10 +273,6 @@ export const behandlingstyper: INøkkelPar = {
         id: 'REVURDERING',
         navn: 'Revurdering',
     },
-    TEKNISK_OPPHØR: {
-        id: 'TEKNISK_OPPHØR',
-        navn: 'Teknisk opphør',
-    },
     TEKNISK_ENDRING: {
         id: 'TEKNISK_ENDRING',
         navn: 'Teknisk endring',


### PR DESCRIPTION
### 📮 Favro: NAV-29928

### 💰 Hva skal gjøres, og hvorfor?
Fjerner `TEKNISK_OPPHØR` som behandlingstype, siden `TEKNISK_ENDRING` erstatter dette. Ingen spor av behandlingstypen i backenden eller databasen.