### PR TITLE
NAV-30112: Lås opp fagsak og visning av låst fagsak

### DIFF
--- a/src/frontend/api/låsOppFagsak.ts
+++ b/src/frontend/api/låsOppFagsak.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IMinimalFagsak } from '@typer/fagsak';
+
+export interface LåsOppFagsakPayload {
+    begrunnelse: string;
+}
+
+export async function låsOppFagsak(fagsakId: number, payload: LåsOppFagsakPayload) {
+    return apiClient.patch<LåsOppFagsakPayload, IMinimalFagsak>({
+        data: payload,
+        url: `/familie-ks-sak/api/fagsaker/${fagsakId}/laas-opp`,
+    });
+}

--- a/src/frontend/context/ModalContext.tsx
+++ b/src/frontend/context/ModalContext.tsx
@@ -23,6 +23,7 @@ export enum ModalType {
     FEILMELDING = 'FEILMELDING',
     KORRIGER_ETTERBETALING = 'KORRIGER_ETTERBETALING',
     FORHÅNDSVIS_OPPRETTING_AV_PDF = 'FORHÅNDSVIS_OPPRETTING_AV_PDF',
+    LÅS_OPP_FAGSAK = 'LÅS_OPP_FAGSAK',
 }
 
 export interface Args {
@@ -76,6 +77,11 @@ const initialState: State = {
         tittel: 'Korriger etterbetaling',
         åpen: false,
         bredde: '35rem',
+    },
+    [ModalType.LÅS_OPP_FAGSAK]: {
+        tittel: 'Lås opp fagsak',
+        åpen: false,
+        bredde: '37rem',
     },
 };
 

--- a/src/frontend/hooks/useErLesevisning.test.ts
+++ b/src/frontend/hooks/useErLesevisning.test.ts
@@ -3,26 +3,32 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useBehandling } from './useBehandling';
 import { useErLesevisning } from './useErLesevisning';
+import { useFagsak } from './useFagsak';
 import { useSaksbehandler } from './useSaksbehandler';
 import { lagBehandling } from '../testutils/testdata/behandlingTestdata';
+import { lagFagsak } from '../testutils/testdata/fagsakTestdata';
 import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
 import { BehandlingStatus, BehandlingSteg, SettPåVentÅrsak } from '../typer/behandling';
 import { harTilgangTilEnhet } from '../typer/enhet';
+import { FagsakStatus } from '../typer/fagsak';
 import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../utils/behandling';
 
 vi.mock('./useBehandling');
 vi.mock('./useSaksbehandler');
+vi.mock('./useFagsak');
 vi.mock('../typer/enhet');
 
 const mockUseBehandling = vi.mocked(useBehandling);
 const mockUseSaksbehandler = vi.mocked(useSaksbehandler);
 const mockHarTilgangTilEnhet = vi.mocked(harTilgangTilEnhet);
+const mockUseFagsak = vi.mocked(useFagsak);
 
 beforeEach(() => {
     vi.resetAllMocks();
     mockUseBehandling.mockReturnValue(lagBehandling());
     mockUseSaksbehandler.mockReturnValue(lagSaksbehandler());
     mockHarTilgangTilEnhet.mockReturnValue(true);
+    mockUseFagsak.mockReturnValue(lagFagsak());
 });
 
 describe('useErLesevisning', () => {
@@ -139,5 +145,13 @@ describe('useErLesevisning', () => {
         const { result } = renderHook(() => useErLesevisning());
 
         expect(result.current).toBe(false);
+    });
+
+    it('returnerer true når fagsaken er låst', () => {
+        mockUseFagsak.mockReturnValue(lagFagsak({ status: FagsakStatus.LÅST }));
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(true);
     });
 });

--- a/src/frontend/hooks/useErLesevisning.ts
+++ b/src/frontend/hooks/useErLesevisning.ts
@@ -1,8 +1,10 @@
 import { useBehandling } from './useBehandling';
+import { useFagsak } from './useFagsak';
 import { useSaksbehandler } from './useSaksbehandler';
 import { BehandlingStatus, BehandlingSteg, BehandlingÅrsak, hentStegNummer } from '../typer/behandling';
 import { harTilgangTilEnhet } from '../typer/enhet';
 import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../utils/behandling';
+import { erFagsakLåst } from '../utils/fagsak';
 
 const ÅRSAKER_ÅPEN_FOR_ALLE = new Set([BehandlingÅrsak.TEKNISK_ENDRING]);
 
@@ -17,6 +19,11 @@ export function useErLesevisning({
 }: Parameters = {}) {
     const saksbehandler = useSaksbehandler();
     const behandling = useBehandling();
+    const fagsak = useFagsak();
+
+    if (erFagsakLåst(fagsak)) {
+        return true;
+    }
 
     const behandlendeEnhetId = behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId;
     const erBehandlingenAvsluttet = behandling.status === BehandlingStatus.AVSLUTTET;

--- a/src/frontend/hooks/useLåsOppFagsak.ts
+++ b/src/frontend/hooks/useLåsOppFagsak.ts
@@ -2,18 +2,18 @@ import { låsOppFagsak, type LåsOppFagsakPayload } from '@api/låsOppFagsak';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
 import type { IMinimalFagsak } from '@typer/fagsak';
 
-interface Parameters extends LåsOppFagsakPayload {
-    fagsakId: number;
-}
+type Parameters = LåsOppFagsakPayload;
 
-type Options = Omit<UseMutationOptions<IMinimalFagsak, DefaultError, Parameters>, 'mutationFn'>;
+type Options = Omit<UseMutationOptions<IMinimalFagsak, DefaultError, Parameters>, 'mutationKey' | 'mutationFn'>;
 
-export function useLåsOppFagsak(options?: Options) {
+export const LåsOppFagsakMutationKeyFactory = {
+    låsOppFagsak: (fagsakId: number) => ['låsOppFagsak', fagsakId],
+};
+
+export function useLåsOppFagsak(fagsakId: number, options?: Options) {
     return useMutation({
-        mutationFn: (parameters: Parameters) => {
-            const { fagsakId, begrunnelse } = parameters;
-            return låsOppFagsak(fagsakId, { begrunnelse });
-        },
+        mutationKey: LåsOppFagsakMutationKeyFactory.låsOppFagsak(fagsakId),
+        mutationFn: (parameters: Parameters) => låsOppFagsak(fagsakId, parameters),
         ...options,
     });
 }

--- a/src/frontend/hooks/useLåsOppFagsak.ts
+++ b/src/frontend/hooks/useLåsOppFagsak.ts
@@ -1,0 +1,19 @@
+import { låsOppFagsak, type LåsOppFagsakPayload } from '@api/låsOppFagsak';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IMinimalFagsak } from '@typer/fagsak';
+
+interface Parameters extends LåsOppFagsakPayload {
+    fagsakId: number;
+}
+
+type Options = Omit<UseMutationOptions<IMinimalFagsak, DefaultError, Parameters>, 'mutationFn'>;
+
+export function useLåsOppFagsak(options?: Options) {
+    return useMutation({
+        mutationFn: (parameters: Parameters) => {
+            const { fagsakId, begrunnelse } = parameters;
+            return låsOppFagsak(fagsakId, { begrunnelse });
+        },
+        ...options,
+    });
+}

--- a/src/frontend/komponenter/Saklinje/Behandlingslinje.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Behandlingslinje.test.tsx
@@ -13,7 +13,7 @@ import { lagFagsak } from '../../testutils/testdata/fagsakTestdata';
 import { lagSaksbehandler } from '../../testutils/testdata/saksbehandlerTestdata';
 import { render, TestProviders } from '../../testutils/testrender';
 import type { IBehandling } from '../../typer/behandling';
-import type { IMinimalFagsak } from '../../typer/fagsak';
+import { FagsakStatus, type IMinimalFagsak } from '../../typer/fagsak';
 import type { Saksbehandler } from '../../typer/saksbehandler';
 
 interface WrapperProps extends PropsWithChildren {
@@ -101,6 +101,21 @@ describe('Behandlingslinje', () => {
                 <Wrapper
                     {...props}
                     saksbehandler={lagSaksbehandler({ groups: ['71f503a2-c28f-4394-a05a-8da263ceca4a'] })}
+                />
+            ),
+        });
+
+        expect(screen.getByRole('button', { name: 'Saksoversikt' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Dokumenter' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Meny' })).not.toBeInTheDocument();
+    });
+
+    test('skal ikke vise behandlingsmeny når fagsaken er låst', () => {
+        const { screen } = render(<Behandlingslinje />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    fagsak={lagFagsak({ status: FagsakStatus.LÅST, behandlinger: [lagVisningBehandling()] })}
                 />
             ),
         });

