### PR TITLE
NAV-30016 Skriv tester for opprettBehandling

### DIFF
--- a/src/frontend/api/opprettBehandling.test.ts
+++ b/src/frontend/api/opprettBehandling.test.ts
@@ -1,0 +1,63 @@
+import { apiClient } from '@api/client/apiClient';
+import { opprettBehandling } from '@api/opprettBehandling';
+import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
+import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import { BehandlingKategori } from '@typer/behandlingstema';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@api/client/apiClient', () => ({
+    apiClient: {
+        post: vi.fn(),
+    },
+}));
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('opprettBehandling', () => {
+    test('skal sende forespørsel om opprettelse av behandling', async () => {
+        const payload = {
+            kategori: BehandlingKategori.NASJONAL,
+            behandlingType: Behandlingstype.FØRSTEGANGSBEHANDLING,
+            behandlingÅrsak: BehandlingÅrsak.SØKNAD,
+            saksbehandlerIdent: 'Z123456',
+            søkersIdent: '129499012851',
+            søknadMottattDato: '2026-08-04',
+        };
+
+        const behandling = lagBehandling({
+            kategori: payload.kategori,
+            type: payload.behandlingType,
+            årsak: payload.behandlingÅrsak,
+            endretAv: payload.saksbehandlerIdent,
+            søknadMottattDato: '2026-08-04T00:00:00',
+        });
+
+        vi.mocked(apiClient.post).mockResolvedValueOnce(behandling);
+
+        const svar = await opprettBehandling(payload);
+
+        expect(apiClient.post).toHaveBeenCalledTimes(1);
+        expect(apiClient.post).toHaveBeenCalledWith({
+            data: payload,
+            url: '/familie-ks-sak/api/behandlinger',
+        });
+        expect(svar).toEqual(behandling);
+    });
+
+    test('skal håndtere feil', async () => {
+        vi.mocked(apiClient.post).mockRejectedValue(new Error('Noe gikk galt'));
+
+        const payload = {
+            kategori: null,
+            behandlingType: Behandlingstype.FØRSTEGANGSBEHANDLING,
+            behandlingÅrsak: BehandlingÅrsak.SØKNAD,
+            saksbehandlerIdent: 'Z123456',
+            søkersIdent: '129499012851',
+            søknadMottattDato: '2026-08-04',
+        };
+
+        await expect(opprettBehandling(payload)).rejects.toThrow('Noe gikk galt');
+    });
+});

--- a/src/frontend/api/opprettKlagebehandling.test.ts
+++ b/src/frontend/api/opprettKlagebehandling.test.ts
@@ -1,0 +1,45 @@
+import { apiClient } from '@api/client/apiClient';
+import { opprettKlagebehandling } from '@api/opprettKlagebehandling';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@api/client/apiClient', () => ({
+    apiClient: {
+        post: vi.fn(),
+    },
+}));
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('opprettKlagebehandling', () => {
+    test('skal sende forespørsel om opprettelse av klagebehandling', async () => {
+        const payload = {
+            klageMottattDato: '2026-08-05',
+        };
+
+        const fagsakId = 123;
+
+        vi.mocked(apiClient.post).mockResolvedValueOnce(fagsakId);
+
+        const svar = await opprettKlagebehandling(payload, fagsakId);
+
+        expect(apiClient.post).toHaveBeenCalledTimes(1);
+        expect(apiClient.post).toHaveBeenCalledWith({
+            data: payload,
+            url: `/familie-ks-sak/api/fagsaker/${fagsakId}/opprett-klagebehandling`,
+        });
+        expect(svar).toEqual(fagsakId);
+    });
+
+    test('skal håndtere feil', async () => {
+        vi.mocked(apiClient.post).mockRejectedValue(new Error('Noe gikk galt'));
+
+        const payload = {
+            klageMottattDato: '2026-08-05',
+        };
+        const fagsakId = 123;
+
+        await expect(opprettKlagebehandling(payload, fagsakId)).rejects.toThrow('Noe gikk galt');
+    });
+});

