### PR TITLE
NAV-29950 Ta i bruk react hook form og react query for RegistrerSøknad

### DIFF
--- a/src/frontend/api/registrerSøknad.ts
+++ b/src/frontend/api/registrerSøknad.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IBehandling } from '@typer/behandling';
+import type { IRestRegistrerSøknad } from '@typer/søknad';
+
+export async function registrerSøknad(payload: IRestRegistrerSøknad, behandlingId: number): Promise<IBehandling> {
+    return apiClient.post<IRestRegistrerSøknad, IBehandling>({
+        url: `/familie-ks-sak/api/behandlinger/${behandlingId}/steg/registrer-søknad`,
+        data: payload,
+    });
+}

--- a/src/frontend/hooks/useRegistrerSøknad.ts
+++ b/src/frontend/hooks/useRegistrerSøknad.ts
@@ -1,0 +1,18 @@
+import { registrerSøknad } from '@api/registrerSøknad';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+import type { IRestRegistrerSøknad } from '@typer/søknad';
+
+interface RegistrerSøknadParameters {
+    behandlingId: number;
+    søknad: IRestRegistrerSøknad;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, RegistrerSøknadParameters>, 'mutationFn'>;
+
+export function useRegistrerSøknad(options?: Options) {
+    return useMutation({
+        mutationFn: ({ behandlingId, søknad }: RegistrerSøknadParameters) => registrerSøknad(søknad, behandlingId),
+        ...options,
+    });
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/Annet.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/Annet.tsx
@@ -1,26 +1,36 @@
 import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useController, useFormContext } from 'react-hook-form';
 
 import { Heading, Textarea, VStack } from '@navikt/ds-react';
 
-import { useSøknadContext } from './SøknadContext';
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues } from './SøknadContext';
 
-const Annet = () => {
-    const { skjema } = useSøknadContext();
-
+export const Annet = () => {
     const erLesevisning = useErLesevisning();
+
+    const { control } = useFormContext<RegistrerSøknadFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: RegistrerSøknadFelt.ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE,
+        control,
+    });
 
     return (
         <VStack marginBlock={'space-32'}>
             <Heading size={'medium'} level={'2'} children={'Annet'} />
             <br />
             <Textarea
-                {...skjema.felter.endringAvOpplysningerBegrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
-                readOnly={erLesevisning}
+                value={value}
+                onChange={onChange}
+                error={error?.message}
+                readOnly={isSubmitting || erLesevisning}
                 label={!erLesevisning && 'Ved endring av opplysningene er begrunnelse obligatorisk'}
                 maxLength={2000}
             />
         </VStack>
     );
 };
-
-export default Annet;

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/BarnMedOpplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/BarnMedOpplysninger.tsx
@@ -2,27 +2,43 @@ import { useErLesevisning } from '@hooks/useErLesevisning';
 import type { IBarnMedOpplysninger } from '@typer/søknad';
 import { formaterIdent, hentAlderSomString } from '@utils/formatter';
 import classNames from 'classnames';
+import { useFormContext } from 'react-hook-form';
 
 import { BodyShort, Box, Button, Checkbox, HStack } from '@navikt/ds-react';
 
 import styles from './BarnMedOpplysninger.module.css';
-import { useSøknadContext } from './SøknadContext';
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues, useSøknadContext } from './SøknadContext';
 import Slett from '../../../../../ikoner/Slett';
 
 interface IProps {
     barn: IBarnMedOpplysninger;
 }
 