--- a/src/frontend/komponenter/Saklinje/Behandlingslinje.tsx
+++ b/src/frontend/komponenter/Saklinje/Behandlingslinje.tsx
@@ -6,6 +6,7 @@ import { Box, Button, HStack } from '@navikt/ds-react';
 import { Behandlingsmeny } from './Meny/Behandlingsmeny';
 import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
+import { erFagsakLåst } from '../../utils/fagsak';
 
 function lagAktivFaneStyle(fanenavn: string, pathname: string) {
     const urlSplit = pathname.split('/');
@@ -44,7 +45,7 @@ export function Behandlingslinje() {
                         Dokumenter
                     </Button>
                 </HStack>
-                {saksbehandler.harSkrivetilgang && <Behandlingsmeny />}
+                {saksbehandler.harSkrivetilgang && !erFagsakLåst(fagsak) && <Behandlingsmeny />}
             </HStack>
         </Box>
     );

--- a/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.test.tsx
@@ -12,15 +12,21 @@ import { ManuelleBrevmottakerePåFagsakProvider } from '../../../sider/Fagsak/Ma
 import { FagsakTestdata } from '../../../testutils/testdata/fagsakTestdata';
 import { lagPerson } from '../../../testutils/testdata/personTestdata';
 import { render, TestProviders } from '../../../testutils/testrender';
+import { FagsakStatus, type IMinimalFagsak } from '../../../typer/fagsak';
 
 interface WrapperProps extends PropsWithChildren {
     initialEntries?: [{ pathname: string }];
+    fagsak?: IMinimalFagsak;
 }
 
-function Wrapper({ initialEntries = [{ pathname: '/fagsak/1' }], children }: WrapperProps) {
+function Wrapper({
+    initialEntries = [{ pathname: '/fagsak/1' }],
+    fagsak = FagsakTestdata.lagFagsak(),
+    children,
+}: WrapperProps) {
     return (
         <TestProviders initialEntries={initialEntries}>
-            <FagsakProvider fagsak={FagsakTestdata.lagFagsak()}>
+            <FagsakProvider fagsak={fagsak}>
                 <BrukerProvider bruker={lagPerson()}>
                     <ManuelleBrevmottakerePåFagsakProvider>
                         <Routes>
@@ -116,5 +122,27 @@ describe('Fagsakmeny', () => {
         await user.click(menuitem);
 
         expect(screen.getByRole('dialog', { name: 'Legg til brevmottaker' })).toBeInTheDocument();
+    });
+
+    test('skal kun vise lås opp fagsak når fagsaken er låst', async () => {
+        const { screen, user } = render(<Fagsakmeny />, {
+            wrapper: props => <Wrapper {...props} fagsak={FagsakTestdata.lagFagsak({ status: FagsakStatus.LÅST })} />,
+        });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        expect(screen.getByRole('menuitem', { name: 'Lås opp fagsak' })).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Opprett behandling' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'Send informasjonsbrev' })).not.toBeInTheDocument();
+    });
+
+    test('skal ikke vise lås opp fagsak når fagsaken ikke er låst', async () => {
+        const { screen, user } = render(<Fagsakmeny />, { wrapper: Wrapper });
+
+        const meny = screen.getByRole('button', { name: 'Meny' });
+        await user.click(meny);
+
+        expect(screen.queryByRole('menuitem', { name: 'Lås opp fagsak' })).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
@@ -1,8 +1,5 @@
 import { useState } from 'react';
 
-import { useFagsak } from '@hooks/useFagsak';
-import { erFagsakLåst } from '@utils/fagsak';
-
 import { ChevronDownIcon } from '@navikt/aksel-icons';
 import { ActionMenu, Button } from '@navikt/ds-react';
 
@@ -17,9 +14,6 @@ import { TilbakekrevingsbehandlingOpprettetModal } from './OpprettBehandling/Til
 import { SendInformasjonsbrev } from './SendInformasjonsbrev/SendInformasjonsbrev';
 
 export function Fagsakmeny() {
-    const fagsak = useFagsak();
-    const fagsakErLåst = erFagsakLåst(fagsak);
-
     const [visOpprettBehandlingModal, settVisOpprettBehandlingModal] = useState(false);
     const [visTilbakekrevingsbehandlingOpprettetModal, settVisTilbakekrevingsbehandlingOpprettetModal] =
         useState(false);
@@ -50,16 +44,12 @@ export function Fagsakmeny() {
                 </ActionMenu.Trigger>
                 <ActionMenu.Content>
                     <ActionMenu.Group className={Styles.group} aria-label={'Fagsak'}>
-                        {!fagsakErLåst && (
-                            <>
-                                <OpprettBehandling åpneModal={() => settVisOpprettBehandlingModal(true)} />
-                                <LeggTilEllerFjernBrevmottakerePåFagsak
-                                    åpneModal={() => settVisLeggTilBrevmottakerModal(true)}
-                                />
-                                <SendInformasjonsbrev />
-                            </>
-                        )}
-                        {fagsakErLåst && <LåsOppFagsak />}
+                        <OpprettBehandling åpneModal={() => settVisOpprettBehandlingModal(true)} />
+                        <LeggTilEllerFjernBrevmottakerePåFagsak
+                            åpneModal={() => settVisLeggTilBrevmottakerModal(true)}
+                        />
+                        <SendInformasjonsbrev />
+                        <LåsOppFagsak />
                     </ActionMenu.Group>
                 </ActionMenu.Content>
             </ActionMenu>

--- a/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
@@ -1,17 +1,25 @@
 import { useState } from 'react';
 
+import { useFagsak } from '@hooks/useFagsak';
+import { erFagsakLåst } from '@utils/fagsak';
+
 import { ChevronDownIcon } from '@navikt/aksel-icons';
 import { ActionMenu, Button } from '@navikt/ds-react';
 
 import Styles from './Fagsakmeny.module.css';
 import { LeggTilBrevmottakerModalFagsak } from './LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak';
 import { LeggTilEllerFjernBrevmottakerePåFagsak } from './LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak';
+import { LåsOppFagsak } from './LåsOppFagsak/LåsOppFagsak';
+import { LåsOppFagsakModal } from './LåsOppFagsak/LåsOppFagsakModal';
 import { OpprettBehandling } from './OpprettBehandling/OpprettBehandling';
 import { OpprettBehandlingModal } from './OpprettBehandling/OpprettBehandlingModal';
 import { TilbakekrevingsbehandlingOpprettetModal } from './OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal';
 import { SendInformasjonsbrev } from './SendInformasjonsbrev/SendInformasjonsbrev';
 
 export function Fagsakmeny() {
+    const fagsak = useFagsak();
+    const fagsakErLåst = erFagsakLåst(fagsak);
+
     const [visOpprettBehandlingModal, settVisOpprettBehandlingModal] = useState(false);
     const [visTilbakekrevingsbehandlingOpprettetModal, settVisTilbakekrevingsbehandlingOpprettetModal] =
         useState(false);
@@ -33,6 +41,7 @@ export function Fagsakmeny() {
             {visLeggTilBrevmottakerModal && (
                 <LeggTilBrevmottakerModalFagsak lukkModal={() => settVisLeggTilBrevmottakerModal(false)} />
             )}
+            {fagsakErLåst && <LåsOppFagsakModal />}
             <ActionMenu>
                 <ActionMenu.Trigger>
                     <Button variant={'secondary'} size={'small'} iconPosition={'right'} icon={<ChevronDownIcon />}>
@@ -41,11 +50,16 @@ export function Fagsakmeny() {
                 </ActionMenu.Trigger>
                 <ActionMenu.Content>
                     <ActionMenu.Group className={Styles.group} aria-label={'Fagsak'}>
-                        <OpprettBehandling åpneModal={() => settVisOpprettBehandlingModal(true)} />
-                        <LeggTilEllerFjernBrevmottakerePåFagsak
-                            åpneModal={() => settVisLeggTilBrevmottakerModal(true)}
-                        />
-                        <SendInformasjonsbrev />
+                        {!fagsakErLåst && (
+                            <>
+                                <OpprettBehandling åpneModal={() => settVisOpprettBehandlingModal(true)} />
+                                <LeggTilEllerFjernBrevmottakerePåFagsak
+                                    åpneModal={() => settVisLeggTilBrevmottakerModal(true)}
+                                />
+                                <SendInformasjonsbrev />
+                            </>
+                        )}
+                        {fagsakErLåst && <LåsOppFagsak />}
                     </ActionMenu.Group>
                 </ActionMenu.Content>
             </ActionMenu>

--- a/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
@@ -41,7 +41,7 @@ export function Fagsakmeny() {
             {visLeggTilBrevmottakerModal && (
                 <LeggTilBrevmottakerModalFagsak lukkModal={() => settVisLeggTilBrevmottakerModal(false)} />
             )}
-            {fagsakErLåst && <LåsOppFagsakModal />}
+            <LåsOppFagsakModal />
             <ActionMenu>
                 <ActionMenu.Trigger>
                     <Button variant={'secondary'} size={'small'} iconPosition={'right'} icon={<ChevronDownIcon />}>

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.test.tsx
@@ -7,43 +7,55 @@ import { ActionMenu, Heading } from '@navikt/ds-react';
 
 import { LeggTilEllerFjernBrevmottakerePåFagsak } from './LeggTilEllerFjernBrevmottakerePåFagsak';
 import type { SkjemaBrevmottaker } from './useBrevmottakerSkjema';
+import { FagsakProvider } from '../../../../sider/Fagsak/FagsakContext';
 import { ManuelleBrevmottakerePåFagsakProvider } from '../../../../sider/Fagsak/ManuelleBrevmottakerePåFagsakContext';
 import { BrevmottakerTestdata } from '../../../../testutils/testdata/brevmottakerTestdata';
+import { lagFagsak } from '../../../../testutils/testdata/fagsakTestdata';
 import { render, TestProviders } from '../../../../testutils/testrender';
+import type { IMinimalFagsak } from '../../../../typer/fagsak';
+import { FagsakStatus } from '../../../../typer/fagsak';
 
 interface WrapperProps extends PropsWithChildren {
     initialEntries?: [{ pathname: string }];
     brevmottakere?: SkjemaBrevmottaker[];
+    fagsak?: IMinimalFagsak;
 }
 
-function Wrapper({ initialEntries = [{ pathname: '/fagsak/1' }], brevmottakere = [], children }: WrapperProps) {
+function Wrapper({
+    initialEntries = [{ pathname: '/fagsak/1' }],
+    brevmottakere = [],
+    fagsak = lagFagsak(),
+    children,
+}: WrapperProps) {
     return (
         <TestProviders initialEntries={initialEntries}>
-            <ManuelleBrevmottakerePåFagsakProvider brevmottakere={brevmottakere}>
-                <Routes>
-                    <Route
-                        path={'/fagsak/:fagsakId/dokumentutsending'}
-                        element={
-                            <>
-                                <Heading level={'1'} size={'medium'}>
-                                    Dokumentutsending
-                                </Heading>
+            <FagsakProvider fagsak={fagsak}>
+                <ManuelleBrevmottakerePåFagsakProvider brevmottakere={brevmottakere}>
+                    <Routes>
+                        <Route
+                            path={'/fagsak/:fagsakId/dokumentutsending'}
+                            element={
+                                <>
+                                    <Heading level={'1'} size={'medium'}>
+                                        Dokumentutsending
+                                    </Heading>
+                                    <ActionMenu open={true}>
+                                        <ActionMenu.Content>{children}</ActionMenu.Content>
+                                    </ActionMenu>
+                                </>
+                            }
+                        />
+                        <Route
+                            path={'/fagsak/:fagsakId'}
+                            element={
                                 <ActionMenu open={true}>
                                     <ActionMenu.Content>{children}</ActionMenu.Content>
                                 </ActionMenu>
-                            </>
-                        }
-                    />
-                    <Route
-                        path={'/fagsak/:fagsakId'}
-                        element={
-                            <ActionMenu open={true}>
-                                <ActionMenu.Content>{children}</ActionMenu.Content>
-                            </ActionMenu>
-                        }
-                    />
-                </Routes>
-            </ManuelleBrevmottakerePåFagsakProvider>
+                            }
+                        />
+                    </Routes>
+                </ManuelleBrevmottakerePåFagsakProvider>
+            </FagsakProvider>
         </TestProviders>
     );
 }
@@ -114,5 +126,21 @@ describe('LeggTilEllerFjernBrevmottakerePåFagsak', () => {
         await user.click(knapp);
 
         expect(åpneModal).toHaveBeenCalledOnce();
+    });
+
+    test('skal ikke rendre komponenten når fagsaken er låst', () => {
+        const åpneModal = vi.fn();
+
+        const { screen } = render(<LeggTilEllerFjernBrevmottakerePåFagsak åpneModal={åpneModal} />, {
+            wrapper: props => (
+                <Wrapper
+                    {...props}
+                    initialEntries={[{ pathname: '/fagsak/1/dokumentutsending' }]}
+                    fagsak={lagFagsak({ status: FagsakStatus.LÅST })}
+                />
+            ),
+        });
+
+        expect(screen.queryByRole('menuitem', { name: 'Legg til brevmottaker' })).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.tsx
@@ -3,7 +3,9 @@ import { useLocation } from 'react-router';
 import { ActionMenu } from '@navikt/ds-react';
 
 import type { SkjemaBrevmottaker } from './useBrevmottakerSkjema';
+import { useFagsakContext } from '../../../../sider/Fagsak/FagsakContext';
 import { useManuelleBrevmottakerePåFagsakContext } from '../../../../sider/Fagsak/ManuelleBrevmottakerePåFagsakContext';
+import { erFagsakLåst } from '../../../../utils/fagsak';
 
 function utledLabel(brevmottakere: SkjemaBrevmottaker[]) {
     if (brevmottakere.length === 0) {
@@ -18,11 +20,12 @@ interface Props {
 
 export function LeggTilEllerFjernBrevmottakerePåFagsak({ åpneModal }: Props) {
     const { manuelleBrevmottakerePåFagsak } = useManuelleBrevmottakerePåFagsakContext();
+    const { fagsak } = useFagsakContext();
     const location = useLocation();
 
     const erPåDokumentutsending = location.pathname.includes('dokumentutsending');
 
-    if (!erPåDokumentutsending) {
+    if (!erPåDokumentutsending || erFagsakLåst(fagsak)) {
         return null;
     }
 

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsak.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsak.tsx
@@ -1,0 +1,10 @@
+import { ModalType } from '@context/ModalContext';
+import { useModal } from '@hooks/useModal';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+export function LåsOppFagsak() {
+    const { åpneModal } = useModal(ModalType.LÅS_OPP_FAGSAK);
+
+    return <ActionMenu.Item onSelect={() => åpneModal()}>Lås opp fagsak</ActionMenu.Item>;
+}

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsak.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsak.tsx
@@ -1,10 +1,17 @@
 import { ModalType } from '@context/ModalContext';
+import { useFagsak } from '@hooks/useFagsak';
 import { useModal } from '@hooks/useModal';
+import { erFagsakLåst } from '@utils/fagsak';
 
 import { ActionMenu } from '@navikt/ds-react';
 
 export function LåsOppFagsak() {
+    const fagsak = useFagsak();
     const { åpneModal } = useModal(ModalType.LÅS_OPP_FAGSAK);
+
+    if (!erFagsakLåst(fagsak)) {
+        return null;
+    }
 
     return <ActionMenu.Item onSelect={() => åpneModal()}>Lås opp fagsak</ActionMenu.Item>;
 }

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
@@ -1,5 +1,8 @@
 import { ModalType } from '@context/ModalContext';
+import { useFagsak } from '@hooks/useFagsak';
+import { LåsOppFagsakMutationKeyFactory } from '@hooks/useLåsOppFagsak';
 import { useModal } from '@hooks/useModal';
+import { useIsMutating } from '@tanstack/react-query';
 import { FormProvider, useController, useFormContext } from 'react-hook-form';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
@@ -13,12 +16,20 @@ import {
 } from './useLåsOppFagsakForm';
 
 export function LåsOppFagsakModal() {
+    const fagsak = useFagsak();
     const { erModalÅpen, tittel, lukkModal, bredde } = useModal(ModalType.LÅS_OPP_FAGSAK);
+
+    const antallPågåendeOpplåsinger = useIsMutating({
+        mutationKey: LåsOppFagsakMutationKeyFactory.låsOppFagsak(fagsak.id),
+    });
+
     return (
         <Modal
             open={erModalÅpen}
             width={bredde}
             onClose={lukkModal}
+            // Hindrer at Escape og lukkeknappen avmonterer skjemaet mens opplåsingen er underveis.
+            onBeforeClose={() => antallPågåendeOpplåsinger === 0}
             header={{ heading: tittel, size: 'medium' }}
             portal={true}
         >
@@ -76,7 +87,7 @@ function BegrunnelseFelt() {
     const { control } = useFormContext<LåsOppFagsakFormValues>();
 
     const {
-        field: { value, onBlur, onChange },
+        field: { name, ref, value, onBlur, onChange },
         fieldState: { error },
         formState: { isSubmitting },
     } = useController({
@@ -97,13 +108,16 @@ function BegrunnelseFelt() {
 
     return (
         <Textarea
+            ref={ref}
+            id={name}
+            name={name}
             label={'Begrunnelse'}
             maxLength={4000}
             value={value}
             onBlur={onBlur}
             onChange={onChange}
             error={error?.message}
-            disabled={isSubmitting}
+            readOnly={isSubmitting}
         />
     );
 }

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
@@ -1,0 +1,114 @@
+import { ModalType } from '@context/ModalContext';
+import { useModal } from '@hooks/useModal';
+import { FormProvider, useController, useFormContext } from 'react-hook-form';
+
+import { InformationSquareIcon } from '@navikt/aksel-icons';
+import { Button, Fieldset, InfoCard, Modal, Textarea, VStack } from '@navikt/ds-react';
+
+import {
+    LÅS_OPP_FAGSAK_FORM_ID,
+    LåsOppFagsakFormFields,
+    LåsOppFagsakServerErrors,
+    type LåsOppFagsakFormValues,
+    useLåsOppFagsakForm,
+} from './useLåsOppFagsakForm';
+
+export function LåsOppFagsakModal() {
+    const { erModalÅpen, tittel, lukkModal, bredde } = useModal(ModalType.LÅS_OPP_FAGSAK);
+    return (
+        <Modal
+            open={erModalÅpen}
+            width={bredde}
+            onClose={lukkModal}
+            header={{ heading: tittel, size: 'medium' }}
+            portal={true}
+        >
+            {erModalÅpen && <Innhold />}
+        </Modal>
+    );
+}
+
+function Innhold() {
+    const { lukkModal } = useModal(ModalType.LÅS_OPP_FAGSAK);
+    const { form, onSubmit } = useLåsOppFagsakForm();
+
+    const {
+        handleSubmit,
+        formState: { isSubmitting, errors },
+    } = form;
+    return (
+        <>
+            <Modal.Body>
+                <VStack gap={'space-16'}>
+                    <InfoCard data-color="info">
+                        <InfoCard.Message icon={<InformationSquareIcon aria-hidden />}>
+                            Skriv en begrunnelse som forklarer hvorfor fagsaken låses opp. Merk at fagsaken vil låses
+                            ned igjen etter en periode dersom det ikke opprettes en ny behandling.
+                        </InfoCard.Message>
+                    </InfoCard>
+                    <FormProvider {...form}>
+                        <form id={LÅS_OPP_FAGSAK_FORM_ID} onSubmit={handleSubmit(onSubmit)}>
+                            <Fieldset
+                                legend={'Lås opp fagsak'}
+                                hideLegend={true}
+                                error={LåsOppFagsakServerErrors.onSubmitError.lookup(errors)}
+                            >
+                                <BegrunnelseFelt />
+                            </Fieldset>
+                        </form>
+                    </FormProvider>
+                </VStack>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    form={LÅS_OPP_FAGSAK_FORM_ID}
+                    variant={'primary'}
+                    size={'small'}
+                    type={'submit'}
+                    loading={isSubmitting}
+                >
+                    Bekreft
+                </Button>
+                <Button variant={'tertiary'} size={'small'} onClick={() => lukkModal()} disabled={isSubmitting}>
+                    Avbryt
+                </Button>
+            </Modal.Footer>
+        </>
+    );
+}
+
+function BegrunnelseFelt() {
+    const { control } = useFormContext<LåsOppFagsakFormValues>();
+
+    const {
+        field: { value, onBlur, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: LåsOppFagsakFormFields.BEGRUNNELSE,
+        control,
+        rules: {
+            validate: verdi => {
+                const trimmed = verdi.trim();
+                if (trimmed.length < 5) {
+                    return 'Skriv en begrunnelse med minst 5 tegn.';
+                }
+                if (trimmed.length > 4000) {
+                    return 'Begrunnelsen kan ikke være lengre enn 4000 tegn.';
+                }
+            },
+        },
+    });
+
+    return (
+        <Textarea
+            label={'Begrunnelse'}
+            maxLength={4000}
+            value={value}
+            onBlur={onBlur}
+            onChange={onChange}
+            error={error?.message}
+            disabled={isSubmitting}
+        />
+    );
+}

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
@@ -8,7 +8,6 @@ import { Button, Fieldset, InfoCard, Modal, Textarea, VStack } from '@navikt/ds-
 import {
     LÅS_OPP_FAGSAK_FORM_ID,
     LåsOppFagsakFormFields,
-    LåsOppFagsakServerErrors,
     type LåsOppFagsakFormValues,
     useLåsOppFagsakForm,
 } from './useLåsOppFagsakForm';
@@ -48,11 +47,7 @@ function Innhold() {
                     </InfoCard>
                     <FormProvider {...form}>
                         <form id={LÅS_OPP_FAGSAK_FORM_ID} onSubmit={handleSubmit(onSubmit)}>
-                            <Fieldset
-                                legend={'Lås opp fagsak'}
-                                hideLegend={true}
-                                error={LåsOppFagsakServerErrors.onSubmitError.lookup(errors)}
-                            >
+                            <Fieldset legend={'Lås opp fagsak'} hideLegend={true} error={errors?.root?.message}>
                                 <BegrunnelseFelt />
                             </Fieldset>
                         </form>

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
@@ -19,7 +19,7 @@ export const LÅS_OPP_FAGSAK_FORM_ID = 'las_opp_fagsak_modal_form';
 export function useLåsOppFagsakForm() {
     const fagsak = useFagsak();
     const { lukkModal } = useModal(ModalType.LÅS_OPP_FAGSAK);
-    const { mutateAsync } = useLåsOppFagsak();
+    const { mutateAsync } = useLåsOppFagsak(fagsak.id);
     const queryClient = useQueryClient();
 
     const form = useForm<LåsOppFagsakFormValues>({
@@ -32,18 +32,17 @@ export function useLåsOppFagsakForm() {
 
     async function onSubmit(values: LåsOppFagsakFormValues) {
         const { begrunnelse } = values;
-        return mutateAsync({ fagsakId: fagsak.id, begrunnelse: begrunnelse.trim() })
-            .then(async () => {
-                await queryClient.invalidateQueries({
-                    queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id),
-                });
-                lukkModal();
-            })
-            .catch(error =>
-                setError('root', {
-                    message: error.message,
-                })
-            );
+        try {
+            await mutateAsync({ begrunnelse: begrunnelse.trim() });
+        } catch (error) {
+            // Kun feil fra selve opplåsingen skal rapporteres som en mislykket opplåsing.
+            setError('root', { message: (error as Error).message });
+            return;
+        }
+        await queryClient.invalidateQueries({
+            queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id),
+        });
+        lukkModal();
     }
 
     return { form, onSubmit };

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
@@ -4,20 +4,7 @@ import { HentFagsakQueryKeyFactory } from '@hooks/useHentFagsak';
 import { useLåsOppFagsak } from '@hooks/useLåsOppFagsak';
 import { useModal } from '@hooks/useModal';
 import { useQueryClient } from '@tanstack/react-query';
-import { type FieldErrors, useForm } from 'react-hook-form';
-
-export const LåsOppFagsakServerErrors: Record<
-    'onSubmitError',
-    {
-        id: `root.${string}`;
-        lookup: (errors: FieldErrors<LåsOppFagsakFormValues>) => string | undefined;
-    }
-> = {
-    onSubmitError: {
-        id: 'root.onSubmitError',
-        lookup: errors => errors?.root?.onSubmitError?.message,
-    },
-};
+import { useForm } from 'react-hook-form';
 
 export enum LåsOppFagsakFormFields {
     BEGRUNNELSE = 'begrunnelse',
@@ -53,8 +40,8 @@ export function useLåsOppFagsakForm() {
                 lukkModal();
             })
             .catch(error =>
-                setError(LåsOppFagsakServerErrors.onSubmitError.id, {
-                    message: error.message ?? 'En feil oppstod.',
+                setError('root', {
+                    message: error.message,
                 })
             );
     }

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
@@ -1,0 +1,63 @@
+import { ModalType } from '@context/ModalContext';
+import { useFagsak } from '@hooks/useFagsak';
+import { HentFagsakQueryKeyFactory } from '@hooks/useHentFagsak';
+import { useLåsOppFagsak } from '@hooks/useLåsOppFagsak';
+import { useModal } from '@hooks/useModal';
+import { useQueryClient } from '@tanstack/react-query';
+import { type FieldErrors, useForm } from 'react-hook-form';
+
+export const LåsOppFagsakServerErrors: Record<
+    'onSubmitError',
+    {
+        id: `root.${string}`;
+        lookup: (errors: FieldErrors<LåsOppFagsakFormValues>) => string | undefined;
+    }
+> = {
+    onSubmitError: {
+        id: 'root.onSubmitError',
+        lookup: errors => errors?.root?.onSubmitError?.message,
+    },
+};
+
+export enum LåsOppFagsakFormFields {
+    BEGRUNNELSE = 'begrunnelse',
+}
+
+export interface LåsOppFagsakFormValues {
+    [LåsOppFagsakFormFields.BEGRUNNELSE]: string;
+}
+
+export const LÅS_OPP_FAGSAK_FORM_ID = 'las_opp_fagsak_modal_form';
+
+export function useLåsOppFagsakForm() {
+    const fagsak = useFagsak();
+    const { lukkModal } = useModal(ModalType.LÅS_OPP_FAGSAK);
+    const { mutateAsync } = useLåsOppFagsak();
+    const queryClient = useQueryClient();
+
+    const form = useForm<LåsOppFagsakFormValues>({
+        defaultValues: {
+            [LåsOppFagsakFormFields.BEGRUNNELSE]: '',
+        },
+    });
+
+    const { setError } = form;
+
+    async function onSubmit(values: LåsOppFagsakFormValues) {
+        const { begrunnelse } = values;
+        return mutateAsync({ fagsakId: fagsak.id, begrunnelse: begrunnelse.trim() })
+            .then(async () => {
+                await queryClient.invalidateQueries({
+                    queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id),
+                });
+                lukkModal();
+            })
+            .catch(error =>
+                setError(LåsOppFagsakServerErrors.onSubmitError.id, {
+                    message: error.message ?? 'En feil oppstod.',
+                })
+            );
+    }
+
+    return { form, onSubmit };
+}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandling.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandling.test.tsx
@@ -5,13 +5,23 @@ import { expect } from 'vitest';
 import { ActionMenu } from '@navikt/ds-react';
 
 import { OpprettBehandling } from './OpprettBehandling';
+import { FagsakProvider } from '../../../../sider/Fagsak/FagsakContext';
+import { lagFagsak } from '../../../../testutils/testdata/fagsakTestdata';
 import { render } from '../../../../testutils/testrender';
+import type { IMinimalFagsak } from '../../../../typer/fagsak';
+import { FagsakStatus } from '../../../../typer/fagsak';
 
-function Wrapper({ children }: PropsWithChildren) {
+interface WrapperProps extends PropsWithChildren {
+    fagsak?: IMinimalFagsak;
+}
+
+function Wrapper({ fagsak = lagFagsak(), children }: WrapperProps) {
     return (
-        <ActionMenu open={true}>
-            <ActionMenu.Content>{children}</ActionMenu.Content>
-        </ActionMenu>
+        <FagsakProvider fagsak={fagsak}>
+            <ActionMenu open={true}>
+                <ActionMenu.Content>{children}</ActionMenu.Content>
+            </ActionMenu>
+        </FagsakProvider>
     );
 }
 
@@ -33,5 +43,15 @@ describe('OpprettBehandling', () => {
         await user.click(knapp);
 
         expect(åpneModal).toHaveBeenCalledOnce();
+    });
+
+    test('skal ikke rendre komponenten når fagsaken er låst', () => {
+        const åpneModal = vi.fn();
+
+        const { screen } = render(<OpprettBehandling åpneModal={åpneModal} />, {
+            wrapper: props => <Wrapper {...props} fagsak={lagFagsak({ status: FagsakStatus.LÅST })} />,
+        });
+
+        expect(screen.queryByRole('menuitem', { name: 'Opprett behandling' })).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandling.tsx
@@ -1,3 +1,6 @@
+import { useFagsak } from '@hooks/useFagsak';
+import { erFagsakLåst } from '@utils/fagsak';
+
 import { ActionMenu } from '@navikt/ds-react';
 
 interface Props {
@@ -5,5 +8,11 @@ interface Props {
 }
 
 export function OpprettBehandling({ åpneModal }: Props) {
+    const fagsak = useFagsak();
+
+    if (erFagsakLåst(fagsak)) {
+        return null;
+    }
+
     return <ActionMenu.Item onSelect={åpneModal}>Opprett behandling</ActionMenu.Item>;
 }

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/opprettBehandlingUtils.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/opprettBehandlingUtils.ts
@@ -2,6 +2,7 @@ import type { VisningBehandling } from '@sider/Fagsak/Saksoversikt/visningBehand
 import { BehandlingStatus, erBehandlingHenlagt } from '@typer/behandling';
 import type { IMinimalFagsak } from '@typer/fagsak';
 import { FagsakStatus } from '@typer/fagsak';
+import { erFagsakLåst } from '@utils/fagsak';
 
 const kanOppretteNyBehandling = (aktivBehandling: VisningBehandling | undefined) =>
     !aktivBehandling || aktivBehandling?.status === BehandlingStatus.AVSLUTTET;
@@ -9,7 +10,11 @@ const kanOppretteNyBehandling = (aktivBehandling: VisningBehandling | undefined)
 export const kanOppretteFørstegangsbehandling = (
     minimalFagsak: IMinimalFagsak | undefined,
     aktivBehandling: VisningBehandling | undefined
-) => !minimalFagsak || (minimalFagsak.status !== FagsakStatus.LØPENDE && kanOppretteNyBehandling(aktivBehandling));
+) =>
+    !minimalFagsak ||
+    (!erFagsakLåst(minimalFagsak) &&
+        minimalFagsak.status !== FagsakStatus.LØPENDE &&
+        kanOppretteNyBehandling(aktivBehandling));
 
 export const kanOppretteRevurdering = (
     minimalFagsak: IMinimalFagsak | undefined,
@@ -19,5 +24,10 @@ export const kanOppretteRevurdering = (
         erBehandlingHenlagt(behandling.resultat)
     );
 
-    return minimalFagsak && !alleBehandlingerErHenlagt && kanOppretteNyBehandling(aktivBehandling);
+    return (
+        minimalFagsak &&
+        !erFagsakLåst(minimalFagsak) &&
+        !alleBehandlingerErHenlagt &&
+        kanOppretteNyBehandling(aktivBehandling)
+    );
 };

--- a/src/frontend/komponenter/Saklinje/Meny/SendInformasjonsbrev/SendInformasjonsbrev.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/SendInformasjonsbrev/SendInformasjonsbrev.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router';
 import { ActionMenu } from '@navikt/ds-react';
 
 import { useFagsakContext } from '../../../../sider/Fagsak/FagsakContext';
+import { erFagsakLåst } from '../../../../utils/fagsak';
 
 export function SendInformasjonsbrev() {
     const { fagsak } = useFagsakContext();
@@ -12,7 +13,7 @@ export function SendInformasjonsbrev() {
 
     const erPåDokumentutsending = location.pathname.includes('dokumentutsending');
 
-    if (erPåDokumentutsending) {
+    if (erPåDokumentutsending || erFagsakLåst(fagsak)) {
         return null;
     }
 

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -1,13 +1,15 @@
 import type { ChangeEvent } from 'react';
 
+import { useFagsak } from '@hooks/useFagsak';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { BrevmottakereAlert } from '@komponenter/BrevmottakereAlert';
 import { LeggTilBarnModal } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
 import { LeggTilBarnModalContextProvider } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
 import type { IBarnMedOpplysninger } from '@typer/søknad';
+import { erFagsakLåst } from '@utils/fagsak';
 
 import { FileTextIcon, InformationSquareIcon } from '@navikt/aksel-icons';
-import { Box, Button, Fieldset, Heading, HStack, InfoCard, Label, Select } from '@navikt/ds-react';
+import { Alert, Box, Button, Fieldset, Heading, HStack, InfoCard, Label, Select } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import BarnIBrevSkjema from './BarnIBrev/BarnIBrevSkjema';
@@ -27,6 +29,8 @@ export function DokumentutsendingSkjema() {
     const { bruker } = useBrukerContext();
 
     const saksbehandler = useSaksbehandler();
+
+    const fagsak = useFagsak();
 
     const {
         hentForhåndsvisningPåFagsak,
@@ -68,7 +72,7 @@ export function DokumentutsendingSkjema() {
 
     const skalViseFritekstAvsnitt = årsakVerdi === DokumentÅrsak.INNHENTE_OPPLYSNINGER_KLAGE;
 
-    const erLesevisning = !saksbehandler.harSkrivetilgang;
+    const erLesevisning = !saksbehandler.harSkrivetilgang || erFagsakLåst(fagsak);
 
     function onLeggTilBarn(barn: IBarnMedOpplysninger) {
         skjema.felter.barnIBrev.validerOgSettFelt([...skjema.felter.barnIBrev.verdi, barn]);
@@ -83,6 +87,14 @@ export function DokumentutsendingSkjema() {
             {!erLesevisning && <LeggTilBarnModal />}
             <Box padding={'space-32'} overflow={'auto'}>
                 <Heading size={'large'} level={'1'} children={'Send informasjonsbrev'} />
+                {erFagsakLåst(fagsak) && (
+                    <Box marginBlock={'space-16'}>
+                        <Alert variant={'info'}>
+                            Fagsaken er låst etter arkivlovens kasseringsregler, og det er ikke mulig å sende brev. Lås
+                            opp fagsaken fra menyen i saksoversikten hvis du likevel skal sende brev.
+                        </Alert>
+                    </Box>
+                )}
                 {manuelleBrevmottakerePåFagsak.length > 0 && (
                     <Box marginBlock={'space-16'}>
                         <BrevmottakereAlert
@@ -162,7 +174,7 @@ export function DokumentutsendingSkjema() {
                             size="medium"
                             variant="primary"
                             loading={senderBrev()}
-                            disabled={skjemaErLåst()}
+                            disabled={skjemaErLåst() || erLesevisning}
                             onClick={sendBrevPåFagsak}
                         >
                             Send brev

--- a/src/frontend/sider/Fagsak/FagsakContext.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContext.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 import type { IMinimalFagsak } from '../../typer/fagsak';
 
@@ -14,7 +14,9 @@ interface Props extends PropsWithChildren {
 }
 
 export function FagsakProvider({ fagsak, children }: Props) {
-    return <Context.Provider value={{ fagsak }}>{children}</Context.Provider>;
+    const value = useMemo(() => ({ fagsak }), [fagsak]);
+
+    return <Context.Provider value={value}>{children}</Context.Provider>;
 }
 
 export function useFagsakContext() {

--- a/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
@@ -1,7 +1,8 @@
 import { BehandlingStatus } from '@typer/behandling';
 import type { IBehandlingstema } from '@typer/behandlingstema';
 import { tilBehandlingstema } from '@typer/behandlingstema';
-import { hentAktivBehandlingPåMinimalFagsak, hentFagsakStatusVisning } from '@utils/fagsak';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
+import { erFagsakLåst, hentAktivBehandlingPåMinimalFagsak, hentFagsakStatusVisning } from '@utils/fagsak';
 import { Link as ReactRouterLink } from 'react-router';
 
 import { BodyShort, Box, HStack, Link, LinkCard, VStack } from '@navikt/ds-react';
@@ -15,6 +16,7 @@ function Innholdstabell() {
     const { fagsak } = useFagsakContext();
     const behandlingstema: IBehandlingstema | undefined =
         fagsak.løpendeKategori && tilBehandlingstema(fagsak.løpendeKategori);
+    const fagsakErLåst = erFagsakLåst(fagsak);
 
     return (
         <HStack gap="space-80">
@@ -34,6 +36,19 @@ function Innholdstabell() {
                     {hentFagsakStatusVisning(fagsak)}
                 </BodyShort>
             </div>
+            {fagsakErLåst && fagsak.låstTidspunkt && (
+                <div>
+                    <BodyShort className={styles.header} spacing>
+                        Låst dato
+                    </BodyShort>
+                    <BodyShort className={styles.body} weight="semibold">
+                        {isoStringTilFormatertString({
+                            isoString: fagsak.låstTidspunkt,
+                            tilFormat: Datoformat.DATO,
+                        })}
+                    </BodyShort>
+                </div>
+            )}
         </HStack>
     );
 }

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -8,6 +8,7 @@ export enum FagsakStatus {
     OPPRETTET = 'OPPRETTET',
     LØPENDE = 'LØPENDE',
     AVSLUTTET = 'AVSLUTTET',
+    LÅST = 'LÅST',
 }
 
 // Interface
@@ -19,6 +20,7 @@ interface IBaseFagsak {
     søkerFødselsnummer: string;
     underBehandling: boolean;
     løpendeKategori?: BehandlingKategori;
+    låstTidspunkt?: string;
 }
 
 export interface IMinimalFagsak extends IBaseFagsak {
@@ -39,5 +41,9 @@ export const fagsakStatus: INøkkelPar = {
     AVSLUTTET: {
         id: 'AVSLUTTET',
         navn: 'Avsluttet',
+    },
+    LÅST: {
+        id: 'LÅST',
+        navn: 'Låst',
     },
 };

--- a/src/frontend/utils/fagsak.ts
+++ b/src/frontend/utils/fagsak.ts
@@ -3,14 +3,18 @@ import { isAfter } from 'date-fns';
 import { hentDagensDato, isoStringTilDateMedFallback, tidenesEnde } from './dato';
 import type { VisningBehandling } from '../sider/Fagsak/Saksoversikt/visningBehandling';
 import type { IMinimalFagsak } from '../typer/fagsak';
-import { fagsakStatus } from '../typer/fagsak';
+import { fagsakStatus, FagsakStatus } from '../typer/fagsak';
+
+export const erFagsakLåst = (fagsak: Pick<IMinimalFagsak, 'status'>): boolean => fagsak.status === FagsakStatus.LÅST;
 
 export const hentFagsakStatusVisning = (minimalFagsak: IMinimalFagsak): string =>
-    minimalFagsak.behandlinger.length === 0
-        ? '-'
-        : minimalFagsak.underBehandling
-          ? 'Under behandling'
-          : fagsakStatus[minimalFagsak.status].navn;
+    erFagsakLåst(minimalFagsak)
+        ? fagsakStatus[FagsakStatus.LÅST].navn
+        : minimalFagsak.behandlinger.length === 0
+          ? '-'
+          : minimalFagsak.underBehandling
+            ? 'Under behandling'
+            : fagsakStatus[minimalFagsak.status].navn;
 
 export const hentAktivBehandlingPåMinimalFagsak = (minimalFagsak: IMinimalFagsak): VisningBehandling | undefined => {
     return minimalFagsak.behandlinger.find((behandling: VisningBehandling) => behandling.aktiv);

--- a/src/frontend/utils/test/minimalFagsak/minimalFagsak.mock.ts
+++ b/src/frontend/utils/test/minimalFagsak/minimalFagsak.mock.ts
@@ -1,43 +1,20 @@
-import type { VisningBehandling } from '../../../sider/Fagsak/Saksoversikt/visningBehandling';
 import { lagVisningBehandling } from '../../../testutils/testdata/behandlingTestdata';
 import { BehandlingKategori } from '../../../typer/behandlingstema';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { FagsakStatus } from '../../../typer/fagsak';
-import type { Utbetalingsperiode } from '../../../typer/utbetalingsperiode';
 
-interface IMockMinimalFagsak {
-    behandlinger?: VisningBehandling[];
-    gjeldendeUtbetalingsperioder?: Utbetalingsperiode[];
-    id?: number;
-    opprettetTidspunkt?: string;
-    saksnummer?: string;
-    status?: FagsakStatus;
-    søkerFødselsnummer?: string;
-    underBehandling?: boolean;
-    løpendeKategori?: BehandlingKategori;
-    finnesStrengtFortroligPersonIFagsak?: boolean;
-}
-
-export const mockMinimalFagsak = ({
-    behandlinger = [lagVisningBehandling()],
-    gjeldendeUtbetalingsperioder = [],
-    id = 1,
-    opprettetTidspunkt = '2020-09-19T09:08:56.8',
-    saksnummer = '1234',
-    status = FagsakStatus.LØPENDE,
-    søkerFødselsnummer = '12345678910',
-    underBehandling = false,
-    løpendeKategori = BehandlingKategori.NASJONAL,
-    finnesStrengtFortroligPersonIFagsak = false,
-}: IMockMinimalFagsak = {}): IMinimalFagsak => ({
-    behandlinger,
-    id,
-    søkerFødselsnummer,
-    opprettetTidspunkt,
-    saksnummer,
-    status,
-    underBehandling,
-    gjeldendeUtbetalingsperioder,
-    løpendeKategori,
-    finnesStrengtFortroligPersonIFagsak,
+// Tar Partial<IMinimalFagsak> framfor et håndskrevet interface, slik at nye felter
+// på IMinimalFagsak blir tilgjengelige her uten at builderen må vedlikeholdes.
+export const mockMinimalFagsak = (overstyringer: Partial<IMinimalFagsak> = {}): IMinimalFagsak => ({
+    behandlinger: [lagVisningBehandling()],
+    id: 1,
+    søkerFødselsnummer: '12345678910',
+    opprettetTidspunkt: '2020-09-19T09:08:56.8',
+    saksnummer: '1234',
+    status: FagsakStatus.LØPENDE,
+    underBehandling: false,
+    gjeldendeUtbetalingsperioder: [],
+    løpendeKategori: BehandlingKategori.NASJONAL,
+    finnesStrengtFortroligPersonIFagsak: false,
+    ...overstyringer,
 });


### PR DESCRIPTION
### 📮 Favro: Nav-30112 – Lås fagsak etter arkivlovens kasseringsregler

### 💰 Hva skal gjøres, og hvorfor?
Frontend-delen av fagsaklåsingen (backend: familie-ks-sak). Når en fagsak er låst iht. arkivlovens
kasseringsregler skal den vises som låst, all saksbehandling skal være utilgjengelig, og
saksbehandler skal kunne låse den opp igjen med en begrunnelse.