--- a/src/frontend/api/opprettKlagebehandling.ts
+++ b/src/frontend/api/opprettKlagebehandling.ts
@@ -1,5 +1,4 @@
 import { apiClient } from '@api/client/apiClient';
-import type { IBehandling } from '@typer/behandling';
 import type { IsoDatoString } from '@utils/dato';
 
 export interface OpprettKlagebehandlingPayload {
@@ -7,7 +6,7 @@ export interface OpprettKlagebehandlingPayload {
 }
 
 export async function opprettKlagebehandling(payload: OpprettKlagebehandlingPayload, fagsakId: number) {
-    return apiClient.post<OpprettKlagebehandlingPayload, IBehandling>({
+    return apiClient.post<OpprettKlagebehandlingPayload, number>({
         data: payload,
         url: `/familie-ks-sak/api/fagsaker/${fagsakId}/opprett-klagebehandling`,
     });

--- a/src/frontend/api/opprettTilbakekreving.test.ts
+++ b/src/frontend/api/opprettTilbakekreving.test.ts
@@ -1,0 +1,40 @@
+import { apiClient } from '@api/client/apiClient';
+import { opprettTilbakekreving } from '@api/opprettTilbakekreving';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@api/client/apiClient', () => ({
+    apiClient: {
+        post: vi.fn(),
+    },
+}));
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('opprettTilbakekreving', () => {
+    test('skal sende forespørsel om opprettelse av tilbakekreving', async () => {
+        const fagsakId = 123;
+        const payload = { fagsakId };
+
+        vi.mocked(apiClient.post).mockResolvedValueOnce(fagsakId); // TODO: finn ut hva som returneres fra KS BE
+
+        const svar = await opprettTilbakekreving(payload);
+
+        expect(apiClient.post).toHaveBeenCalledTimes(1);
+        expect(apiClient.post).toHaveBeenCalledWith({
+            data: payload,
+            url: `/familie-ks-sak/api/tilbakekreving/manuell`,
+        });
+        expect(svar).toEqual(fagsakId);
+    });
+
+    test('skal håndtere feil', async () => {
+        vi.mocked(apiClient.post).mockRejectedValue(new Error('Noe gikk galt'));
+
+        const fagsakId = 123;
+        const payload = { fagsakId };
+
+        await expect(opprettTilbakekreving(payload)).rejects.toThrow('Noe gikk galt');
+    });
+});

--- a/src/frontend/api/opprettTilbakekreving.test.ts
+++ b/src/frontend/api/opprettTilbakekreving.test.ts
@@ -14,10 +14,9 @@ afterEach(() => {
 
 describe('opprettTilbakekreving', () => {
     test('skal sende forespørsel om opprettelse av tilbakekreving', async () => {
-        const fagsakId = 123;
-        const payload = { fagsakId };
+        const payload = { fagsakId: 123 };
 
-        vi.mocked(apiClient.post).mockResolvedValueOnce(fagsakId); // TODO: finn ut hva som returneres fra KS BE
+        vi.mocked(apiClient.post).mockResolvedValueOnce(undefined);
 
         const svar = await opprettTilbakekreving(payload);
 
@@ -26,14 +25,13 @@ describe('opprettTilbakekreving', () => {
             data: payload,
             url: `/familie-ks-sak/api/tilbakekreving/manuell`,
         });
-        expect(svar).toEqual(fagsakId);
+        expect(svar).toBeUndefined();
     });
 
     test('skal håndtere feil', async () => {
         vi.mocked(apiClient.post).mockRejectedValue(new Error('Noe gikk galt'));
 
-        const fagsakId = 123;
-        const payload = { fagsakId };
+        const payload = { fagsakId: 123 };
 
         await expect(opprettTilbakekreving(payload)).rejects.toThrow('Noe gikk galt');
     });

--- a/src/frontend/api/opprettTilbakekreving.ts
+++ b/src/frontend/api/opprettTilbakekreving.ts
@@ -11,3 +11,5 @@ export async function opprettTilbakekreving(payload: OpprettTilbakekrevingPayloa
         url: `/familie-ks-sak/api/tilbakekreving/manuell`,
     });
 }
+
+// TODO: finn ut hva som er return-typen i KS

--- a/src/frontend/api/opprettTilbakekreving.ts
+++ b/src/frontend/api/opprettTilbakekreving.ts
@@ -1,15 +1,12 @@
 import { apiClient } from '@api/client/apiClient';
-import type { IBehandling } from '@typer/behandling';
 
 export interface OpprettTilbakekrevingPayload {
     fagsakId: number;
 }
 
 export async function opprettTilbakekreving(payload: OpprettTilbakekrevingPayload) {
-    return apiClient.post<OpprettTilbakekrevingPayload, IBehandling>({
+    return apiClient.post<OpprettTilbakekrevingPayload, void>({
         data: payload,
         url: `/familie-ks-sak/api/tilbakekreving/manuell`,
     });
 }
-
-// TODO: finn ut hva som er return-typen i KS

--- a/src/frontend/hooks/useOpprettKlagebehandling.ts
+++ b/src/frontend/hooks/useOpprettKlagebehandling.ts
@@ -1,16 +1,15 @@
 import { opprettKlagebehandling, type OpprettKlagebehandlingPayload } from '@api/opprettKlagebehandling';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
-import type { IBehandling } from '@typer/behandling';
 
 interface OpprettKlagebehandlingParameters extends OpprettKlagebehandlingPayload {
     fagsakId: number;
 }
 
-type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettKlagebehandlingParameters>, 'mutationFn'>;
+type Options = Omit<UseMutationOptions<number, DefaultError, OpprettKlagebehandlingParameters>, 'mutationFn'>;
 
 export function useOpprettKlagebehandling(options?: Options) {
-    return useMutation<IBehandling, Error, OpprettKlagebehandlingParameters>({
-        mutationFn: ({ klageMottattDato, fagsakId }: OpprettKlagebehandlingParameters): Promise<IBehandling> =>
+    return useMutation<number, Error, OpprettKlagebehandlingParameters>({
+        mutationFn: ({ klageMottattDato, fagsakId }: OpprettKlagebehandlingParameters): Promise<number> =>
             opprettKlagebehandling({ klageMottattDato }, fagsakId),
         ...options,
     });

--- a/src/frontend/hooks/useOpprettTilbakekreving.ts
+++ b/src/frontend/hooks/useOpprettTilbakekreving.ts
@@ -1,14 +1,13 @@
 import { opprettTilbakekreving, type OpprettTilbakekrevingPayload } from '@api/opprettTilbakekreving';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
-import type { IBehandling } from '@typer/behandling';
 
 type OpprettTilbakekrevingParameters = OpprettTilbakekrevingPayload;
 
-type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettTilbakekrevingParameters>, 'mutationFn'>;
+type Options = Omit<UseMutationOptions<void, DefaultError, OpprettTilbakekrevingParameters>, 'mutationFn'>;
 
 export function useOpprettTilbakekreving(options?: Options) {
-    return useMutation<IBehandling, Error, OpprettTilbakekrevingParameters>({
-        mutationFn: ({ fagsakId }: OpprettTilbakekrevingParameters): Promise<IBehandling> =>
+    return useMutation<void, Error, OpprettTilbakekrevingParameters>({
+        mutationFn: ({ fagsakId }: OpprettTilbakekrevingParameters): Promise<void> =>
             opprettTilbakekreving({ fagsakId }),
         ...options,
     });


### PR DESCRIPTION
### 📮 Favro: [NAV-30016](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-30016)

### 💰 Hva skal gjøres, og hvorfor?
Skriv tester for OpprettBehandling etter omskriving til React Hook Form og React Query. For å påse at funksjonaliteten fungerer som forventet, også ved senere endringer av koden.

Oppdaget at return-typene på kallene til `opprettKlagebehandling` og `opprettTilbakekreving` var feil, så har endret disse fra `IBehandling` til hhv. `number` og `void`.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.


### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_ Ingen visuelle endringer