### PR TITLE
NAV-29957: Skriver om valutakurs til react query og rhf

### DIFF
--- a/src/frontend/api/valutakurs.ts
+++ b/src/frontend/api/valutakurs.ts
@@ -1,0 +1,25 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IBehandling } from '@typer/behandling';
+
+export interface OppdaterValutakursPayload {
+    id: number;
+    fom: string;
+    tom?: string;
+    barnIdenter: string[];
+    valutakode?: string;
+    valutakursdato?: string;
+    kurs?: string;
+}
+
+export async function oppdaterValutakurs(payload: OppdaterValutakursPayload, behandlingId: number) {
+    return apiClient.put<OppdaterValutakursPayload, IBehandling>({
+        data: payload,
+        url: `/familie-ks-sak/api/differanseberegning/valutakurs/${behandlingId}`,
+    });
+}
+
+export async function slettValutakurs(behandlingId: number, valutakursId: number) {
+    return apiClient.delete<void, IBehandling>({
+        url: `/familie-ks-sak/api/differanseberegning/valutakurs/${behandlingId}/${valutakursId}`,
+    });
+}

--- a/src/frontend/hooks/useOppdaterValutakurs.ts
+++ b/src/frontend/hooks/useOppdaterValutakurs.ts
@@ -1,0 +1,17 @@
+import { oppdaterValutakurs, type OppdaterValutakursPayload } from '@api/valutakurs';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+interface OppdaterValutakursParameters extends OppdaterValutakursPayload {
+    behandlingId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OppdaterValutakursParameters>, 'mutationFn'>;
+
+export function useOppdaterValutakurs(options?: Options) {
+    return useMutation({
+        mutationFn: ({ behandlingId, ...payload }: OppdaterValutakursParameters) =>
+            oppdaterValutakurs(payload, behandlingId),
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useSlettValutakurs.ts
+++ b/src/frontend/hooks/useSlettValutakurs.ts
@@ -1,0 +1,18 @@
+import { slettValutakurs } from '@api/valutakurs';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+interface SlettValutakursParameters {
+    behandlingId: number;
+    valutakursId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, SlettValutakursParameters>, 'mutationFn'>;
+
+export function useSlettValutakurs(options?: Options) {
+    return useMutation({
+        mutationFn: ({ behandlingId, valutakursId }: SlettValutakursParameters) =>
+            slettValutakurs(behandlingId, valutakursId),
+        ...options,
+    });
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursBarnFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursBarnFelt.tsx
@@ -1,0 +1,49 @@
+import type { OptionType } from '@typer/common';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { UNSAFE_Combobox } from '@navikt/ds-react';
+
+import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
+
+interface Props {
+    tilgjengeligeBarn: OptionType[];
+    lesevisning: boolean;
+}
+
+export function ValutakursBarnFelt({ tilgjengeligeBarn, lesevisning }: Props) {
+    const { control } = useFormContext<ValutakursFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+    } = useController({
+        name: ValutakursFelt.BARN,
+        control,
+        rules: {
+            validate: barn => (barn.length > 0 ? undefined : 'Minst ett barn må være valgt'),
+        },
+    });
+
+    const onToggleSelected = (optionValue: string, isSelected: boolean) => {
+        if (isSelected) {
+            const nyttValg = tilgjengeligeBarn.find(barn => barn.value === optionValue);
+            if (nyttValg) {
+                onChange([...value, nyttValg]);
+            }
+        } else {
+            onChange(value.filter(barn => barn.value !== optionValue));
+        }
+    };
+
+    return (
+        <UNSAFE_Combobox
+            isMultiSelect
+            label={'Barn'}
+            options={tilgjengeligeBarn}
+            selectedOptions={value}
+            onToggleSelected={onToggleSelected}
+            readOnly={lesevisning}
+            error={error?.message}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursDatoFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursDatoFelt.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+
+import { hentDagensDato } from '@utils/dato';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { DatePicker, type DateValidationT, useDatepicker } from '@navikt/ds-react';
+
+import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
+
+interface Props {
+    readOnly: boolean;
+}
+
+export function ValutakursDatoFelt({ readOnly }: Props) {
+    const { control, trigger, setValue } = useFormContext<ValutakursFormValues>();
+
+    const [dateValidation, setDateValidation] = useState<DateValidationT | undefined>(undefined);
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitted },
+    } = useController({
+        name: ValutakursFelt.VALUTAKURSDATO,
+        control,
+        rules: {
+            validate: valgtDato => {
+                if (dateValidation?.isWeekend) {
+                    return 'Du må velge en dato som er en ukedag';
+                }
+                if (dateValidation?.isAfter) {
+                    return 'Du kan ikke sette en dato som er frem i tid';
+                }
+                if (!valgtDato || dateValidation?.isInvalid || (dateValidation && !dateValidation.isValidDate)) {
+                    return 'Du må velge en gyldig dato';
+                }
+                return undefined;
+            },
+        },
+    });
+
+    const { datepickerProps, inputProps, setSelected, selectedDay } = useDatepicker({
+        defaultSelected: value,
+        toDate: hentDagensDato(),
+        disableWeekends: true,
+        onDateChange: dato => {
+            onChange(dato);
+            // Når valutakursdato endres må registrert kurs nullstilles slik at ny kurs hentes/registreres.
+            setValue(ValutakursFelt.KURS, '', { shouldDirty: true });
+            if (isSubmitted) {
+                trigger(ValutakursFelt.VALUTAKURSDATO);
+            }
+        },
+        onValidate: validation => {
+            setDateValidation(validation);
+            if (isSubmitted) {
+                trigger(ValutakursFelt.VALUTAKURSDATO);
+            }
+        },
+    });
+
+    // Synkroniser datovelgeren dersom feltverdien endres uten at det er datovelgeren som trigget endringen.
+    const [forrigeVerdi, settForrigeVerdi] = useState<Date | undefined>(value);
+    if (value !== forrigeVerdi) {
+        settForrigeVerdi(value);
+        if (value !== selectedDay) {
+            setSelected(value);
+        }
+    }
+
+    return (
+        <DatePicker dropdownCaption {...datepickerProps}>
+            <DatePicker.Input
+                {...inputProps}
+                label={'Valutakursdato'}
+                placeholder={'DD.MM.ÅÅÅÅ'}
+                readOnly={readOnly}
+                error={error?.message}
+            />
+        </DatePicker>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursKursFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursKursFelt.tsx
@@ -1,0 +1,57 @@
+import { isEmpty, isNumeric, tellAntallDesimaler } from '@utils/eøsValidators';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { TextField } from '@navikt/ds-react';
+
+import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
+import { konverterSkjemaverdiTilDesimal } from '../utils';
+
+const validerKurs = (verdi: string | undefined): string | undefined => {
+    if (!verdi || isEmpty(verdi) || typeof verdi != 'string') {
+        return 'Valutakurs er påkrevd, men mangler input';
+    }
+    const nyKurs = konverterSkjemaverdiTilDesimal(verdi);
+    if (!nyKurs) {
+        return 'Valutakurs er påkrevd, men mangler input';
+    }
+    if (!isNumeric(nyKurs)) {
+        return `Valutakurs innholder ugyldige verdier, kurs: ${verdi}`;
+    }
+    if (tellAntallDesimaler(nyKurs) === 0) {
+        return `Valutakurs må oppgis med desimaler, kurs: ${verdi}`;
+    }
+    if (Number(nyKurs) < 0) {
+        return `Kan ikke registrere negativt kurs: ${verdi}`;
+    }
+    return undefined;
+};
+
+interface Props {
+    readOnly: boolean;
+    erManuellInputAvKurs: boolean;
+}
+
+export function ValutakursKursFelt({ readOnly, erManuellInputAvKurs }: Props) {
+    const { control } = useFormContext<ValutakursFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+    } = useController({
+        name: ValutakursFelt.KURS,
+        control,
+        rules: {
+            validate: kurs => (erManuellInputAvKurs ? validerKurs(kurs) : undefined),
+        },
+    });
+
+    return (
+        <TextField
+            label={'Valutakurs'}
+            readOnly={readOnly}
+            value={value ?? ''}
+            onChange={event => onChange(event.target.value)}
+            error={error?.message}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursPeriodeFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursPeriodeFelt.tsx
@@ -1,0 +1,119 @@
+import MånedÅrVelger from '@komponenter/MånedÅrInput/MånedÅrVelger';
+import { hentDagensDato, isoStringTilDate } from '@utils/dato';
+import { isEmpty } from '@utils/eøsValidators';
+import { addMonths, endOfMonth, isAfter } from 'date-fns';
+import { useController, useFormContext } from 'react-hook-form';
+import styled from 'styled-components';
+
+import { Fieldset } from '@navikt/ds-react';
+
+import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
+
+const FlexDiv = styled.div`
+    width: 32rem;
+    display: flex;
+    justify-content: space-between;
+    font-size: 1rem;
+
+    div {
+        z-index: 0;
+    }
+
+    div div.skjemaelement {
+        margin-bottom: 0;
+    }
+`;
+
+const valgtDatoErNesteMånedEllerSenere = (valgtDato: string) =>
+    isAfter(isoStringTilDate(valgtDato), endOfMonth(hentDagensDato()));
+
+const valgtDatoErSenereEnnNesteMåned = (valgtDato: string) =>
+    isAfter(isoStringTilDate(valgtDato), endOfMonth(addMonths(hentDagensDato(), 1)));
+
+interface Props {
+    initielFom: string;
+    periodeFeilmeldingId: string;
+    lesevisning: boolean;
+    behandlingsÅrsakErOvergangsordning: boolean;
+}
+
+export function ValutakursPeriodeFelt({
+    initielFom,
+    periodeFeilmeldingId,
+    lesevisning,
+    behandlingsÅrsakErOvergangsordning,
+}: Props) {
+    const { control } = useFormContext<ValutakursFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+    } = useController({
+        name: ValutakursFelt.PERIODE,
+        control,
+        rules: {
+            validate: periode => {
+                const fom = periode.fom;
+                const tom = periode.tom;
+
+                if (!fom || isEmpty(fom)) {
+                    return 'Fra og med måned må være utfylt';
+                }
+                if (fom && valgtDatoErSenereEnnNesteMåned(fom) && !behandlingsÅrsakErOvergangsordning) {
+                    return 'Du kan ikke sette fra og med (f.o.m.) til måneden etter neste måned eller senere';
+                }
+                if (initielFom && !isAfter(isoStringTilDate(fom), isoStringTilDate(initielFom))) {
+                    return `Du kan ikke legge inn fra og med måned som er før: ${initielFom}`;
+                }
+                if (tom && valgtDatoErNesteMånedEllerSenere(tom) && !behandlingsÅrsakErOvergangsordning) {
+                    return 'Du kan ikke sette til og med (t.o.m.) til neste måned eller senere';
+                }
+                return undefined;
+            },
+        },
+    });
+
+    const finnÅrTilbakeTil = (): number => new Date().getFullYear() - new Date(initielFom).getFullYear();
+    const antallÅrFrem = behandlingsÅrsakErOvergangsordning ? 1 : 0;
+
+    return (
+        <Fieldset
+            className={lesevisning ? 'lesevisning' : ''}
+            errorId={periodeFeilmeldingId}
+            error={error?.message}
+            legend="Periode"
+            size="medium"
+        >
+            <FlexDiv>
+                <MånedÅrVelger
+                    lesevisning={lesevisning}
+                    id={'periode_fom'}
+                    label={'F.o.m'}
+                    antallÅrTilbake={finnÅrTilbakeTil()}
+                    antallÅrFrem={antallÅrFrem}
+                    value={value.fom ?? undefined}
+                    onEndret={årMåned => {
+                        if (årMåned === value.fom) {
+                            return;
+                        }
+                        onChange({ ...value, fom: årMåned });
+                    }}
+                />
+                <MånedÅrVelger
+                    lesevisning={lesevisning}
+                    id={'periode_tom'}
+                    label={'T.o.m (valgfri)'}
+                    antallÅrTilbake={finnÅrTilbakeTil()}
+                    antallÅrFrem={antallÅrFrem}
+                    value={value.tom ?? undefined}
+                    onEndret={årMåned => {
+                        if (årMåned === value.tom) {
+                            return;
+                        }
+                        onChange({ ...value, tom: årMåned });
+                    }}
+                />
+            </FlexDiv>
+        </Fieldset>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursPeriodeFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursPeriodeFelt.tsx
@@ -3,26 +3,10 @@ import { hentDagensDato, isoStringTilDate } from '@utils/dato';
 import { isEmpty } from '@utils/eøsValidators';
 import { addMonths, endOfMonth, isAfter } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';
-import styled from 'styled-components';
 
-import { Fieldset } from '@navikt/ds-react';
+import { Fieldset, HStack } from '@navikt/ds-react';
 
 import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
-
-const FlexDiv = styled.div`
-    width: 32rem;
-    display: flex;
-    justify-content: space-between;
-    font-size: 1rem;
-
-    div {
-        z-index: 0;
-    }
-
-    div div.skjemaelement {
-        margin-bottom: 0;
-    }
-`;
 
 const valgtDatoErNesteMånedEllerSenere = (valgtDato: string) =>
     isAfter(isoStringTilDate(valgtDato), endOfMonth(hentDagensDato()));
@@ -31,14 +15,14 @@ const valgtDatoErSenereEnnNesteMåned = (valgtDato: string) =>
     isAfter(isoStringTilDate(valgtDato), endOfMonth(addMonths(hentDagensDato(), 1)));
 
 interface Props {
-    initielFom: string;
+    initiellFom: string;
     periodeFeilmeldingId: string;
     lesevisning: boolean;
     behandlingsÅrsakErOvergangsordning: boolean;
 }
 
 export function ValutakursPeriodeFelt({
-    initielFom,
+    initiellFom,
     periodeFeilmeldingId,
     lesevisning,
     behandlingsÅrsakErOvergangsordning,
@@ -62,8 +46,8 @@ export function ValutakursPeriodeFelt({
                 if (fom && valgtDatoErSenereEnnNesteMåned(fom) && !behandlingsÅrsakErOvergangsordning) {
                     return 'Du kan ikke sette fra og med (f.o.m.) til måneden etter neste måned eller senere';
                 }
-                if (initielFom && !isAfter(isoStringTilDate(fom), isoStringTilDate(initielFom))) {
-                    return `Du kan ikke legge inn fra og med måned som er før: ${initielFom}`;
+                if (initiellFom && !isAfter(isoStringTilDate(fom), isoStringTilDate(initiellFom))) {
+                    return `Du kan ikke legge inn fra og med måned som er før: ${initiellFom}`;
                 }
                 if (tom && valgtDatoErNesteMånedEllerSenere(tom) && !behandlingsÅrsakErOvergangsordning) {
                     return 'Du kan ikke sette til og med (t.o.m.) til neste måned eller senere';
@@ -73,7 +57,7 @@ export function ValutakursPeriodeFelt({
         },
     });
 
-    const finnÅrTilbakeTil = (): number => new Date().getFullYear() - new Date(initielFom).getFullYear();
+    const finnÅrTilbakeTil = (): number => new Date().getFullYear() - new Date(initiellFom).getFullYear();
     const antallÅrFrem = behandlingsÅrsakErOvergangsordning ? 1 : 0;
 
     return (
@@ -84,7 +68,7 @@ export function ValutakursPeriodeFelt({
             legend="Periode"
             size="medium"
         >
-            <FlexDiv>
+            <HStack justify={'space-between'} gap={'space-16'} width={'32rem'}>
                 <MånedÅrVelger
                     lesevisning={lesevisning}
                     id={'periode_fom'}
@@ -113,7 +97,7 @@ export function ValutakursPeriodeFelt({
                         onChange({ ...value, tom: årMåned });
                     }}
                 />
-            </FlexDiv>
+            </HStack>
         </Fieldset>
     );
 }

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
@@ -1,10 +1,12 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
+import { FormProvider } from 'react-hook-form';
 
 import { Table } from '@navikt/ds-react';
 
 import { useValutakursSkjema, valutakursFeilmeldingId } from './useValutakursSkjema';
 import ValutakursTabellRadEndre from './ValutakursTabellRadEndre';
-import { BehandlingÅrsak, type IBehandling } from '../../../../../../../typer/behandling';
+import type { IBehandling } from '../../../../../../../typer/behandling';
 import type { OptionType } from '../../../../../../../typer/common';
 import type { IRestValutakurs } from '../../../../../../../typer/eøsPerioder';
 import { Datoformat, isoStringTilFormatertString } from '../../../../../../../utils/dato';
@@ -18,40 +20,39 @@ interface IProps {
 }
 
 const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: IProps) => {
+    const [erValutakursEkspandert, settErValutakursEkspandert] = useState(false);
+
     const barn: OptionType[] = valutakurs.barnIdenter.map(barn => ({
         value: barn,
         label: lagPersonLabel(barn, åpenBehandling.personer),
     }));
 
     const {
-        erValutakursEkspandert,
-        settErValutakursEkspandert,
-        skjema,
-        valideringErOk,
-        sendInnSkjema,
-        tilbakestillFelterTilDefault,
-        kanSendeSkjema,
-        erValutakursSkjemaEndret,
+        form,
+        onSubmit,
         slettValutakurs,
         sletterValutakurs,
         erManuellInputAvKurs,
+        initielFom,
+        behandlingsÅrsakErOvergangsordning,
     } = useValutakursSkjema({
         valutakurs,
         barnIValutakurs: barn,
+        lukkSkjema: () => settErValutakursEkspandert(false),
     });
 
     useEffect(() => {
         if (visFeilmeldinger && erValutakursEkspandert) {
-            kanSendeSkjema();
+            form.trigger();
         }
     }, [visFeilmeldinger, erValutakursEkspandert]);
 
     const toggleForm = (visAlert: boolean) => {
-        if (erValutakursEkspandert && visAlert && erValutakursSkjemaEndret()) {
+        if (erValutakursEkspandert && visAlert && form.formState.isDirty) {
             alert('Valutakurs har endringer som ikke er lagret!');
         } else {
             settErValutakursEkspandert(!erValutakursEkspandert);
-            tilbakestillFelterTilDefault();
+            form.reset();
         }
     };
 
@@ -62,19 +63,20 @@ const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: 
             onOpenChange={() => toggleForm(true)}
             id={valutakursFeilmeldingId(valutakurs)}
             content={
-                <ValutakursTabellRadEndre
-                    skjema={skjema}
-                    tilgjengeligeBarn={barn}
-                    status={valutakurs.status}
-                    valideringErOk={valideringErOk}
-                    sendInnSkjema={sendInnSkjema}
-                    toggleForm={toggleForm}
-                    slettValutakurs={slettValutakurs}
-                    sletterValutakurs={sletterValutakurs}
-                    erManuellInputAvKurs={erManuellInputAvKurs}
-                    key={`${valutakurs.id}-${erValutakursEkspandert ? 'ekspandert' : 'lukket'}`}
-                    behandlingsÅrsakErOvergangsordning={åpenBehandling.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024}
-                />
+                <FormProvider {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)}>
+                        <ValutakursTabellRadEndre
+                            valutakurs={valutakurs}
+                            tilgjengeligeBarn={barn}
+                            initielFom={initielFom}
+                            erManuellInputAvKurs={erManuellInputAvKurs}
+                            behandlingsÅrsakErOvergangsordning={behandlingsÅrsakErOvergangsordning}
+                            onAvbryt={() => toggleForm(false)}
+                            slettValutakurs={slettValutakurs}
+                            sletterValutakurs={sletterValutakurs}
+                        />
+                    </form>
+                </FormProvider>
             }
         >
             <StatusBarnCelleOgPeriodeCelle

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
@@ -33,7 +33,7 @@ const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: 
         slettValutakurs,
         sletterValutakurs,
         erManuellInputAvKurs,
-        initielFom,
+        initiellFom,
         behandlingsÅrsakErOvergangsordning,
     } = useValutakursSkjema({
         valutakurs,
@@ -68,7 +68,7 @@ const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: 
                         <ValutakursTabellRadEndre
                             valutakurs={valutakurs}
                             tilgjengeligeBarn={barn}
-                            initielFom={initielFom}
+                            initiellFom={initiellFom}
                             erManuellInputAvKurs={erManuellInputAvKurs}
                             behandlingsÅrsakErOvergangsordning={behandlingsÅrsakErOvergangsordning}
                             onAvbryt={() => toggleForm(false)}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -1,23 +1,21 @@
-import type { ReactNode } from 'react';
-
 import { useErLesevisning } from '@hooks/useErLesevisning';
-import { type Valutakode, ValutaCombobox, EØS_VALUTAKODER } from '@komponenter/FlaggCombobox';
-import type { IBehandling } from '@typer/behandling';
 import type { OptionType } from '@typer/common';
-import { EøsPeriodeStatus, type IValutakurs } from '@typer/eøsPerioder';
+import { EøsPeriodeStatus, type IRestValutakurs } from '@typer/eøsPerioder';
+import { useFormContext } from 'react-hook-form';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
-import { Box, Button, Fieldset, HGrid, Link, LocalAlert, TextField, UNSAFE_Combobox } from '@navikt/ds-react';
-import type { ISkjema } from '@navikt/familie-skjema';
-import { Valideringsstatus } from '@navikt/familie-skjema';
-import { RessursStatus } from '@navikt/familie-typer';
+import { Box, Button, Fieldset, HGrid, Link, LocalAlert } from '@navikt/ds-react';
 
-import Datovelger from '../../../../../../../komponenter/Datovelger/Datovelger';
-import EøsPeriodeSkjema from '../EøsKomponenter/EøsPeriodeSkjema';
+import { type ValutakursFormValues } from './useValutakursSkjema';
+import { ValutakursBarnFelt } from './ValutakursBarnFelt';
+import { ValutakursDatoFelt } from './ValutakursDatoFelt';
+import { ValutakursKursFelt } from './ValutakursKursFelt';
+import { ValutakursPeriodeFelt } from './ValutakursPeriodeFelt';
+import { ValutakursValutaFelt } from './ValutakursValutaFelt';
 import { EøsPeriodeSkjemaContainer, Knapperad } from '../EøsKomponenter/EøsSkjemaKomponenter';
 
-const StyledEøsPeriodeSkjema = styled(EøsPeriodeSkjema)`
+const StyledPeriodeWrapper = styled.div`
     margin-top: 1.5rem;
 `;
 
@@ -25,123 +23,56 @@ const StyledFieldset = styled(Fieldset)`
     margin-top: 1.5rem;
 `;
 
-const valutakursPeriodeFeilmeldingId = (valutakurs: ISkjema<IValutakurs, IBehandling>): string =>
-    `valutakurs-periode_${valutakurs.felter.barnIdenter.verdi.map(barn => `${barn.value}`)}_${
-        valutakurs.felter.initielFom.verdi
-    }`;
-
-const valutakursValutaFeilmeldingId = (valutakurs: ISkjema<IValutakurs, IBehandling>): string =>
-    `valutakurs-valuta_${valutakurs.felter.barnIdenter.verdi.map(barn => `${barn.value}`)}_${
-        valutakurs.felter.initielFom.verdi
-    }`;
-
-interface IProps {
-    skjema: ISkjema<IValutakurs, IBehandling>;
+interface Props {
+    valutakurs: IRestValutakurs;
     tilgjengeligeBarn: OptionType[];
-    status: EøsPeriodeStatus;
-    valideringErOk: () => boolean;
-    sendInnSkjema: () => void;
-    toggleForm: (visAlert: boolean) => void;
-    slettValutakurs: () => void;
-    sletterValutakurs: boolean;
+    initielFom: string;
     erManuellInputAvKurs: boolean;
     behandlingsÅrsakErOvergangsordning: boolean;
+    onAvbryt: () => void;
+    slettValutakurs: () => void;
+    sletterValutakurs: boolean;
 }
 
 const ValutakursTabellRadEndre = ({
-    skjema,
+    valutakurs,
     tilgjengeligeBarn,
-    status,
-    sendInnSkjema,
-    toggleForm,
-    slettValutakurs,
-    sletterValutakurs,
+    initielFom,
     erManuellInputAvKurs,
     behandlingsÅrsakErOvergangsordning,
-}: IProps) => {
+    onAvbryt,
+    slettValutakurs,
+    sletterValutakurs,
+}: Props) => {
     const erLesevisning = useErLesevisning();
 
-    const visKursGruppeFeilmelding = (): ReactNode => {
-        if (skjema.felter.valutakode?.valideringsstatus === Valideringsstatus.FEIL) {
-            return skjema.felter.valutakode.feilmelding;
-        } else if (skjema.felter.valutakursdato?.valideringsstatus === Valideringsstatus.FEIL) {
-            return skjema.felter.valutakursdato.feilmelding;
-        } else if (skjema.felter.kurs?.valideringsstatus === Valideringsstatus.FEIL) {
-            return skjema.felter.kurs.feilmelding;
-        }
-    };
+    const {
+        formState: { isSubmitting, errors },
+    } = useFormContext<ValutakursFormValues>();
 
-    const visSubmitFeilmelding = () => {
-        if (
-            skjema.submitRessurs.status === RessursStatus.FEILET ||
-            skjema.submitRessurs.status === RessursStatus.FUNKSJONELL_FEIL ||
-            skjema.submitRessurs.status === RessursStatus.IKKE_TILGANG
-        ) {
-            return skjema.submitRessurs.frontendFeilmelding;
-        } else {
-            return null;
-        }
-    };
+    const erRedigeringDeaktivert = erLesevisning;
+
+    const periodeFeilmeldingId = `valutakurs-periode_${valutakurs.barnIdenter.map(barn => `${barn}`)}_${valutakurs.fom}`;
 
     return (
-        <Fieldset error={skjema.visFeilmeldinger && visSubmitFeilmelding()} legend={'Endre valutakurs'} hideLegend>
-            <EøsPeriodeSkjemaContainer $lesevisning={erLesevisning} $status={status}>
-                <UNSAFE_Combobox
-                    error={skjema.felter.barnIdenter.hentNavInputProps(skjema.visFeilmeldinger).error}
-                    readOnly={erLesevisning}
-                    label={'Barn'}
-                    isMultiSelect
-                    options={tilgjengeligeBarn}
-                    selectedOptions={skjema.felter.barnIdenter.verdi}
-                    onToggleSelected={(option, isSelected) => {
-                        if (isSelected) {
-                            skjema.felter.barnIdenter.validerOgSettFelt(
-                                skjema.felter.barnIdenter.verdi.concat(
-                                    tilgjengeligeBarn.find(barn => barn.value === option)!
-                                )
-                            );
-                        } else {
-                            skjema.felter.barnIdenter.validerOgSettFelt(
-                                skjema.felter.barnIdenter.verdi.filter(barn => barn.value !== option)
-                            );
-                        }
-                    }}
-                />
-                <StyledEøsPeriodeSkjema
-                    periode={skjema.felter.periode}
-                    periodeFeilmeldingId={valutakursPeriodeFeilmeldingId(skjema)}
-                    initielFom={skjema.felter.initielFom}
-                    visFeilmeldinger={skjema.visFeilmeldinger}
-                    lesevisning={erLesevisning}
-                    maxWidth={32}
-                    behandlingsÅrsakErOvergangsordning={behandlingsÅrsakErOvergangsordning}
-                />
-                <StyledFieldset
-                    errorId={valutakursValutaFeilmeldingId(skjema)}
-                    error={skjema.visFeilmeldinger && visKursGruppeFeilmelding()}
-                    legend={'Registrer valutakursdato'}
-                >
+        <Fieldset error={errors.root?.message} legend={'Endre valutakurs'} hideLegend>
+            <EøsPeriodeSkjemaContainer $lesevisning={erRedigeringDeaktivert} $status={valutakurs.status}>
+                <ValutakursBarnFelt tilgjengeligeBarn={tilgjengeligeBarn} lesevisning={erRedigeringDeaktivert} />
+                <StyledPeriodeWrapper>
+                    <ValutakursPeriodeFelt
+                        initielFom={initielFom}
+                        periodeFeilmeldingId={periodeFeilmeldingId}
+                        lesevisning={erRedigeringDeaktivert}
+                        behandlingsÅrsakErOvergangsordning={behandlingsÅrsakErOvergangsordning}
+                    />
+                </StyledPeriodeWrapper>
+                <StyledFieldset legend={'Registrer valutakursdato'}>
                     <HGrid columns={'1fr 2fr 1fr'} gap={'space-12'}>
-                        <Datovelger
-                            felt={skjema.felter.valutakursdato}
-                            label={'Valutakursdato'}
-                            visFeilmeldinger={false}
-                            readOnly={erLesevisning}
-                            disableWeekends
-                            kanKunVelgeFortid
-                        />
-                        <ValutaCombobox
-                            label={'Valuta'}
-                            value={skjema.felter.valutakode?.verdi as Valutakode}
-                            options={EØS_VALUTAKODER}
-                            onChange={() => {}}
-                            readOnly={true}
-                        />
-                        <TextField
-                            label={'Valutakurs'}
-                            readOnly={erLesevisning || !erManuellInputAvKurs}
-                            value={skjema.felter.kurs?.verdi}
-                            onChange={event => skjema.felter.kurs?.validerOgSettFelt(event.target.value)}
+                        <ValutakursDatoFelt readOnly={erRedigeringDeaktivert} />
+                        <ValutakursValutaFelt />
+                        <ValutakursKursFelt
+                            readOnly={erRedigeringDeaktivert || !erManuellInputAvKurs}
+                            erManuellInputAvKurs={erManuellInputAvKurs}
                         />
                     </HGrid>
                     {erManuellInputAvKurs && (
@@ -165,20 +96,16 @@ const ValutakursTabellRadEndre = ({
                         </Box>
                     )}
                 </StyledFieldset>
-                {!erLesevisning && (
+                {!erRedigeringDeaktivert && (
                     <Knapperad>
                         <div>
-                            <Button
-                                onClick={() => sendInnSkjema()}
-                                size="small"
-                                variant={'primary'}
-                                loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                            >
+                            <Button type={'submit'} size="small" variant={'primary'} loading={isSubmitting}>
                                 Ferdig
                             </Button>
                             <Button
+                                type={'button'}
                                 style={{ marginLeft: '1rem' }}
-                                onClick={() => toggleForm(false)}
+                                onClick={onAvbryt}
                                 size="small"
                                 variant="tertiary"
                             >
@@ -186,18 +113,17 @@ const ValutakursTabellRadEndre = ({
                             </Button>
                         </div>
 
-                        {skjema.felter.status?.verdi !== EøsPeriodeStatus.IKKE_UTFYLT && (
+                        {valutakurs.status !== EøsPeriodeStatus.IKKE_UTFYLT && (
                             <Button
+                                type={'button'}
                                 variant={'tertiary'}
-                                onClick={() => slettValutakurs()}
-                                id={`slett_valutakurs_${skjema.felter.barnIdenter.verdi.map(
-                                    barn => `${barn}-`
-                                )}_${skjema.felter.initielFom.verdi}`}
+                                onClick={slettValutakurs}
+                                id={`slett_valutakurs_${valutakurs.barnIdenter.map(barn => `${barn}-`)}_${initielFom}`}
                                 loading={sletterValutakurs}
                                 size={'small'}
                                 icon={<TrashIcon />}
                             >
-                                {'Fjern'}
+                                Fjern
                             </Button>
                         )}
                     </Knapperad>

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -2,7 +2,6 @@ import { useErLesevisning } from '@hooks/useErLesevisning';
 import type { OptionType } from '@typer/common';
 import { EøsPeriodeStatus, type IRestValutakurs } from '@typer/eøsPerioder';
 import { useFormContext } from 'react-hook-form';
-import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Box, Button, Fieldset, HGrid, Link, LocalAlert } from '@navikt/ds-react';
@@ -15,18 +14,10 @@ import { ValutakursPeriodeFelt } from './ValutakursPeriodeFelt';
 import { ValutakursValutaFelt } from './ValutakursValutaFelt';
 import { EøsPeriodeSkjemaContainer, Knapperad } from '../EøsKomponenter/EøsSkjemaKomponenter';
 
-const StyledPeriodeWrapper = styled.div`
-    margin-top: 1.5rem;
-`;
-
-const StyledFieldset = styled(Fieldset)`
-    margin-top: 1.5rem;
-`;
-
 interface Props {
     valutakurs: IRestValutakurs;
     tilgjengeligeBarn: OptionType[];
-    initielFom: string;
+    initiellFom: string;
     erManuellInputAvKurs: boolean;
     behandlingsÅrsakErOvergangsordning: boolean;
     onAvbryt: () => void;
@@ -37,7 +28,7 @@ interface Props {
 const ValutakursTabellRadEndre = ({
     valutakurs,
     tilgjengeligeBarn,
-    initielFom,
+    initiellFom,
     erManuellInputAvKurs,
     behandlingsÅrsakErOvergangsordning,
     onAvbryt,
@@ -50,53 +41,53 @@ const ValutakursTabellRadEndre = ({
         formState: { isSubmitting, errors },
     } = useFormContext<ValutakursFormValues>();
 
-    const erRedigeringDeaktivert = erLesevisning;
-
     const periodeFeilmeldingId = `valutakurs-periode_${valutakurs.barnIdenter.map(barn => `${barn}`)}_${valutakurs.fom}`;
 
     return (
         <Fieldset error={errors.root?.message} legend={'Endre valutakurs'} hideLegend>
-            <EøsPeriodeSkjemaContainer $lesevisning={erRedigeringDeaktivert} $status={valutakurs.status}>
-                <ValutakursBarnFelt tilgjengeligeBarn={tilgjengeligeBarn} lesevisning={erRedigeringDeaktivert} />
-                <StyledPeriodeWrapper>
+            <EøsPeriodeSkjemaContainer $lesevisning={erLesevisning} $status={valutakurs.status}>
+                <ValutakursBarnFelt tilgjengeligeBarn={tilgjengeligeBarn} lesevisning={erLesevisning} />
+                <Box marginBlock={'space-24 space-0'}>
                     <ValutakursPeriodeFelt
-                        initielFom={initielFom}
+                        initiellFom={initiellFom}
                         periodeFeilmeldingId={periodeFeilmeldingId}
-                        lesevisning={erRedigeringDeaktivert}
+                        lesevisning={erLesevisning}
                         behandlingsÅrsakErOvergangsordning={behandlingsÅrsakErOvergangsordning}
                     />
-                </StyledPeriodeWrapper>
-                <StyledFieldset legend={'Registrer valutakursdato'}>
-                    <HGrid columns={'1fr 2fr 1fr'} gap={'space-12'}>
-                        <ValutakursDatoFelt readOnly={erRedigeringDeaktivert} />
-                        <ValutakursValutaFelt />
-                        <ValutakursKursFelt
-                            readOnly={erRedigeringDeaktivert || !erManuellInputAvKurs}
-                            erManuellInputAvKurs={erManuellInputAvKurs}
-                        />
-                    </HGrid>
-                    {erManuellInputAvKurs && (
-                        <Box marginBlock={'space-32 space-0'}>
-                            <LocalAlert status="warning">
-                                <LocalAlert.Header>
-                                    <LocalAlert.Title>
-                                        Manuell innhenting av valutakurs for Islandske kroner (ISK)
-                                    </LocalAlert.Title>
-                                </LocalAlert.Header>
-                                Systemet har ikke valutakurser for valutakursdatoer før 1. februar 2018. Disse må hentes
-                                fra{' '}
-                                <Link
-                                    href="https://navno.sharepoint.com/:x:/r/sites/fag-og-ytelser-familie-barnetrygd/Delte%20dokumenter/E%C3%98S/Valutakalkulator%202022.xlsm?d=w200955f53e1d4323ae72f9d1b15f617c&csf=1&web=1&e=w3OE5N"
-                                    target="_blank"
-                                >
-                                    Valutakalkulator
-                                </Link>
-                                .
-                            </LocalAlert>
-                        </Box>
-                    )}
-                </StyledFieldset>
-                {!erRedigeringDeaktivert && (
+                </Box>
+                <Box marginBlock={'space-24 space-0'}>
+                    <Fieldset legend={'Registrer valutakursdato'}>
+                        <HGrid columns={'1fr 2fr 1fr'} gap={'space-12'}>
+                            <ValutakursDatoFelt readOnly={erLesevisning} />
+                            <ValutakursValutaFelt />
+                            <ValutakursKursFelt
+                                readOnly={erLesevisning || !erManuellInputAvKurs}
+                                erManuellInputAvKurs={erManuellInputAvKurs}
+                            />
+                        </HGrid>
+                        {erManuellInputAvKurs && (
+                            <Box marginBlock={'space-32 space-0'}>
+                                <LocalAlert status="warning">
+                                    <LocalAlert.Header>
+                                        <LocalAlert.Title>
+                                            Manuell innhenting av valutakurs for Islandske kroner (ISK)
+                                        </LocalAlert.Title>
+                                    </LocalAlert.Header>
+                                    Systemet har ikke valutakurser for valutakursdatoer før 1. februar 2018. Disse må
+                                    hentes fra{' '}
+                                    <Link
+                                        href="https://navno.sharepoint.com/:x:/r/sites/fag-og-ytelser-familie-barnetrygd/Delte%20dokumenter/E%C3%98S/Valutakalkulator%202022.xlsm?d=w200955f53e1d4323ae72f9d1b15f617c&csf=1&web=1&e=w3OE5N"
+                                        target="_blank"
+                                    >
+                                        Valutakalkulator
+                                    </Link>
+                                    .
+                                </LocalAlert>
+                            </Box>
+                        )}
+                    </Fieldset>
+                </Box>
+                {!erLesevisning && (
                     <Knapperad>
                         <div>
                             <Button type={'submit'} size="small" variant={'primary'} loading={isSubmitting}>
@@ -118,7 +109,7 @@ const ValutakursTabellRadEndre = ({
                                 type={'button'}
                                 variant={'tertiary'}
                                 onClick={slettValutakurs}
-                                id={`slett_valutakurs_${valutakurs.barnIdenter.map(barn => `${barn}-`)}_${initielFom}`}
+                                id={`slett_valutakurs_${valutakurs.barnIdenter.map(barn => `${barn}-`)}_${initiellFom}`}
                                 loading={sletterValutakurs}
                                 size={'small'}
                                 icon={<TrashIcon />}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursValutaFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursValutaFelt.tsx
@@ -1,0 +1,20 @@
+import { EØS_VALUTAKODER, type Valutakode, ValutaCombobox } from '@komponenter/FlaggCombobox';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
+
+export function ValutakursValutaFelt() {
+    const { control } = useFormContext<ValutakursFormValues>();
+
+    const valutakode = useWatch({ control, name: ValutakursFelt.VALUTAKODE });
+
+    return (
+        <ValutaCombobox
+            label={'Valuta'}
+            value={valutakode as Valutakode}
+            options={EØS_VALUTAKODER}
+            onChange={() => {}}
+            readOnly={true}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
@@ -118,7 +118,7 @@ export const useValutakursSkjema = ({ valutakurs, barnIValutakurs, lukkSkjema }:
         slettValutakurs,
         sletterValutakurs,
         erManuellInputAvKurs,
-        initielFom: valutakurs.fom,
+        initiellFom: valutakurs.fom,
         behandlingsÅrsakErOvergangsordning,
     };
 };

--- a/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
@@ -1,259 +1,124 @@
-import { useState } from 'react';
-
-import { isBefore } from 'date-fns';
-
-import { useHttp } from '@navikt/familie-http';
-import type { FeltState } from '@navikt/familie-skjema';
-import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import type { Ressurs } from '@navikt/familie-typer';
-import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
-
-import { BehandlingÅrsak, type IBehandling } from '../../../../../../../typer/behandling';
-import type { OptionType } from '../../../../../../../typer/common';
-import type { EøsPeriodeStatus, IRestValutakurs, IValutakurs } from '../../../../../../../typer/eøsPerioder';
+import { useOnFormSubmitSuccessful } from '@hooks/useOnFormSubmitSuccessful';
+import { useOppdaterValutakurs } from '@hooks/useOppdaterValutakurs';
+import { useSlettValutakurs } from '@hooks/useSlettValutakurs';
+import type { OptionType } from '@typer/common';
+import type { IRestValutakurs } from '@typer/eøsPerioder';
 import {
-    dateTilIsoDatoString,
     dateTilIsoDatoStringEllerUndefined,
     type IIsoMånedPeriode,
+    isoStringTilDate,
     nyIsoMånedPeriode,
-    validerGyldigDato,
-} from '../../../../../../../utils/dato';
-import {
-    erBarnGyldig,
-    erEøsPeriodeGyldig,
-    erValutakodeGyldig,
-    isEmpty,
-    isNumeric,
-    tellAntallDesimaler,
-} from '../../../../../../../utils/eøsValidators';
+} from '@utils/dato';
+import { isBefore } from 'date-fns';
+import { useForm, useWatch } from 'react-hook-form';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+import { BehandlingÅrsak } from '../../../../../../../typer/behandling';
 import { useBehandlingContext } from '../../../../context/BehandlingContext';
 import { konverterDesimalverdiTilSkjemaVisning, konverterSkjemaverdiTilDesimal } from '../utils';
 
-const erValutakursGyldig = (
-    felt: FeltState<string | undefined>,
-    skalValideres: boolean
-): FeltState<string | undefined> => {
-    if (skalValideres) {
-        if (!felt.verdi || isEmpty(felt.verdi) || typeof felt.verdi != 'string') {
-            return feil(felt, 'Valutakurs er påkrevd, men mangler input');
-        }
-        const nyKurs = konverterSkjemaverdiTilDesimal(felt.verdi);
-        if (!nyKurs) {
-            return feil(felt, 'Valutakurs er påkrevd, men mangler input');
-        }
-        if (!isNumeric(nyKurs)) {
-            return feil(felt, `Valutakurs innholder ugyldige verdier, kurs: ${felt.verdi}`);
-        }
-        if (tellAntallDesimaler(nyKurs) === 0) {
-            return feil(felt, `Valutakurs må oppgis med desimaler, kurs: ${felt.verdi}`);
-        }
-        const kurs = Number(nyKurs);
-        if (kurs < 0) {
-            return feil(felt, `Kan ikke registrere negativt kurs: ${felt.verdi}`);
-        }
-        return ok(felt);
-    }
-    return ok(felt);
-};
+export enum ValutakursFelt {
+    BARN = 'barnIdenter',
+    PERIODE = 'periode',
+    VALUTAKODE = 'valutakode',
+    VALUTAKURSDATO = 'valutakursdato',
+    KURS = 'kurs',
+}
+
+export interface ValutakursFormValues {
+    [ValutakursFelt.BARN]: OptionType[];
+    [ValutakursFelt.PERIODE]: IIsoMånedPeriode;
+    [ValutakursFelt.VALUTAKODE]: string | undefined;
+    [ValutakursFelt.VALUTAKURSDATO]: Date | undefined;
+    [ValutakursFelt.KURS]: string | undefined;
+}
 
 export const valutakursFeilmeldingId = (valutakurs: IRestValutakurs): string =>
     `valutakurs_${valutakurs.barnIdenter.map(barn => `${barn}-`)}_${valutakurs.fom}`;
 
-interface IProps {
+// Systemet har ikke automatiske valutakurser for islandske kroner (ISK) med valutakursdato før 1. februar 2018.
+const FØRSTE_DATO_MED_AUTOMATISK_ISK_KURS = new Date(2018, 1, 1, 0, 0, 0);
+
+interface Props {
     valutakurs: IRestValutakurs;
     barnIValutakurs: OptionType[];
+    lukkSkjema: () => void;
 }
 
-const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
-    const [erValutakursEkspandert, settErValutakursEkspandert] = useState<boolean>(false);
-    const [sletterValutakurs, settSletterValutakurs] = useState<boolean>(false);
+export const useValutakursSkjema = ({ valutakurs, barnIValutakurs, lukkSkjema }: Props) => {
     const { behandling, settÅpenBehandling } = useBehandlingContext();
-    const behandlingId = behandling.behandlingId;
+
     const behandlingsÅrsakErOvergangsordning = behandling.årsak === BehandlingÅrsak.OVERGANGSORDNING_2024;
-    const initelFom = useFelt<string>({ verdi: valutakurs.fom });
-    const { request } = useHttp();
 
-    const valutakode = useFelt<string | undefined>({
-        verdi: valutakurs.valutakode,
-        valideringsfunksjon: erValutakodeGyldig,
+    const { mutateAsync: oppdaterValutakurs } = useOppdaterValutakurs();
+    const { mutateAsync: slettValutakursMutate, isPending: sletterValutakurs } = useSlettValutakurs();
+
+    const form = useForm<ValutakursFormValues>({
+        values: {
+            [ValutakursFelt.BARN]: barnIValutakurs,
+            [ValutakursFelt.PERIODE]: nyIsoMånedPeriode(valutakurs.fom, valutakurs.tom),
+            [ValutakursFelt.VALUTAKODE]: valutakurs.valutakode,
+            [ValutakursFelt.VALUTAKURSDATO]: valutakurs.valutakursdato
+                ? isoStringTilDate(valutakurs.valutakursdato)
+                : undefined,
+            [ValutakursFelt.KURS]: konverterDesimalverdiTilSkjemaVisning(valutakurs.kurs),
+        },
     });
 
-    const valutakursdato = useFelt<Date | undefined>({
-        verdi: undefined,
-        valideringsfunksjon: validerGyldigDato,
-    });
+    const { control, setError, reset } = form;
+
+    useOnFormSubmitSuccessful(control, () => reset());
+
+    const valutakode = useWatch({ control, name: ValutakursFelt.VALUTAKODE });
+    const valutakursdato = useWatch({ control, name: ValutakursFelt.VALUTAKURSDATO });
 
     const erManuellInputAvKurs: boolean =
-        valutakode?.verdi === 'ISK' &&
-        !!valutakursdato?.verdi &&
-        isBefore(new Date(valutakursdato.verdi), new Date(2018, 1, 1, 0, 0, 0));
+        valutakode === 'ISK' && !!valutakursdato && isBefore(valutakursdato, FØRSTE_DATO_MED_AUTOMATISK_ISK_KURS);
 
-    const kurs = useFelt<string | undefined>({
-        avhengigheter: {
-            erManuellInputAvKurs,
-        },
-        verdi: konverterDesimalverdiTilSkjemaVisning(valutakurs.kurs),
-        valideringsfunksjon: (felt, avhengigheter): FeltState<string | undefined> => {
-            return erValutakursGyldig(felt, avhengigheter?.erManuellInputAvKurs);
-        },
-    });
-
-    const {
-        skjema,
-        valideringErOk,
-        kanSendeSkjema,
-        nullstillSkjema,
-        onSubmit,
-        settSubmitRessurs,
-        settVisfeilmeldinger,
-    } = useSkjema<IValutakurs, IBehandling>({
-        felter: {
-            periodeId: useFelt<string>({
-                verdi: valutakursFeilmeldingId(valutakurs),
-            }),
-            id: useFelt<number>({ verdi: valutakurs.id }),
-            status: useFelt<EøsPeriodeStatus>({ verdi: valutakurs.status }),
-            initielFom: initelFom,
-            barnIdenter: useFelt<OptionType[]>({
-                verdi: barnIValutakurs,
-                valideringsfunksjon: erBarnGyldig,
-            }),
-            periode: useFelt<IIsoMånedPeriode>({
-                verdi: nyIsoMånedPeriode(valutakurs.fom, valutakurs.tom),
-                avhengigheter: { initelFom },
-                valideringsfunksjon: (felt, avhengigheter) =>
-                    erEøsPeriodeGyldig(behandlingsÅrsakErOvergangsordning, felt, avhengigheter),
-            }),
-            valutakode,
-            valutakursdato,
-            kurs,
-        },
-        skjemanavn: valutakursFeilmeldingId(valutakurs),
-    });
-
-    const [tidligereValutakurs, settTidligereValutakurs] = useState<IRestValutakurs>();
-
-    const settDatofelterTilDefault = () => {
-        if (valutakurs.valutakursdato) {
-            skjema.felter.valutakursdato.validerOgSettFelt(new Date(valutakurs.valutakursdato));
-        } else {
-            skjema.felter.valutakursdato.nullstill();
+    const onSubmit = async (values: ValutakursFormValues) => {
+        try {
+            const oppdatertBehandling = await oppdaterValutakurs({
+                behandlingId: behandling.behandlingId,
+                id: valutakurs.id,
+                fom: values.periode.fom ?? '',
+                tom: values.periode.tom,
+                barnIdenter: values.barnIdenter.map(barn => barn.value),
+                valutakode: values.valutakode,
+                valutakursdato: dateTilIsoDatoStringEllerUndefined(values.valutakursdato),
+                kurs: konverterSkjemaverdiTilDesimal(values.kurs),
+            });
+            settÅpenBehandling(byggSuksessRessurs(oppdatertBehandling));
+            lukkSkjema();
+        } catch (error) {
+            setError('root', {
+                message: error instanceof Error ? error.message : 'Teknisk feil ved lagring av valutakurs.',
+            });
         }
     };
 
-    const tilbakestillFelterTilDefault = () => {
-        skjema.felter.periodeId.nullstill();
-        skjema.felter.id.nullstill();
-        skjema.felter.status.nullstill();
-        skjema.felter.initielFom.nullstill();
-        skjema.felter.barnIdenter.nullstill();
-        skjema.felter.periode.nullstill();
-        skjema.felter.valutakode.nullstill();
-        skjema.felter.kurs.nullstill();
-        settDatofelterTilDefault();
-    };
-
-    if (valutakurs !== tidligereValutakurs) {
-        settTidligereValutakurs(valutakurs);
-        tilbakestillFelterTilDefault();
-    }
-
-    if (dateTilIsoDatoString(skjema.felter.valutakursdato.verdi) !== valutakurs.valutakursdato) {
-        skjema.felter.kurs?.validerOgSettFelt('');
-    }
-
-    if (valutakurs.valutakode !== skjema.felter.valutakode.verdi) {
-        skjema.felter.kurs?.validerOgSettFelt('');
-        skjema.felter.valutakursdato?.nullstill();
-        skjema.felter.valutakode?.validerOgSettFelt(valutakurs.valutakode);
-    }
-
-    const sendInnSkjema = () => {
-        if (kanSendeSkjema()) {
-            settSubmitRessurs(byggTomRessurs());
-            settVisfeilmeldinger(false);
-            onSubmit<Omit<IRestValutakurs, 'status'>>(
-                {
-                    method: 'PUT',
-                    data: {
-                        id: valutakurs.id,
-                        fom: skjema.felter.periode.verdi.fom ?? '',
-                        tom: skjema.felter.periode.verdi.tom,
-                        barnIdenter: skjema.felter.barnIdenter.verdi.map(barn => barn.value),
-                        valutakode: skjema.felter.valutakode?.verdi,
-                        valutakursdato: dateTilIsoDatoStringEllerUndefined(skjema.felter.valutakursdato?.verdi),
-                        kurs: konverterSkjemaverdiTilDesimal(skjema.felter.kurs?.verdi),
-                    },
-                    url: `/familie-ks-sak/api/differanseberegning/valutakurs/${behandlingId}`,
-                },
-                (response: Ressurs<IBehandling>) => {
-                    if (response.status === RessursStatus.SUKSESS) {
-                        nullstillSkjema();
-                        settErValutakursEkspandert(false);
-                        settÅpenBehandling(response);
-                    }
-                }
-            );
+    const slettValutakurs = async () => {
+        try {
+            const oppdatertBehandling = await slettValutakursMutate({
+                behandlingId: behandling.behandlingId,
+                valutakursId: valutakurs.id,
+            });
+            settÅpenBehandling(byggSuksessRessurs(oppdatertBehandling));
+            lukkSkjema();
+        } catch (error) {
+            setError('root', {
+                message: error instanceof Error ? error.message : 'Teknisk feil ved sletting av valutakurs.',
+            });
         }
-    };
-
-    const slettValutakurs = () => {
-        settSubmitRessurs(byggTomRessurs());
-        settVisfeilmeldinger(false);
-        settSletterValutakurs(true);
-        request<void, IBehandling>({
-            method: 'DELETE',
-            url: `/familie-ks-sak/api/differanseberegning/valutakurs/${behandlingId}/${valutakurs.id}`,
-        }).then((response: Ressurs<IBehandling>) => {
-            settSletterValutakurs(false);
-            if (response.status === RessursStatus.SUKSESS) {
-                nullstillSkjema();
-                settErValutakursEkspandert(false);
-                settÅpenBehandling(response);
-            } else {
-                settSubmitRessurs(response);
-                settVisfeilmeldinger(true);
-            }
-        });
-    };
-
-    const erValutakursdatoerLike = () =>
-        (!valutakursdato.verdi && !valutakurs.valutakursdato) ||
-        dateTilIsoDatoStringEllerUndefined(valutakursdato?.verdi) === valutakurs.valutakursdato;
-
-    const erValutakurserLike = () =>
-        (!kurs.verdi && !valutakurs.kurs) || kurs.verdi === konverterDesimalverdiTilSkjemaVisning(valutakurs.kurs);
-
-    const erValutakursSkjemaEndret = () => {
-        const barnFjernetISkjema = valutakurs.barnIdenter.filter(
-            barn => !skjema.felter.barnIdenter.verdi.some(ident => ident.value === barn)
-        );
-        const erTomEndret =
-            !(skjema.felter.periode.verdi.tom === undefined && valutakurs.tom === null) &&
-            skjema.felter.periode?.verdi.tom !== valutakurs.tom;
-        return (
-            barnFjernetISkjema.length > 0 ||
-            skjema.felter.periode?.verdi.fom !== valutakurs.fom ||
-            erTomEndret ||
-            skjema.felter.valutakode?.verdi !== valutakurs.valutakode ||
-            !erValutakursdatoerLike() ||
-            !erValutakurserLike()
-        );
     };
 
     return {
-        erValutakursEkspandert,
-        settErValutakursEkspandert,
-        skjema,
-        valideringErOk,
-        kanSendeSkjema,
-        sendInnSkjema,
-        erValutakursSkjemaEndret,
-        tilbakestillFelterTilDefault,
+        form,
+        onSubmit,
         slettValutakurs,
         sletterValutakurs,
         erManuellInputAvKurs,
+        initielFom: valutakurs.fom,
+        behandlingsÅrsakErOvergangsordning,
     };
 };
-
-export { useValutakursSkjema };


### PR DESCRIPTION
### 📮 Favro:
NAV-29957

### 💰 Hva skal gjøres, og hvorfor?
Skriver om valutakurs-komponentene til å bruke React Query og React Hook Form. Erstatter `useHttp`/`Ressurs`-baserte kall og `useSkjema`/`useFelt` med react-query hooks (`useOppdaterValutakurs`, `useSlettValutakurs`) og RHF-baserte feltkomponenter (`ValutakursBarnFelt`, `ValutakursDatoFelt`, `ValutakursKursFelt`, `ValutakursPeriodeFelt`, `ValutakursValutaFelt`).

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ren omskriving av eksisterende funksjonalitet.

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
