### PR TITLE
NAV-30081 Vis deployet frontend- og backend-branch i preprod

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -60,6 +60,8 @@ spec:
   env:
     - name: APP_VERSION
       value: {{ VERSION }}
+    - name: APP_BRANCH
+      value: "{{ BRANCH }}"
     - name: ENV
       value: preprod
   valkey:

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -25,7 +25,13 @@ const redirectHvisInternUrlIPreprod = () => {
 export default async (authClient: Client, router: Router) => {
     router.get('/version', (_: Request, res: Response) => {
         res.status(200)
-            .send({ status: 'SUKSESS', data: envVar('APP_VERSION') })
+            .send({
+                status: 'SUKSESS',
+                data: {
+                    versjon: envVar('APP_VERSION'),
+                    branch: envVar('APP_BRANCH', false, 'ukjent'),
+                },
+            })
             .end();
     });
 

--- a/src/frontend/api/hentVersjonsinfo.ts
+++ b/src/frontend/api/hentVersjonsinfo.ts
@@ -1,0 +1,16 @@
+import { apiClient } from '@api/client/apiClient';
+
+export interface Versjonsinfo {
+    branch: string;
+    versjon: string;
+}
+
+export async function hentBackendVersjonsinfo() {
+    return apiClient.get<void, Versjonsinfo>({
+        url: '/familie-ks-sak/api/preprod/versjonsinfo',
+    });
+}
+
+export async function hentFrontendVersjonsinfo() {
+    return apiClient.get<void, Versjonsinfo>({ url: '/version' });
+}

--- a/src/frontend/hooks/useVersjonsinfo.ts
+++ b/src/frontend/hooks/useVersjonsinfo.ts
@@ -1,0 +1,33 @@
+import { hentBackendVersjonsinfo, hentFrontendVersjonsinfo } from '@api/hentVersjonsinfo';
+import { useQueries } from '@tanstack/react-query';
+import { erPreprod } from '@utils/miljø';
+
+export const VERSJONSINFO_QUERY_KEY_PREFIX = 'versjonsinfo';
+
+export function useVersjonsinfo() {
+    const skalHentes = erPreprod();
+
+    return useQueries({
+        queries: [
+            {
+                queryKey: [VERSJONSINFO_QUERY_KEY_PREFIX, 'frontend'],
+                queryFn: hentFrontendVersjonsinfo,
+                enabled: skalHentes,
+                staleTime: Infinity,
+                retry: false,
+            },
+            {
+                queryKey: [VERSJONSINFO_QUERY_KEY_PREFIX, 'backend'],
+                queryFn: hentBackendVersjonsinfo,
+                enabled: skalHentes,
+                staleTime: Infinity,
+                retry: false,
+            },
+        ],
+        combine: ([frontend, backend]) => ({
+            laster: frontend.isPending || backend.isPending,
+            frontendBranch: frontend.data?.branch,
+            backendBranch: backend.data?.branch,
+        }),
+    });
+}

--- a/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.module.css
+++ b/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.module.css
@@ -1,0 +1,13 @@
+/*
+ * Header-en rendrer tittelen, en spacer med margin-left: auto og deretter children.
+ * For å plassere branch-informasjonen rett etter tittelen – uten å dytte søkefeltet
+ * ut av posisjon – flyttes tittel og branch foran spaceren med flex order.
+ */
+:global(.aksel-internalheader__title) {
+    order: -2;
+}
+
+.deployetBranch {
+    order: -1;
+    padding-inline: var(--ax-space-16);
+}

--- a/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.test.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.test.tsx
@@ -1,0 +1,89 @@
+import type { PropsWithChildren } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { DeployetBranch } from './DeployetBranch';
+
+const { erPreprodMock, hentFrontendVersjonsinfoMock, hentBackendVersjonsinfoMock } = vi.hoisted(() => ({
+    erPreprodMock: vi.fn(),
+    hentFrontendVersjonsinfoMock: vi.fn(),
+    hentBackendVersjonsinfoMock: vi.fn(),
+}));
+
+vi.mock('@utils/miljø', () => ({ erPreprod: erPreprodMock }));
+
+vi.mock('@api/hentVersjonsinfo', () => ({
+    hentFrontendVersjonsinfo: hentFrontendVersjonsinfoMock,
+    hentBackendVersjonsinfo: hentBackendVersjonsinfoMock,
+}));
+
+const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+);
+
+describe('DeployetBranch', () => {
+    test('viser ingenting utenfor preprod', () => {
+        // Arrange
+        erPreprodMock.mockReturnValue(false);
+
+        // Act
+        const { container } = render(<DeployetBranch />, { wrapper });
+
+        // Assert
+        expect(container).toBeEmptyDOMElement();
+        expect(hentFrontendVersjonsinfoMock).not.toHaveBeenCalled();
+        expect(hentBackendVersjonsinfoMock).not.toHaveBeenCalled();
+    });
+
+    test('viser deployet branch for frontend og backend i preprod', async () => {
+        // Arrange
+        erPreprodMock.mockReturnValue(true);
+        hentFrontendVersjonsinfoMock.mockResolvedValue({
+            branch: 'min-frontend-branch',
+            versjon: 'fe:1',
+        });
+        hentBackendVersjonsinfoMock.mockResolvedValue({
+            branch: 'min-backend-branch',
+            versjon: 'be:1',
+        });
+
+        // Act
+        render(<DeployetBranch />, { wrapper });
+
+        // Assert
+        expect(await screen.findByText('Frontend: min-frontend-branch')).toBeInTheDocument();
+        expect(await screen.findByText('Backend: min-backend-branch')).toBeInTheDocument();
+    });
+
+    test('viser ingenting mens versjonsinfo hentes', () => {
+        // Arrange
+        erPreprodMock.mockReturnValue(true);
+        hentFrontendVersjonsinfoMock.mockReturnValue(new Promise(() => {}));
+        hentBackendVersjonsinfoMock.mockReturnValue(new Promise(() => {}));
+
+        // Act
+        const { container } = render(<DeployetBranch />, { wrapper });
+
+        // Assert
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('viser ukjent når henting av versjonsinfo feiler', async () => {
+        // Arrange
+        erPreprodMock.mockReturnValue(true);
+        hentFrontendVersjonsinfoMock.mockResolvedValue({
+            branch: 'min-frontend-branch',
+            versjon: 'fe:1',
+        });
+        hentBackendVersjonsinfoMock.mockRejectedValue(new Error('Backend er nede'));
+
+        // Act
+        render(<DeployetBranch />, { wrapper });
+
+        // Assert
+        expect(await screen.findByText('Frontend: min-frontend-branch')).toBeInTheDocument();
+        expect(await screen.findByText('Backend: ukjent')).toBeInTheDocument();
+    });
+});

--- a/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.tsx
@@ -1,0 +1,21 @@
+import { useVersjonsinfo } from '@hooks/useVersjonsinfo';
+import { erPreprod } from '@utils/miljø';
+
+import { Detail, HStack } from '@navikt/ds-react';
+
+import Styles from './DeployetBranch.module.css';
+
+export function DeployetBranch() {
+    const { laster, frontendBranch, backendBranch } = useVersjonsinfo();
+
+    if (!erPreprod() || laster) {
+        return null;
+    }
+
+    return (
+        <HStack gap="space-8" align="center" wrap={false} className={Styles.deployetBranch}>
+            <Detail textColor="subtle">{`Frontend: ${frontendBranch ?? 'ukjent'}`}</Detail>
+            <Detail textColor="subtle">{`Backend: ${backendBranch ?? 'ukjent'}`}</Detail>
+        </HStack>
+    );
+}

--- a/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
@@ -1,5 +1,6 @@
 import { Header } from '@navikt/familie-header';
 
+import { DeployetBranch } from './DeployetBranch';
 import FagsakDeltagerSøk from './FagsakDeltagerSøk';
 import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 
@@ -31,6 +32,7 @@ export function HeaderMedSøk() {
             brukerPopoverItems={[{ name: 'Logg ut', href: `${window.origin}/auth/logout` }]}
             eksterneLenker={eksterneLenker}
         >
+            <DeployetBranch />
             <FagsakDeltagerSøk />
         </Header>
     );

--- a/src/frontend/testutils/mocks/handlers/versionHandlers.ts
+++ b/src/frontend/testutils/mocks/handlers/versionHandlers.ts
@@ -4,6 +4,6 @@ import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 export const versionHandlers = [
     http.get('/version', () => {
-        return HttpResponse.json(byggSuksessRessurs('1'));
+        return HttpResponse.json(byggSuksessRessurs({ versjon: '1', branch: 'main' }));
     }),
 ];


### PR DESCRIPTION
### 📮 Favro: NAV-30081

### 💰 Hva skal gjøres, og hvorfor?
Viser hvilken branch frontend og backend er deployet fra i headeren når appen kjører i preprod, slik at testere kan verifisere at riktig branch faktisk er deployet før de tester. Samme løsning som allerede er innført i `familie-ba-sak-frontend`.

- `.nais/app-dev.yaml`: eksponerer `APP_BRANCH` fra nais-variabelen `{{ BRANCH }}`.
- `src/backend/router.ts`: `GET /version` returnerer nå `{ versjon, branch }` i stedet for kun versjonsstrengen. `APP_BRANCH` defaulter til `ukjent`.
- `hentVersjonsinfo`: nye API-funksjoner mot `/version` (frontend) og `/familie-ks-sak/api/preprod/versjonsinfo` (backend).
- `useVersjonsinfo`: henter begge i parallell med `useQueries`. Kallene er kun aktivert i preprod.

- `DeployetBranch`: ny komponent som viser «Frontend: \<branch\> / Backend: \<branch\>» i headeren, rendret fra `HeaderMedSøk`.

- Tester: ny `DeployetBranch.test.tsx`, og msw-mocken for `/version` er oppdatert til det nye responsformatet.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.