-const BarnMedOpplysninger = ({ barn }: IProps) => {
-    const { skjema, barnMedLøpendeUtbetaling } = useSøknadContext();
+export const BarnMedOpplysninger = ({ barn }: IProps) => {
+    const { barnMedLøpendeUtbetaling } = useSøknadContext();
 
     const erLesevisning = useErLesevisning();
+
+    const { getValues, setValue } = useFormContext<RegistrerSøknadFormValues>();
 
     const barnetHarLøpendeUtbetaling = barnMedLøpendeUtbetaling.has(barn.ident);
 
     const navnOgIdentTekst = `${barn.navn ?? 'Navn ukjent'} (${hentAlderSomString(
         barn.fødselsdato
     )}) | ${formaterIdent(barn.ident)} ${barnetHarLøpendeUtbetaling ? '(løpende)' : ''}`;
+
+    const fjernBarn = () => {
+        setValue(
+            RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER,
+            getValues(RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER).filter(
+                barnMedOpplysninger =>
+                    barnMedOpplysninger.ident !== barn.ident ||
+                    barnMedOpplysninger.navn !== barn.navn ||
+                    barnMedOpplysninger.fødselsdato !== barn.fødselsdato
+            ),
+            { shouldValidate: true, shouldDirty: true }
+        );
+    };
 
     return (
         <HStack gap={'space-16'}>
@@ -49,16 +65,7 @@ const BarnMedOpplysninger = ({ barn }: IProps) => {
                     id={`fjern__${barn.ident}`}
                     size={'small'}
                     icon={<Slett />}
-                    onClick={() => {
-                        skjema.felter.barnaMedOpplysninger.validerOgSettFelt([
-                            ...skjema.felter.barnaMedOpplysninger.verdi.filter(
-                                barnMedOpplysninger =>
-                                    barnMedOpplysninger.ident !== barn.ident ||
-                                    barnMedOpplysninger.navn !== barn.navn ||
-                                    barnMedOpplysninger.fødselsdato !== barn.fødselsdato
-                            ),
-                        ]);
-                    }}
+                    onClick={fjernBarn}
                 >
                     {'Fjern barn'}
                 </Button>
@@ -66,4 +73,3 @@ const BarnMedOpplysninger = ({ barn }: IProps) => {
         </HStack>
     );
 };
-export default BarnMedOpplysninger;

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/Barna.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/Barna.tsx
@@ -5,21 +5,41 @@ import { adressebeskyttelsestyper, ForelderBarnRelasjonRolle } from '@typer/pers
 import type { IBarnMedOpplysninger } from '@typer/søknad';
 import { isoStringTilDate } from '@utils/dato';
 import { differenceInMilliseconds } from 'date-fns';
+import { useController, useFormContext } from 'react-hook-form';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
 import { CheckboxGroup, Heading, HStack, InfoCard, Label, VStack } from '@navikt/ds-react';
 
-import BarnMedOpplysninger from './BarnMedOpplysninger';
-import { useSøknadContext } from './SøknadContext';
+import { BarnMedOpplysninger } from './BarnMedOpplysninger';
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues, useSøknadContext } from './SøknadContext';
 import RødError from '../../../../../ikoner/RødError';
 
-const Barna = () => {
-    const { skjema } = useSøknadContext();
+export const BARN_CHECKBOX_GROUP_ID = 'registrer-søknad-barn';
+
+export const Barna = () => {
+    const { barnMedLøpendeUtbetaling } = useSøknadContext();
 
     const bruker = useBruker();
     const lesevisning = useErLesevisning();
 
-    const sorterteBarnMedOpplysninger = skjema.felter.barnaMedOpplysninger.verdi.sort(
+    const { control } = useFormContext<RegistrerSøknadFormValues>();
+
+    const {
+        field: { value: barnaMedOpplysninger, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER,
+        control,
+        rules: {
+            validate: barna =>
+                barna.some((barn: IBarnMedOpplysninger) => barn.merket) || barnMedLøpendeUtbetaling.size > 0
+                    ? undefined
+                    : 'Ingen av barna er valgt.',
+        },
+    });
+
+    const sorterteBarnMedOpplysninger = [...barnaMedOpplysninger].sort(
         (a: IBarnMedOpplysninger, b: IBarnMedOpplysninger) => {
             if (!a.fødselsdato) {
                 return 1;
@@ -41,8 +61,8 @@ const Barna = () => {
     );
 
     const oppdaterBarnMedMerketStatus = (barnaSomErSjekketAv: string[]) => {
-        skjema.felter.barnaMedOpplysninger.validerOgSettFelt(
-            skjema.felter.barnaMedOpplysninger.verdi.map((barnMedOpplysninger: IBarnMedOpplysninger) => ({
+        onChange(
+            barnaMedOpplysninger.map((barnMedOpplysninger: IBarnMedOpplysninger) => ({
                 ...barnMedOpplysninger,
                 merket: barnaSomErSjekketAv.includes(barnMedOpplysninger.ident),
             }))
@@ -72,13 +92,15 @@ const Barna = () => {
             })}
             <br />
             <CheckboxGroup
-                {...skjema.felter.barnaMedOpplysninger.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                id={BARN_CHECKBOX_GROUP_ID}
+                readOnly={isSubmitting}
+                error={error?.message}
                 legend={
                     !lesevisning ? <Label>Velg hvilke barn det er søkt om</Label> : <Label>Barn det er søkt om</Label>
                 }
-                value={skjema.felter.barnaMedOpplysninger.verdi
-                    .filter(barnMedOpplysninger => barnMedOpplysninger.merket)
-                    .map(barnMedOpplysninger => barnMedOpplysninger.ident)}
+                value={barnaMedOpplysninger
+                    .filter((barnMedOpplysninger: IBarnMedOpplysninger) => barnMedOpplysninger.merket)
+                    .map((barnMedOpplysninger: IBarnMedOpplysninger) => barnMedOpplysninger.ident)}
                 onChange={(merkedeBarn: string[]) => oppdaterBarnMedMerketStatus(merkedeBarn)}
             >
                 {sorterteBarnMedOpplysninger.map((barnMedOpplysninger: IBarnMedOpplysninger) => (
@@ -97,5 +119,3 @@ const Barna = () => {
         </VStack>
     );
 };
-
-export default Barna;

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/MålformFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/MålformFelt.tsx
@@ -1,0 +1,57 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { Målform, målform } from '@typer/søknad';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Box, Heading, Radio, RadioGroup } from '@navikt/ds-react';
+
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues } from './SøknadContext';
+
+export const MÅLFORM_RADIOGROUP_ID = 'registrer-søknad-målform';
+
+export const MålformFelt = () => {
+    const erLesevisning = useErLesevisning();
+
+    const { control } = useFormContext<RegistrerSøknadFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: RegistrerSøknadFelt.MÅLFORM,
+        control,
+        rules: {
+            validate: value => (value !== undefined ? undefined : 'Målform er ikke valgt.'),
+        },
+    });
+
+    return (
+        <RadioGroup
+            id={MÅLFORM_RADIOGROUP_ID}
+            readOnly={isSubmitting || erLesevisning}
+            error={error?.message}
+            value={value ? målform[value] : ''}
+            legend={<Heading size={'medium'} level={'2'} children={'Målform'} />}
+        >
+            <Box paddingInline={'space-16 space-0'}>
+                <Radio
+                    value={målform[Målform.NB]}
+                    name={'registrer-søknad-målform'}
+                    checked={value === Målform.NB}
+                    onChange={() => onChange(Målform.NB)}
+                    id={'målform-nb'}
+                >
+                    {målform[Målform.NB]}
+                </Radio>
+                <Radio
+                    value={målform[Målform.NN]}
+                    name={'registrer-søknad-målform'}
+                    checked={value === Målform.NN}
+                    onChange={() => onChange(Målform.NN)}
+                >
+                    {målform[Målform.NN]}
+                </Radio>
+            </Box>
+        </RadioGroup>
+    );
+};

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/RegistrerSøknad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/RegistrerSøknad.tsx
@@ -4,32 +4,59 @@ import { LeggTilBarnModal } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModa
 import { LeggTilBarnModalContextProvider } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
 import { BehandlingSteg } from '@typer/behandling';
 import type { IBarnMedOpplysninger } from '@typer/søknad';
+import { useFormContext } from 'react-hook-form';
 
 import { ErrorSummary, LocalAlert } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 
-import Annet from './Annet';
-import Barna from './Barna';
+import { Annet } from './Annet';
+import { Barna, BARN_CHECKBOX_GROUP_ID } from './Barna';
 import { LeggTilBarnKnapp } from './LeggTilBarnKnapp';
-import { useSøknadContext } from './SøknadContext';
-import MålformVelger from '../../../../../komponenter/MålformVelger';
+import { MÅLFORM_RADIOGROUP_ID, MålformFelt } from './MålformFelt';
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues, useSøknadContext } from './SøknadContext';
 import Skjemasteg from '../../../../../komponenter/Skjemasteg/Skjemasteg';
 
 const RegistrerSøknad = () => {
     const behandling = useBehandling();
     const erLesevisning = useErLesevisning();
 
-    const { hentFeilTilOppsummering, nesteAction, skjema, søknadErLastetFraBackend } = useSøknadContext();
+    const { erSenderInn, nesteAction, søknadErLastetFraBackend } = useSøknadContext();
+
+    const {
+        getValues,
+        setValue,
+        watch,
+        formState: { errors },
+    } = useFormContext<RegistrerSøknadFormValues>();
 
     const harBrevmottaker = behandling.brevmottakere.length > 0;
 
+    const barnaMedOpplysninger = watch(RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER);
+
     function onLeggTilBarn(barn: IBarnMedOpplysninger) {
-        skjema.felter.barnaMedOpplysninger.validerOgSettFelt([...skjema.felter.barnaMedOpplysninger.verdi, barn]);
+        setValue(
+            RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER,
+            [...getValues(RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER), barn],
+            {
+                shouldValidate: true,
+                shouldDirty: true,
+            }
+        );
     }
+
+    const feiloppsummering = [
+        errors.barnaMedOpplysninger?.message && {
+            id: BARN_CHECKBOX_GROUP_ID,
+            feilmelding: errors.barnaMedOpplysninger.message,
+        },
+        errors.målform?.message && {
+            id: MÅLFORM_RADIOGROUP_ID,
+            feilmelding: errors.målform.message,
+        },
+    ].filter((feil): feil is { id: string; feilmelding: string } => Boolean(feil));
 
     return (
         <LeggTilBarnModalContextProvider
-            barn={skjema.felter.barnaMedOpplysninger.verdi}
+            barn={barnaMedOpplysninger}
             onLeggTilBarn={onLeggTilBarn}
             harBrevmottaker={harBrevmottaker}
         >
@@ -41,7 +68,7 @@ const RegistrerSøknad = () => {
                     nesteAction(false);
                 }}
                 nesteKnappTittel={erLesevisning ? 'Neste' : 'Bekreft og fortsett'}
-                senderInn={skjema.submitRessurs.status === RessursStatus.HENTER}
+                senderInn={erSenderInn}
                 steg={BehandlingSteg.REGISTRERE_SØKNAD}
             >
                 {søknadErLastetFraBackend && !erLesevisning && (
@@ -63,26 +90,21 @@ const RegistrerSøknad = () => {
 
                 {!erLesevisning && <LeggTilBarnKnapp />}
 
-                <MålformVelger
-                    målformFelt={skjema.felter.målform}
-                    visFeilmeldinger={skjema.visFeilmeldinger}
-                    erLesevisning={erLesevisning}
-                />
+                <MålformFelt />
 
                 <Annet />
 
-                {(skjema.submitRessurs.status === RessursStatus.FEILET ||
-                    skjema.submitRessurs.status === RessursStatus.IKKE_TILGANG) && (
+                {errors.root?.message && (
                     <LocalAlert status="error">
                         <LocalAlert.Header>
-                            <LocalAlert.Title>{skjema.submitRessurs.frontendFeilmelding}</LocalAlert.Title>
+                            <LocalAlert.Title>{errors.root.message}</LocalAlert.Title>
                         </LocalAlert.Header>
                     </LocalAlert>
                 )}
-                {skjema.visFeilmeldinger && hentFeilTilOppsummering().length > 0 && (
+                {feiloppsummering.length > 0 && (
                     <ErrorSummary heading={'For å gå videre må du rette opp følgende:'}>
-                        {hentFeilTilOppsummering().map(item => (
-                            <ErrorSummary.Item key={item.skjemaelementId} href={`#${item.skjemaelementId}`}>
+                        {feiloppsummering.map(item => (
+                            <ErrorSummary.Item key={item.id} href={`#${item.id}`}>
                                 {item.feilmelding}
                             </ErrorSummary.Item>
                         ))}

--- a/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/SøknadContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/RegistrerSøknad/SøknadContext.tsx
@@ -1,32 +1,36 @@
-import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 import { useBruker } from '@hooks/useBruker';
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsak } from '@hooks/useFagsak';
-import type { IBehandling } from '@typer/behandling';
+import { useRegistrerSøknad } from '@hooks/useRegistrerSøknad';
 import { ForelderBarnRelasjonRolle, type IForelderBarnRelasjon } from '@typer/person';
-import type { IBarnMedOpplysninger, IBarnMedOpplysningerBackend, IRestRegistrerSøknad, Målform } from '@typer/søknad';
+import type { IBarnMedOpplysninger, IBarnMedOpplysningerBackend, Målform } from '@typer/søknad';
 import { hentBarnMedLøpendeUtbetaling } from '@utils/fagsak';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
-import type { Avhengigheter, FeiloppsummeringFeil, ISkjema } from '@navikt/familie-skjema';
-import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import type { Ressurs } from '@navikt/familie-typer';
-import { RessursStatus } from '@navikt/familie-typer';
+import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-interface SøknadSkjema {
-    barnaMedOpplysninger: IBarnMedOpplysninger[];
-    endringAvOpplysningerBegrunnelse: string;
-    målform: Målform | undefined;
+export enum RegistrerSøknadFelt {
+    BARNA_MED_OPPLYSNINGER = 'barnaMedOpplysninger',
+    ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE = 'endringAvOpplysningerBegrunnelse',
+    MÅLFORM = 'målform',
+}
+
+export interface RegistrerSøknadFormValues {
+    [RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER]: IBarnMedOpplysninger[];
+    [RegistrerSøknadFelt.ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE]: string;
+    [RegistrerSøknadFelt.MÅLFORM]: Målform | undefined;
 }
 
 interface SøknadContextValue {
     barnMedLøpendeUtbetaling: Set<string>;
-    hentFeilTilOppsummering: () => FeiloppsummeringFeil[];
+    erSenderInn: boolean;
     nesteAction: (bekreftEndringerViaFrontend: boolean) => void;
-    skjema: ISkjema<SøknadSkjema, IBehandling>;
     søknadErLastetFraBackend: boolean;
 }
 
@@ -40,50 +44,42 @@ export const SøknadProvider = ({ children }: PropsWithChildren) => {
     const erLesevisning = useErLesevisning();
     const navigate = useNavigate();
 
-    const barnMedLøpendeUtbetaling = hentBarnMedLøpendeUtbetaling(fagsak);
-
-    const { skjema, nullstillSkjema, onSubmit, hentFeilTilOppsummering } = useSkjema<SøknadSkjema, IBehandling>({
-        felter: {
-            barnaMedOpplysninger: useFelt<IBarnMedOpplysninger[]>({
-                verdi: [],
-                valideringsfunksjon: (felt, avhengigheter?: Avhengigheter) => {
-                    return felt.verdi.some((barn: IBarnMedOpplysninger) => barn.merket) ||
-                        (avhengigheter?.barnMedLøpendeUtbetaling.size ?? []) > 0
-                        ? ok(felt)
-                        : feil(felt, 'Ingen av barna er valgt.');
-                },
-                avhengigheter: { barnMedLøpendeUtbetaling },
-            }),
-            endringAvOpplysningerBegrunnelse: useFelt<string>({
-                verdi: '',
-            }),
-            målform: useFelt<Målform | undefined>({
-                verdi: undefined,
-                valideringsfunksjon: felt =>
-                    felt.verdi !== undefined ? ok(felt) : feil(felt, 'Målform er ikke valgt.'),
-            }),
-        },
-        skjemanavn: 'Registrer søknad',
-    });
-
     const [søknadErLastetFraBackend, settSøknadErLastetFraBackend] = useState(false);
 
+    const barnMedLøpendeUtbetaling = hentBarnMedLøpendeUtbetaling(fagsak);
+
+    const { mutateAsync: registrerSøknad, isPending } = useRegistrerSøknad();
+
+    const form = useForm<RegistrerSøknadFormValues>({
+        defaultValues: {
+            [RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER]: [],
+            [RegistrerSøknadFelt.ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE]: '',
+            [RegistrerSøknadFelt.MÅLFORM]: undefined,
+        },
+    });
+
+    const { reset, setError, handleSubmit } = form;
+
+    const byggBarnaFraFolkeregister = (): IBarnMedOpplysninger[] =>
+        bruker.forelderBarnRelasjon
+            .filter((relasjon: IForelderBarnRelasjon) => relasjon.relasjonRolle === ForelderBarnRelasjonRolle.BARN)
+            .map(
+                (relasjon: IForelderBarnRelasjon): IBarnMedOpplysninger => ({
+                    merket: false,
+                    ident: relasjon.personIdent,
+                    navn: relasjon.navn,
+                    fødselsdato: relasjon.fødselsdato,
+                    manueltRegistrert: false,
+                    erFolkeregistrert: true,
+                })
+            );
+
     const tilbakestillSøknad = () => {
-        nullstillSkjema();
-        skjema.felter.barnaMedOpplysninger.validerOgSettFelt(
-            bruker.forelderBarnRelasjon
-                .filter((relasjon: IForelderBarnRelasjon) => relasjon.relasjonRolle === ForelderBarnRelasjonRolle.BARN)
-                .map(
-                    (relasjon: IForelderBarnRelasjon): IBarnMedOpplysninger => ({
-                        merket: false,
-                        ident: relasjon.personIdent,
-                        navn: relasjon.navn,
-                        fødselsdato: relasjon.fødselsdato,
-                        manueltRegistrert: false,
-                        erFolkeregistrert: true,
-                    })
-                ) ?? []
-        );
+        reset({
+            [RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER]: byggBarnaFraFolkeregister(),
+            [RegistrerSøknadFelt.ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE]: '',
+            [RegistrerSøknadFelt.MÅLFORM]: undefined,
+        });
         settSøknadErLastetFraBackend(false);
     };
 
@@ -94,73 +90,76 @@ export const SøknadProvider = ({ children }: PropsWithChildren) => {
     useEffect(() => {
         if (behandling.søknadsgrunnlag) {
             settSøknadErLastetFraBackend(true);
-            skjema.felter.barnaMedOpplysninger.validerOgSettFelt(
-                behandling.søknadsgrunnlag.barnaMedOpplysninger.map(
+            reset({
+                [RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER]: behandling.søknadsgrunnlag.barnaMedOpplysninger.map(
                     (barnMedOpplysninger: IBarnMedOpplysningerBackend) => ({
                         ...barnMedOpplysninger,
                         merket: barnMedOpplysninger.inkludertISøknaden,
                     })
-                )
-            );
-
-            skjema.felter.målform.validerOgSettFelt(behandling.søknadsgrunnlag.søkerMedOpplysninger.målform);
-            skjema.felter.endringAvOpplysningerBegrunnelse.validerOgSettFelt(
-                behandling.søknadsgrunnlag.endringAvOpplysningerBegrunnelse
-            );
+                ),
+                [RegistrerSøknadFelt.ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE]:
+                    behandling.søknadsgrunnlag.endringAvOpplysningerBegrunnelse,
+                [RegistrerSøknadFelt.MÅLFORM]: behandling.søknadsgrunnlag.søkerMedOpplysninger.målform,
+            });
         } else {
             // Ny behandling er lastet som ikke har fullført søknad-steget.
             tilbakestillSøknad();
         }
     }, [behandling]);
 
+    const sendInn = async (values: RegistrerSøknadFormValues, bekreftEndringerViaFrontend: boolean) => {
+        return registrerSøknad({
+            behandlingId: behandling.behandlingId,
+            søknad: {
+                søknad: {
+                    søkerMedOpplysninger: {
+                        ident: bruker.personIdent,
+                        målform: values.målform,
+                    },
+                    barnaMedOpplysninger: values.barnaMedOpplysninger.map(
+                        (barn: IBarnMedOpplysninger): IBarnMedOpplysningerBackend => ({
+                            ...barn,
+                            inkludertISøknaden: barn.merket,
+                            ident: barn.ident ?? '',
+                        })
+                    ),
+                    endringAvOpplysningerBegrunnelse: values.endringAvOpplysningerBegrunnelse,
+                },
+                bekreftEndringerViaFrontend,
+            },
+        })
+            .then(oppdatertBehandling => {
+                settÅpenBehandling(byggSuksessRessurs(oppdatertBehandling));
+                navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
+            })
+            .catch((error: unknown) => {
+                setError('root', {
+                    message: error instanceof Error ? error.message : 'Teknisk feil ved registrering av søknad.',
+                });
+            });
+    };
+
     const nesteAction = (bekreftEndringerViaFrontend: boolean) => {
         if (erLesevisning) {
             navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
-        } else {
-            onSubmit<IRestRegistrerSøknad>(
-                {
-                    method: 'POST',
-                    data: {
-                        søknad: {
-                            søkerMedOpplysninger: {
-                                ident: bruker.personIdent,
-                                målform: skjema.felter.målform.verdi,
-                            },
-                            barnaMedOpplysninger: skjema.felter.barnaMedOpplysninger.verdi.map(
-                                (barn: IBarnMedOpplysninger): IBarnMedOpplysningerBackend => ({
-                                    ...barn,
-                                    inkludertISøknaden: barn.merket,
-                                    ident: barn.ident ?? '',
-                                })
-                            ),
-                            endringAvOpplysningerBegrunnelse: skjema.felter.endringAvOpplysningerBegrunnelse.verdi,
-                        },
-                        bekreftEndringerViaFrontend,
-                    },
-                    url: `/familie-ks-sak/api/behandlinger/${behandling.behandlingId}/steg/registrer-søknad`,
-                },
-                (response: Ressurs<IBehandling>) => {
-                    if (response.status === RessursStatus.SUKSESS) {
-                        settÅpenBehandling(response);
-                        navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
-                    }
-                }
-            );
+            return;
         }
+        handleSubmit(values => sendInn(values, bekreftEndringerViaFrontend))();
     };
 
     return (
-        <SøknadContext.Provider
-            value={{
-                barnMedLøpendeUtbetaling,
-                hentFeilTilOppsummering,
-                nesteAction,
-                skjema,
-                søknadErLastetFraBackend,
-            }}
-        >
-            {children}
-        </SøknadContext.Provider>
+        <FormProvider {...form}>
+            <SøknadContext.Provider
+                value={{
+                    barnMedLøpendeUtbetaling,
+                    erSenderInn: isPending,
+                    nesteAction,
+                    søknadErLastetFraBackend,
+                }}
+            >
+                {children}
+            </SøknadContext.Provider>
+        </FormProvider>
     );
 };
 


### PR DESCRIPTION
### 📮 Favro:
NAV-29950

### 💰 Hva skal gjøres, og hvorfor?
Migrerer RegistrerSøknad-steget fra `@navikt/familie-skjema` (`useSkjema`/`useFelt`) til `react-hook-form` + `react-query`, i tråd med etablert mønster i kodebasen.

- Ny API-funksjon `api/registrerSøknad.ts` som bruker `apiClient`.
- Ny mutasjonshook `hooks/useRegistrerSøknad.ts` (tynn `useMutation`-wrapper).
- `SøknadContext` bruker nå `useForm` + `FormProvider`; feltene styres via `useController` i egne feltkomponenter (`MålformFelt`, `Annet`, `Barna`).
- Innsending går via `handleSubmit` → `mutateAsync`; feil vises via `root`-feil og `ErrorSummary`.

Ingen funksjonell endring – kun teknisk refaktorering.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Synkronisering av skjema mot `søknadsgrunnlag`.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ren teknisk refaktorering uten funksjonell endring.

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Ingen visuelle endringer.
